### PR TITLE
Do not ignore database creation errors

### DIFF
--- a/automation/roles/postgresql_databases/tasks/main.yml
+++ b/automation/roles/postgresql_databases/tasks/main.yml
@@ -19,7 +19,7 @@
     login_password: "{{ patroni_superuser_password }}"
     state: "{{ item.state | default('present') }}"
     force: "{{ 'true' if item.state | default('present') == 'absent' else 'false' }}"
-  ignore_errors: true
+  ignore_errors: "{{ postgresql_databases_ignore_errors | default(false) }}"
   loop: "{{ postgresql_databases | flatten(1) }}"
   when:
     - postgresql_databases | default('') | length > 0


### PR DESCRIPTION
Replace hard-coded `ignore_errors: true` with a configurable variable `postgresql_databases_ignore_errors` (defaults to false) in automation/roles/postgresql_databases/tasks/main.yml so callers can control whether errors during database creation/removal are ignored.