### PR TITLE
Remove cloud_resources role from config_pgcluster

### DIFF
--- a/automation/playbooks/config_pgcluster.yml
+++ b/automation/playbooks/config_pgcluster.yml
@@ -1,27 +1,5 @@
 ---
-- name: vitabaks.autobase.config_pgcluster | Configuration PostgreSQL HA Cluster (based on "Patroni")
-  hosts: localhost
-  gather_facts: true
-  any_errors_fatal: true
-  pre_tasks:
-    # set_fact: 'pgbackrest_install' to configure Postgres backups if not disabled explicitly.
-    # Note: Applicable only for "aws", "gcp", "azure".
-    - name: "Set variable: 'pgbackrest_install' to configure Postgres backups"
-      ansible.builtin.set_fact:
-        pgbackrest_install: true
-      when:
-        - not (pgbackrest_install | default(false) | bool or wal_g_install | default(false) | bool)
-        - cloud_provider | default('') | lower in ['aws', 'gcp', 'azure']
-        - pgbackrest_auto_conf | default(true) | bool # to be able to disable auto backup settings
-      tags: always
-  roles:
-    - role: vitabaks.autobase.cloud_resources
-      when: cloud_provider | default('') | length > 0
-      vars:
-        postgresql_cluster_maintenance: true
-      tags: always
-
-- name: vitabaks.autobase.config_pgcluster | Check the cluster state and perform pre-checks
+- name: vitabaks.autobase.config_pgcluster | Configure PostgreSQL HA Cluster (based on "Patroni")
   hosts: postgres_cluster:etcd_cluster
   become: true
   become_method: sudo


### PR DESCRIPTION
Do not use the `cloud_resources` role when configuring the PostgreSQL cluster. Instead, rely on the availability of an inventory file.

This allows us to reduce several seconds of playbook execution time.