### PR TITLE
Skip locale-gen if locales-all present

### DIFF
--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -16,18 +16,12 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - distro: debian12
+          - distro: ubuntu2604
             tag: latest
             namespace: geerlingguy
-          - distro: debian13
+          - distro: rockylinux10
             tag: latest
             namespace: geerlingguy
-#          - distro: ubuntu2604
-#            tag: latest
-#            namespace: geerlingguy
-#          - distro: rockylinux10
-#            tag: latest
-#            namespace: geerlingguy
 
     steps:
       - name: Set TERM environment variable

--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -16,12 +16,18 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - distro: ubuntu2604
+          - distro: debian12
             tag: latest
             namespace: geerlingguy
-          - distro: rockylinux10
+          - distro: debian13
             tag: latest
             namespace: geerlingguy
+#          - distro: ubuntu2604
+#            tag: latest
+#            namespace: geerlingguy
+#          - distro: rockylinux10
+#            tag: latest
+#            namespace: geerlingguy
 
     steps:
       - name: Set TERM environment variable

--- a/automation/roles/common/defaults/main.yml
+++ b/automation/roles/common/defaults/main.yml
@@ -939,7 +939,7 @@ timezone: ""
 # timezone: "Europe/Berlin"
 
 # Generate locale
-# (except RHEL,use glibc-langpack)
+# (if locales-all is not installed, e.g. on Debian/Ubuntu)
 locale_gen:
   - { language_country: "en_US", encoding: "UTF-8" }
 #  - { language_country: "ru_RU", encoding: "UTF-8" }

--- a/automation/roles/common/defaults/main.yml
+++ b/automation/roles/common/defaults/main.yml
@@ -1232,6 +1232,7 @@ system_os_specific_packages:
     - moreutils
     - dnsutils
     - curl
+    - locales
     - locales-all
   RedHat:
     - python{{ python_version }}-devel

--- a/automation/roles/locales/tasks/main.yml
+++ b/automation/roles/locales/tasks/main.yml
@@ -25,6 +25,10 @@
         name: "{{ item }}"
       loop: "{{ glibc_langpack }}"
       environment: "{{ proxy_env | default({}) }}"
+      register: langpack_install_result
+      until: langpack_install_result is succeeded
+      retries: 3
+      delay: 5
       when:
         - ansible_os_family == "RedHat"
         - item not in ansible_facts.packages

--- a/automation/roles/locales/tasks/main.yml
+++ b/automation/roles/locales/tasks/main.yml
@@ -15,6 +15,7 @@
       loop: "{{ locale_gen | flatten(1) }}"
       when:
         - ansible_os_family == "Debian"
+        - "'locales' in ansible_facts.packages"
         - "'locales-all' not in ansible_facts.packages"
         - "'locales-all' not in system_packages"
 

--- a/automation/roles/locales/tasks/main.yml
+++ b/automation/roles/locales/tasks/main.yml
@@ -15,7 +15,7 @@
       loop: "{{ locale_gen | flatten(1) }}"
       when:
         - ansible_os_family == "Debian"
-        - "'locales' in ansible_facts.packages"
+        - "'locales' in ansible_facts.packages or 'locales' in system_packages"
         - "'locales-all' not in ansible_facts.packages"
         - "'locales-all' not in system_packages"
 

--- a/automation/roles/locales/tasks/main.yml
+++ b/automation/roles/locales/tasks/main.yml
@@ -13,7 +13,9 @@
         name: "{{ item.language_country }}.{{ item.encoding }}"
         state: present
       loop: "{{ locale_gen | flatten(1) }}"
-      when: ansible_os_family == "Debian"
+      when:
+        - ansible_os_family == "Debian"
+        - "'locales-all' not in ansible_facts.packages"
 
     # RedHat
     - name: Install glibc-langpack

--- a/automation/roles/locales/tasks/main.yml
+++ b/automation/roles/locales/tasks/main.yml
@@ -16,6 +16,7 @@
       when:
         - ansible_os_family == "Debian"
         - "'locales-all' not in ansible_facts.packages"
+        - "'locales-all' not in system_packages"
 
     # RedHat
     - name: Install glibc-langpack


### PR DESCRIPTION
Add a guard to the Debian locale generation task so it only runs when the 'locales-all' package is not installed.

This prevents redundant locale generation on systems that provide all locales via the locales-all package.