### PR TITLE
fix: add mount role to add_node playbook and improve its implementation

### DIFF
--- a/automation/playbooks/add_node.yml
+++ b/automation/playbooks/add_node.yml
@@ -269,6 +269,7 @@
     - role: vitabaks.autobase.add_repository
     - role: vitabaks.autobase.packages
     - role: vitabaks.autobase.sudo
+    - role: vitabaks.autobase.mount
     - role: vitabaks.autobase.swap
     - role: vitabaks.autobase.sysctl
     - role: vitabaks.autobase.transparent_huge_pages

--- a/automation/roles/mount/README.md
+++ b/automation/roles/mount/README.md
@@ -10,7 +10,7 @@ This role configures filesystems and mount points:
 |---|---|---|
 | mount | [] | List of mount definitions. Each item may include: path, src, fstype, opts, state. See below for item fields. |
 | mount[].path | "/pgdata" | Mount point path. Used as fallback for the first item when auto-provisioning. |
-| mount[].src | "" | Device UUID=... or device path. If empty and cloud_provider is set, the role will try to detect an empty disk and fill the UUID automatically for the first item. |
+| mount[].src | "" | Device UUID=... or device path. If empty and cloud_provider is set, the role will try to auto-detect exactly one writable, unmounted data disk and fill the UUID automatically for the first item. |
 | mount[].fstype | "ext4" | Filesystem type (e.q., ext4, xfs). Use "zfs" to create a zpool and mount it. |
 | mount[].opts | "defaults,noatime" | Mount options (not applicable to zfs creation). |
 | mount[].state | "mounted" | Desired state (mounted, present, absent, etc.). |
@@ -19,6 +19,8 @@ This role configures filesystems and mount points:
 
 Notes:
 - The role relies on lsblk and jq for disk detection; ensure jq is available (it is installed by the common role by default).
+- If no candidate disk is detected during auto-provisioning, the role fails and asks you to attach a data volume or set `mount[].src` explicitly.
+- If multiple candidate disks are detected, the role fails and asks you to set `mount[].src` explicitly.
 - ZFS packages are installed per OS family (Ubuntu/Debian/RedHat) and the zfs module is loaded automatically.
 
 ## Example:

--- a/automation/roles/mount/README.md
+++ b/automation/roles/mount/README.md
@@ -10,7 +10,7 @@ This role configures filesystems and mount points:
 |---|---|---|
 | mount | [] | List of mount definitions. Each item may include: path, src, fstype, opts, state. See below for item fields. |
 | mount[].path | "/pgdata" | Mount point path. Used as fallback for the first item when auto-provisioning. |
-| mount[].src | "" | Device UUID=... or device path. If empty and cloud_provider is set, the role will try to auto-detect exactly one writable, unmounted data disk and fill the UUID automatically for the first item. |
+| mount[].src | "" | Device UUID=... or device path. If empty and cloud_provider is set, the role will try to auto-detect exactly one writable, unmounted data disk and fill the UUID automatically for the first item. If a `/dev/...` path is provided for a standard filesystem, the role can create the filesystem on that device before mounting it. |
 | mount[].fstype | "ext4" | Filesystem type (e.q., ext4, xfs). Use "zfs" to create a zpool and mount it. |
 | mount[].opts | "defaults,noatime" | Mount options (not applicable to zfs creation). |
 | mount[].state | "mounted" | Desired state (mounted, present, absent, etc.). |
@@ -21,6 +21,7 @@ Notes:
 - The role relies on lsblk and jq for disk detection; ensure jq is available (it is installed by the common role by default).
 - If no candidate disk is detected during auto-provisioning, the role fails and asks you to attach a data volume or set `mount[].src` explicitly.
 - If multiple candidate disks are detected, the role fails and asks you to set `mount[].src` explicitly.
+- If `mount[].src` is given as `UUID=...`, the role assumes the filesystem already exists and only mounts it.
 - ZFS packages are installed per OS family (Ubuntu/Debian/RedHat) and the zfs module is loaded automatically.
 
 ## Example:

--- a/automation/roles/mount/tasks/main.yml
+++ b/automation/roles/mount/tasks/main.yml
@@ -10,42 +10,64 @@
     - name: Detect empty volume
       ansible.builtin.shell: |
         set -o pipefail;
-        lsblk -e7 --output NAME,FSTYPE,TYPE --json \
-          | jq -r '.blockdevices[] | select(.children == null and .fstype == null and .type == "disk") | .name'
+        lsblk -e7 --bytes --output NAME,FSTYPE,TYPE,RO,SIZE,MOUNTPOINTS --json \
+          | jq -r '.blockdevices[]
+            | select(
+                ((.children // []) | length == 0)
+                and .fstype == null
+                and .type == "disk"
+                and .ro == false
+                and .size > 1073741824
+                and ((.mountpoints // []) | all(. == null))
+              )
+            | .name'
       args:
         executable: /bin/bash
       register: lsblk_disk
       changed_when: false
       when: (cloud_provider | default('') | length > 0) and (mount | first | default({})).src | default('') | length < 1
 
-    # Show the error message, if empty volume is not detected
+    # Stop if empty volume is not detected
     - name: Empty volume is not detected
       ansible.builtin.fail:
-        msg: "Whoops! The empty volume is not detected. Skip mounting."
-      ignore_errors: true
+        msg: >-
+          Whoops! The empty volume is not detected.
+          Attach a data volume or set mount[0].src explicitly.
       when: lsblk_disk.stdout is defined and lsblk_disk.stdout | length < 1
 
+    - name: Fail if multiple empty volumes are detected
+      ansible.builtin.fail:
+        msg: >-
+          Whoops! Multiple empty volumes were detected: {{ lsblk_disk.stdout_lines | join(', ') }}.
+          Set mount[0].src explicitly to choose the correct device.
+      when: lsblk_disk.stdout_lines | default([]) | length > 1
+
+    - name: Set auto-detected mount disk
+      ansible.builtin.set_fact:
+        lsblk_disk_device: "{{ lsblk_disk.stdout_lines | first }}"
+      when: lsblk_disk.stdout_lines | default([]) | length == 1
+
     # Filesystem
-    - name: Create "{{ postgresql_data_dir_mount_fstype | default('ext4') }}" filesystem on the disk "/dev/{{ lsblk_disk.stdout | default('') }}"
+    - name: Create "{{ postgresql_data_dir_mount_fstype | default('ext4') }}" filesystem on the disk "/dev/{{ lsblk_disk_device | default('') }}"
       community.general.filesystem:
-        dev: "/dev/{{ lsblk_disk.stdout }}"
+        dev: "/dev/{{ lsblk_disk_device }}"
         fstype: "{{ postgresql_data_dir_mount_fstype | default('ext4') }}"
       when:
-        - (lsblk_disk.stdout is defined and lsblk_disk.stdout | length > 0)
+        - lsblk_disk_device is defined
         - ((postgresql_data_dir_mount_fstype is defined and postgresql_data_dir_mount_fstype != 'zfs') or
           (postgresql_data_dir_mount_fstype is not defined and (mount | first | default({})).fstype | default('') != 'zfs'))
 
     # UUID
-    - name: Get UUID of the disk "/dev/{{ lsblk_disk.stdout | default('') }}"
+    - name: Get UUID of the disk "/dev/{{ lsblk_disk_device | default('') }}"
       ansible.builtin.shell: |
         set -o pipefail;
-        lsblk -no UUID /dev/{{ lsblk_disk.stdout }} | tr -d '\n'
+        lsblk -no UUID /dev/{{ lsblk_disk_device }} | tr -d '\n'
       args:
         executable: /bin/bash
       register: lsblk_uuid
       changed_when: false
       when:
-        - (lsblk_disk.stdout is defined and lsblk_disk.stdout | length > 0)
+        - lsblk_disk_device is defined
         - ((postgresql_data_dir_mount_fstype is defined and postgresql_data_dir_mount_fstype != 'zfs') or
           (postgresql_data_dir_mount_fstype is not defined and (mount | first | default({})).fstype | default('') != 'zfs'))
 
@@ -143,7 +165,7 @@
             line: zfs
             create: true
 
-        - name: "Create zpool (use {{ (mount | first | default({})).src | default('/dev/' ~ (lsblk_disk.stdout | default('')), true) }})"
+        - name: "Create zpool (use {{ (mount | first | default({})).src | default('/dev/' ~ (lsblk_disk_device | default('')), true) }})"
           ansible.builtin.command: >-
             zpool create -f
             -O compression=on
@@ -151,9 +173,9 @@
             -O recordsize=128k
             -O logbias=throughput
             -m {{ postgresql_data_dir_mount_path | default((mount | first | default({})).path | default('/pgdata', true), true) }}
-            pgdata {{ (mount | first | default({})).src | default("/dev/" + lsblk_disk.stdout, true) }}
+            pgdata {{ (mount | first | default({})).src | default("/dev/" + lsblk_disk_device, true) }}
       when:
-        - ((mount | first | default({})).src | default('') | length > 0 or lsblk_disk.stdout | default('') | length > 0)
+        - ((mount | first | default({})).src | default('') | length > 0 or lsblk_disk_device is defined)
         - ((postgresql_data_dir_mount_fstype is defined and postgresql_data_dir_mount_fstype == 'zfs') or
           (postgresql_data_dir_mount_fstype is not defined and (mount | first | default({})).fstype | default('') == 'zfs'))
   tags: mount, zpool

--- a/automation/roles/mount/tasks/main.yml
+++ b/automation/roles/mount/tasks/main.yml
@@ -57,6 +57,17 @@
         - ((postgresql_data_dir_mount_fstype is defined and postgresql_data_dir_mount_fstype != 'zfs') or
           (postgresql_data_dir_mount_fstype is not defined and (mount | first | default({})).fstype | default('') != 'zfs'))
 
+    # Explicit /dev paths skip auto-detection, so create the filesystem here before mounting.
+    - name: Create filesystem on explicitly specified devices
+      community.general.filesystem:
+        dev: "{{ item.src }}"
+        fstype: "{{ item.fstype | default(postgresql_data_dir_mount_fstype | default('ext4', true), true) }}"
+      loop: "{{ mount }}"
+      when:
+        - item.src | default('') | regex_search('^/dev/')
+        - ((postgresql_data_dir_mount_fstype is defined and postgresql_data_dir_mount_fstype != 'zfs') or
+          (postgresql_data_dir_mount_fstype is not defined and item.fstype != 'zfs'))
+
     # UUID
     - name: Get UUID of the disk "/dev/{{ lsblk_disk_device | default('') }}"
       ansible.builtin.shell: |

--- a/automation/roles/mount/tasks/main.yml
+++ b/automation/roles/mount/tasks/main.yml
@@ -64,7 +64,7 @@
         fstype: "{{ item.fstype | default(postgresql_data_dir_mount_fstype | default('ext4', true), true) }}"
       loop: "{{ mount }}"
       when:
-        - item.src | default('') | regex_search('^/dev/')
+        - (item.src | default('')) is match('^/dev/')
         - ((postgresql_data_dir_mount_fstype is defined and postgresql_data_dir_mount_fstype != 'zfs') or
           (postgresql_data_dir_mount_fstype is not defined and item.fstype != 'zfs'))
 


### PR DESCRIPTION
1. Fixed an issue where disk mounts were not performed when scaling the cluster.
    - Closes: https://github.com/autobase-tech/autobase/issues/1506
2. Tighten and harden automatic disk detection and handling for mounts.
    - The role now auto-detects exactly one writable, unmounted data disk and will fail if none or multiple candidates are found.
3. Create filesystems for explicit /dev mounts
    - Add an Ansible task that creates a filesystem on mounts whose src is an explicit /dev/... device before mounting (skips zfs). 

