### PR TITLE
Add support for multiple locales

### DIFF
--- a/automation/roles/common/defaults/main.yml
+++ b/automation/roles/common/defaults/main.yml
@@ -1232,6 +1232,7 @@ system_os_specific_packages:
     - moreutils
     - dnsutils
     - curl
+    - locales-all
   RedHat:
     - python{{ python_version }}-devel
     - python{{ python_version }}-libselinux
@@ -1263,7 +1264,8 @@ install_perf: false # or 'true' to install "perf" (Linux profiling with performa
 # RedHat
 # The glibc-langpack package includes the basic information required to support the language in your applications.
 glibc_langpack:
-  - "glibc-langpack-en"
+  - "glibc-all-langpacks"
+#  - "glibc-langpack-en"
 #  - "glibc-langpack-ru"
 #  - "glibc-langpack-de"
 


### PR DESCRIPTION
Add 'locales-all' to Debian system_os_specific_packages and change the RedHat glibc_langpack default from 'glibc-langpack-en' to 'glibc-all-langpacks'. 

Ensures broader locale coverage across distributions.

Fixed:

```

TASK [vitabaks.autobase.postgresql_databases : Make sure the PostgreSQL databases are present] ***
ok: [172.31.35.241] => (item={'db': 'db1', 'encoding': 'UTF8', 'lc_collate': 'en_US.UTF-8', 'lc_ctype': 'en_US.UTF-8', 'owner': 'db1_user'})
ok: [172.31.35.241] => (item={'db': 'postgres', 'encoding': 'UTF-8', 'lc_collate': 'en_US.UTF-8', 'lc_ctype': 'en_US.UTF-8', 'owner': 'postgres'})
[ERROR]: Task failed: Module failed: Database query failed: invalid LC_COLLATE locale name: "ru_RU.UTF-8"
Origin: /root/.ansible/collections/ansible_collections/vitabaks/autobase/roles/postgresql_databases/tasks/main.yml:2:3
1 ---
2 - name: Make sure the PostgreSQL databases are present
    ^ column 3
failed: [172.31.35.241] (item={'db': 'test_db', 'encoding': 'UTF-8', 'lc_collate': 'ru_RU.UTF-8', 'lc_ctype': 'ru_RU.UTF-8', 'owner': 'postgres'}) => {"ansible_loop_var": "item", "changed": false, "item": {"db": "test_db", "encoding": "UTF-8", "lc_collate": "ru_RU.UTF-8", "lc_ctype": "ru_RU.UTF-8", "owner": "postgres"}, "msg": "Database query failed: invalid LC_COLLATE locale name: \"ru_RU.UTF-8\"\n"}
```