### PR TITLE
Do not ignore database users creation errors

### DIFF
--- a/automation/roles/postgresql_users/tasks/main.yml
+++ b/automation/roles/postgresql_users/tasks/main.yml
@@ -14,7 +14,7 @@
     login_password: "{{ patroni_superuser_password }}"
     login_db: "postgres"
     state: "{{ item.state | default('present') }}"
-  ignore_errors: true
+  ignore_errors: "{{ postgresql_users_ignore_errors | default(false) }}"
   loop: "{{ postgresql_users | flatten(1) }}"
   loop_control:
     label: "{{ item.name }}"
@@ -32,7 +32,7 @@
     login_user: "{{ patroni_superuser_username }}"
     login_password: "{{ patroni_superuser_password }}"
     state: "{{ item.state | default('present') }}"
-  ignore_errors: true
+  ignore_errors: "{{ postgresql_users_ignore_errors | default(false) }}"
   loop: "{{ postgresql_users | flatten(1) }}"
   loop_control:
     label: "{{ item.name }}"


### PR DESCRIPTION
Replace hardcoded `ignore_errors: true` with a variable-driven setting `postgresql_users_ignore_errors` (default:false) in automation/roles/postgresql_users/tasks/main.yml. 

This allows callers to toggle whether errors during user/role tasks are ignored, while keeping the default behavior strict (do not ignore errors).