### PR TITLE
Fix [blue-green]: Stop Patroni before stopping PostgreSQL

### DIFF
--- a/automation/roles/upgrade/README.md
+++ b/automation/roles/upgrade/README.md
@@ -356,6 +356,8 @@ Note: For more information, see the `upgrade` role [variables](../upgrade/defaul
     - Pause Patroni on the target cluster before stopping PostgreSQL
     - Execute CHECKPOINT before stopping PostgreSQL
     - Wait for the CHECKPOINT to complete
+    - Stop Patroni service on the standby cluster leader before stopping PostgreSQL
+    - Wait for Patroni REST API to stop on the standby cluster leader
     - Stop PostgreSQL on the standby cluster leader
   - Create a publication and logical replication slot for each database
     - Get a list of tables distributed by groups

--- a/automation/roles/upgrade/tasks/stop_target_primary.yml
+++ b/automation/roles/upgrade/tasks/stop_target_primary.yml
@@ -39,6 +39,24 @@
   delay: 10
   when: inventory_hostname in groups['primary']
 
+# Stop Patroni to prevent PostgreSQL from restarting after it is stopped
+- name: "Stop Patroni service on the standby cluster leader before stopping PostgreSQL"
+  become: true
+  become_user: root
+  ansible.builtin.service:
+    name: patroni
+    state: stopped
+  when: inventory_hostname in groups['primary']
+
+- name: "Wait for Patroni REST API to stop on the standby cluster leader"
+  ansible.builtin.wait_for:
+    port: "{{ patroni_restapi_port | default('8008') }}"
+    host: "{{ patroni_bind_address | default(bind_address, true) }}"
+    state: stopped
+    timeout: 60
+    delay: 2
+  when: inventory_hostname in groups['primary']
+
 - name: "Stop PostgreSQL on the standby cluster leader"
   ansible.builtin.command: >-
     {{ pg_old_bindir }}/pg_ctl -D {{ pg_old_datadir }} stop -w -t {{ pg_start_stop_timeout }}


### PR DESCRIPTION
Add tasks to stop the Patroni service on the standby cluster leader and wait for the Patroni REST API to stop before shutting down PostgreSQL. This prevents Patroni from automatically restarting PostgreSQL during the upgrade stop sequence.

Fixed:

```
FAILED! => {"ansible_job_id": "j21885262782.112446", "attempts": 1, "changed": true, "cmd": ["/usr/lib/postgresql/16/bin/pg_ctl", "start", "-D", "/var/lib/postgresql/16/main", "-w", "-t", "1800", "-o", "--config-file=/etc/postgresql/16/main/postgresql.conf", "-o", "-c archive_mode=off", "-l", "/tmp/pg_start_recovery_target.log"], "delta": "0:00:00.113278", "end": "2026-04-22 04:19:25.115618", "finished": 1, "msg": "non-zero return code", "rc": 1, "results_file": "/var/lib/postgresql/.ansible_async/j21885262782.112446", "start": "2026-04-22 04:19:25.002340", "started": 1, "stderr": "pg_ctl: another server might be running; trying to start server anyway\npg_ctl: could not start server\nExamine the log output.", "stderr_lines": ["pg_ctl: another server might be running; trying to start server anyway", "pg_ctl: could not start server", "Examine the log output."], "stdout": "waiting for server to start.... stopped waiting", "stdout_lines": ["waiting for server to start.... stopped waiting"]}
```

```
cat /tmp/pg_start_recovery_target.log
2026-04-22 04:19:25 UTC [112458-1]  FATAL:  lock file "postmaster.pid" already exists
2026-04-22 04:19:25 UTC [112458-2]  HINT:  Is another postmaster (PID 112420) running in data directory "/var/lib/postgresql/16/main"?
```