### PR TITLE
Do not ignore database privs erros

### DIFF
--- a/automation/roles/postgresql_privs/tasks/main.yml
+++ b/automation/roles/postgresql_privs/tasks/main.yml
@@ -13,7 +13,7 @@
     login_user: "{{ patroni_superuser_username }}"
     login_password: "{{ patroni_superuser_password }}"
     state: "{{ item.state | default('present') }}"
-  ignore_errors: true # noqa ignore-errors
+  ignore_errors: "{{ postgresql_privs_ignore_errors | default(false) }}"
   loop: "{{ postgresql_privs | flatten(1) }}"
   when:
     - postgresql_privs | default('') | length > 0


### PR DESCRIPTION
Replace hardcoded `ignore_errors: true` with a configurable variable `postgresql_privs_ignore_errors` (default: false) in automation/roles/postgresql_privs/tasks/main.yml. 

This lets playbooks opt in to ignoring errors for the postgresql_privs loop instead of always swallowing them; note this may change runtime behavior for consumers that relied on errors being ignored.