### PR TITLE
Do not ignore database schemas creation errors

### DIFF
--- a/automation/roles/postgresql_schemas/tasks/main.yml
+++ b/automation/roles/postgresql_schemas/tasks/main.yml
@@ -11,7 +11,7 @@
     login_user: "{{ patroni_superuser_username }}"
     login_password: "{{ patroni_superuser_password }}"
     state: present
-  ignore_errors: true
+  ignore_errors: "{{ postgresql_schemas_ignore_errors | default(false) }}"
   loop: "{{ postgresql_schemas | flatten(1) }}"
   when:
     - postgresql_schemas | default('') | length > 0


### PR DESCRIPTION
Replace the hardcoded `ignore_errors: true` with `postgresql_schemas_ignore_errors` (default: false)  in automation/roles/postgresql_schemas/tasks/main.yml. 

This allows callers to control whether schema creation errors are ignored to preserve the previous behavior.