### PR TITLE
Do not ignore extension creation errors

### DIFF
--- a/automation/roles/postgresql_extensions/tasks/main.yml
+++ b/automation/roles/postgresql_extensions/tasks/main.yml
@@ -13,7 +13,7 @@
     login_user: "{{ patroni_superuser_username }}"
     login_password: "{{ patroni_superuser_password }}"
     state: "{{ item.state | default('present') }}"
-  ignore_errors: true
+  ignore_errors: "{{ postgresql_extensions_ignore_errors | default(false) }}"
   loop: "{{ postgresql_extensions | flatten(1) }}"
   vars:
     default_schema: "{{ 'pg_catalog' if item.ext == 'pg_cron' else 'public' }}"


### PR DESCRIPTION
Use a variable to control error handling when creating PostgreSQL extensions: replace the hardcoded `ignore_errors: true` with `postgresql_extensions_ignore_errors` (default: false). 

This lets playbooks opt in to ignoring extension errors.