### PR TITLE
 fix: hugepages auto-calculation truncation and cross-play persistence

### DIFF
--- a/automation/roles/pre_checks/tasks/huge_pages.yml
+++ b/automation/roles/pre_checks/tasks/huge_pages.yml
@@ -128,7 +128,8 @@
         - huge_pages_auto_conf | bool
         - sysctl_set | bool
 
-    # Apply vm.nr_hugepages immediately (set_fact does not persist across plays)
+    # Apply vm.nr_hugepages immediately at the OS level instead of waiting for
+    # later processing of the sysctl_conf variable.
     - name: "HugePages | Apply vm.nr_hugepages={{ huge_pages_required }} to the OS"
       ansible.posix.sysctl:
         name: "vm.nr_hugepages"

--- a/automation/roles/pre_checks/tasks/huge_pages.yml
+++ b/automation/roles/pre_checks/tasks/huge_pages.yml
@@ -137,7 +137,6 @@
         state: present
         sysctl_file: "{{ sysctl_file | default('/etc/sysctl.d/autobase.sysctl.conf') }}"
         reload: true
-      become: true
       when:
         - shared_buffers_gb | default(0) | int >= (min_shared_buffers_gb | default(8))
         - huge_pages_total.stdout | default(0) | int < huge_pages_required | int

--- a/automation/roles/pre_checks/tasks/huge_pages.yml
+++ b/automation/roles/pre_checks/tasks/huge_pages.yml
@@ -32,7 +32,7 @@
 
     - name: "HugePages | Set variable: shared_buffers_gb"
       ansible.builtin.set_fact:
-        shared_buffers_gb: "{{ (shared_buffers_value | int) // 1024 }}"
+        shared_buffers_gb: "{{ (shared_buffers_value | int) / 1024 }}"
       when: shared_buffers_unit == 'mb'
 
     - name: "HugePages | Set variable: shared_buffers_gb"
@@ -70,7 +70,7 @@
         huge_pages_required: >-
           {{
             (
-              (shared_buffers_gb | default(0) | int
+              (shared_buffers_gb | default(0) | float
               + additional_huge_pages_gb | default(1))
               * 1024 * 1024
             )
@@ -119,11 +119,28 @@
               (sysctl_conf.postgres_cluster
               | rejectattr('name', 'equalto', 'vm.nr_hugepages')
               | list)
-              + [ { 'name': 'vm.nr_hugepages', 'value': huge_pages_required } ]
+              + [ { 'name': 'vm.nr_hugepages', 'value': huge_pages_required | int } ]
             }}
       when:
         - shared_buffers_gb | default(0) | int >= (min_shared_buffers_gb | default(8))
         - huge_pages_total.stdout | default(0) | int  < huge_pages_required | int
+        - not sysctl_conf_vm_nr_hugepages_sufficient | default(false)
+        - huge_pages_auto_conf | bool
+        - sysctl_set | bool
+
+    # Apply vm.nr_hugepages immediately (set_fact does not persist across plays)
+    - name: "HugePages | Apply vm.nr_hugepages={{ huge_pages_required }} to the OS"
+      ansible.posix.sysctl:
+        name: "vm.nr_hugepages"
+        value: "{{ huge_pages_required | int }}"
+        sysctl_set: true
+        state: present
+        sysctl_file: "{{ sysctl_file | default('/etc/sysctl.d/autobase.sysctl.conf') }}"
+        reload: true
+      become: true
+      when:
+        - shared_buffers_gb | default(0) | int >= (min_shared_buffers_gb | default(8))
+        - huge_pages_total.stdout | default(0) | int < huge_pages_required | int
         - not sysctl_conf_vm_nr_hugepages_sufficient | default(false)
         - huge_pages_auto_conf | bool
         - sysctl_set | bool


### PR DESCRIPTION
This PR fixes three bugs in the HugePages auto-calculation logic:

1. Integer truncation: // 1024 truncated the MB→GB conversion (e.g. 31695MB became 30GB instead of 30.95GB), causing huge_pages_required to be under-calculated. Fixed with float division and | float filter.

2. Float stored in sysctl_conf: Without | int, the value was stored as 16609.0, causing the sysctl role to fail with "setting key vm.nr_hugepages: Invalid argument". Fixed by adding | int when storing the value.

3. Cross-play persistence: set_fact does not persist across Ansible plays, so vm.nr_hugepages was never applied to the OS. Fixed by adding an inline ansible.posix.sysctl task in the same play to apply the value immediately.