### PR TITLE
Make cloud firewall rules VPC-wide for AWS and GCP

### DIFF
--- a/automation/roles/cloud_resources/tasks/aws.yml
+++ b/automation/roles/cloud_resources/tasks/aws.yml
@@ -122,6 +122,13 @@
             server_network: "{{ default_vpc_subnet_info.subnets[0].id }}"
       when: server_network | length < 1
 
+    - name: "AWS: Gather information about VPC '{{ vpc_id | default('') }}'"
+      amazon.aws.ec2_vpc_net_info:
+        region: "{{ server_location }}"
+        filters:
+          vpc-id: "{{ vpc_id }}"
+      register: vpc_info
+
     # Security Group (Firewall)
     - name: "AWS: Create or modify Security Group"
       amazon.aws.ec2_security_group:
@@ -132,7 +139,12 @@
         region: "{{ server_location }}"
         rules: "{{ rules }}"
       vars:
-        vpc_subnet_info: "{{ custom_vpc_subnet_info if custom_vpc_subnet_info.subnets | default('') | length > 0 else default_vpc_subnet_info }}"
+        vpc_cidr_blocks: >-
+          {{
+            vpc_info.vpcs[0].cidr_block_association_set | default([])
+            | map(attribute='cidr_block') | list
+            | default([vpc_info.vpcs[0].cidr_block], true)
+          }}
         rules: >-
           {{
             ([
@@ -175,21 +187,22 @@
               'rule_desc': 'Netdata internal access',
               'proto': 'tcp',
               'ports': [netdata_port | default('19999')],
-              'cidr_ip': vpc_subnet_info.subnets[0].cidr_block }] if netdata_install | bool else []) +
+              'cidr_ip': vpc_cidr_blocks }] if netdata_install | bool else []) +
             ([{
               'rule_desc': 'PgBouncer internal access',
               'proto': 'tcp',
               'ports': [pgbouncer_listen_port | default('6432')],
-              'cidr_ip': vpc_subnet_info.subnets[0].cidr_block }] if pgbouncer_install | bool else []) +
+              'cidr_ip': vpc_cidr_blocks }] if pgbouncer_install | bool else []) +
             ([{
               'rule_desc': 'PostgreSQL internal access',
               'proto': 'tcp',
               'ports': [postgresql_port | default('5432')],
-              'cidr_ip': vpc_subnet_info.subnets[0].cidr_block }]) +
+              'cidr_ip': vpc_cidr_blocks }]) +
             ([{
               'rule_desc': 'Patroni REST API internal access',
               'proto': 'tcp',
-              'ports': [patroni_restapi_port | default('8008')], 'cidr_ip': vpc_subnet_info.subnets[0].cidr_block }]) +
+              'ports': [patroni_restapi_port | default('8008')],
+              'cidr_ip': vpc_cidr_blocks }]) +
             ([{
               'rule_desc': 'HAProxy internal access',
               'proto': 'tcp',
@@ -200,7 +213,7 @@
                 haproxy_listen_port.replicas_async | default('5003'),
                 haproxy_listen_port.stats | default('7000')
               ],
-              'cidr_ip': vpc_subnet_info.subnets[0].cidr_block
+              'cidr_ip': vpc_cidr_blocks
             }] if with_haproxy_load_balancing | bool else []) +
             ([{
               'rule_desc': 'etcd internal access',
@@ -209,7 +222,7 @@
                 etcd_client_port | default('2379'),
                 etcd_peer_port | default('2380')
               ],
-              'cidr_ip': vpc_subnet_info.subnets[0].cidr_block
+              'cidr_ip': vpc_cidr_blocks
             }] if dcs_type == 'etcd' else []) +
             ([{
               'rule_desc': 'Consul internal access',
@@ -222,13 +235,13 @@
                 consul_ports_serf_wan | default('8302'),
                 consul_ports_server | default('8300')
               ],
-              'cidr_ip': vpc_subnet_info.subnets[0].cidr_block
+              'cidr_ip': vpc_cidr_blocks
             }] if dcs_type == 'consul' else []) +
             [{
               'rule_desc': 'SSH internal access',
               'proto': 'tcp',
               'ports': [ansible_ssh_port | default(22)],
-              'cidr_ip': vpc_subnet_info.subnets[0].cidr_block
+              'cidr_ip': vpc_cidr_blocks
             }]
           }}
       register: ec2_security_group_result

--- a/automation/roles/cloud_resources/tasks/gcp.yml
+++ b/automation/roles/cloud_resources/tasks/gcp.yml
@@ -101,18 +101,35 @@
         gcp_network_name: "{{ server_network if server_network is defined and server_network | length > 0 else 'default' }}"
 
     - name: "GCP: Gather information about network"
+      google.cloud.gcp_compute_network_info:
+        auth_kind: "serviceaccount"
+        service_account_contents: "{{ gcp_service_account_contents }}"
+        project: "{{ gcp_project | default(project_info.resources[0].projectNumber) }}"
+        filters:
+          - name = "{{ gcp_network_name }}"
+      register: gcp_network_info
+
+    - name: "GCP: Gather information about subnetworks"
       google.cloud.gcp_compute_subnetwork_info:
         auth_kind: "serviceaccount"
         service_account_contents: "{{ gcp_service_account_contents }}"
         project: "{{ gcp_project | default(project_info.resources[0].projectNumber) }}"
-        region: "{{ server_location[:-2] if server_location[-2:] | regex_search('-[a-z]$') else server_location }}"
+        region: "{{ (item | split('/regions/'))[1] | split('/subnetworks/') | first }}"
         filters:
-          - name = "{{ gcp_network_name }}"
-      register: subnetwork_info
+          - name = "{{ item | split('/subnetworks/') | last }}"
+      loop: "{{ gcp_network_info.resources[0].subnetworks | default([]) }}"
+      loop_control:
+        label: "{{ item | split('/subnetworks/') | last }}"
+      register: gcp_subnetwork_info
 
-    - name: "GCP: Extract ip_range for network '{{ gcp_network_name | default('default') }}'"
+    - name: "GCP: Extract ip_ranges for network '{{ gcp_network_name | default('default') }}'"
       ansible.builtin.set_fact:
-        gcp_network_ip_range: "{{ subnetwork_info.resources[0].ipCidrRange }}"
+        gcp_network_ip_ranges: >-
+          {{
+            gcp_subnetwork_info.results | default([])
+            | map(attribute='resources') | map('default', []) | list | flatten
+            | map(attribute='ipCidrRange') | list | unique
+          }}
 
     # Firewall
     - name: "GCP: Create or modify SSH public firewall rule"
@@ -199,8 +216,7 @@
         allowed:
           - ip_protocol: tcp
             ports: "{{ allowed_ports }}"
-        source_ranges:
-          - "{{ gcp_network_ip_range }}"
+        source_ranges: "{{ gcp_network_ip_ranges }}"
         target_tags:
           - "{{ patroni_cluster_name }}" # Only VMs with this tag will be affected
         network:

--- a/automation/roles/cloud_resources/tasks/gcp.yml
+++ b/automation/roles/cloud_resources/tasks/gcp.yml
@@ -100,6 +100,10 @@
       ansible.builtin.set_fact:
         gcp_network_name: "{{ server_network if server_network is defined and server_network | length > 0 else 'default' }}"
 
+    - name: "Set variable: gcp_region"
+      ansible.builtin.set_fact:
+        gcp_region: "{{ server_location[:-2] if server_location[-2:] | regex_search('-[a-z]$') else server_location }}"
+
     - name: "GCP: Gather information about network"
       google.cloud.gcp_compute_network_info:
         auth_kind: "serviceaccount"
@@ -109,7 +113,7 @@
           - name = "{{ gcp_network_name }}"
       register: gcp_network_info
 
-    - name: "GCP: Gather information about subnetworks"
+    - name: "GCP: Gather information about regional subnetworks"
       google.cloud.gcp_compute_subnetwork_info:
         auth_kind: "serviceaccount"
         service_account_contents: "{{ gcp_service_account_contents }}"
@@ -117,12 +121,12 @@
         region: "{{ (item | split('/regions/'))[1] | split('/subnetworks/') | first }}"
         filters:
           - name = "{{ item | split('/subnetworks/') | last }}"
-      loop: "{{ gcp_network_info.resources[0].subnetworks | default([]) }}"
+      loop: "{{ gcp_network_info.resources[0].subnetworks | default([]) | select('search', '/regions/' ~ gcp_region ~ '/') | list }}"
       loop_control:
         label: "{{ item | split('/subnetworks/') | last }}"
       register: gcp_subnetwork_info
 
-    - name: "GCP: Extract ip_ranges for network '{{ gcp_network_name | default('default') }}'"
+    - name: "GCP: Extract regional ip_ranges for network '{{ gcp_network_name | default('default') }}'"
       ansible.builtin.set_fact:
         gcp_network_ip_ranges: >-
           {{


### PR DESCRIPTION
Internal Security Group / Firewall rules for AWS and GCP now allow access from the entire VPC/network instead of only the current subnet.

This aligns AWS and GCP behavior with Azure, DigitalOcean, and Hetzner, and allows cluster nodes to communicate across availability zones within the same network.

Part of the [Multi-AZ](https://github.com/autobase-tech/autobase/issues/1167) support.