### PR TITLE
feat(console): support Docker Secrets via _FILE convention

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ __pycache__/
 molecule/**/tmp
 .ansible
 .ansible-lint-env
+# Docker Secrets directory created by docker-compose.secrets.yml
+console/secrets/

--- a/console/README.md
+++ b/console/README.md
@@ -86,3 +86,27 @@ The Console stack consists of the following core components:
 - The Caddy network is created automatically by Docker Compose
 - All services are configured to restart automatically unless stopped manually.
 - Additional [environment variables](https://github.com/autobase-tech/autobase/tree/main/console/service#configuration) can be configured based on your project needs.
+
+## Using Docker Secrets
+
+Sensitive values (auth token, database password) can be supplied via files
+mounted under `/run/secrets` instead of plain-text env vars in `.env`. Every
+console image honors the `_FILE` convention used by the official postgres
+image: if `FOO_FILE` is set, its file contents are loaded as `FOO`. Setting
+both `FOO` and `FOO_FILE` is an error.
+
+A ready-to-use override is provided at `docker-compose.secrets.yml`:
+
+```sh
+mkdir -p ./secrets && chmod 700 ./secrets
+printf '%s' 'your-secret-token' > ./secrets/auth_token
+printf '%s' 'your-db-password'  > ./secrets/db_password
+chmod 600 ./secrets/*
+
+docker compose -f docker-compose.yml -f docker-compose.secrets.yml up -d
+# or, with Caddy:
+docker compose -f docker-compose.caddy.yml -f docker-compose.secrets.yml up -d
+```
+
+For a Swarm deployment, replace the `file:` sources in the override with
+`external: true` and create the secrets via `docker secret create`.

--- a/console/db/README.md
+++ b/console/db/README.md
@@ -122,3 +122,10 @@ Output example:
     - Note: This function generates names in the format `postgres-cluster-XX`, where `XX` is a sequential number starting from 01. It checks the existing cluster names to ensure the generated name is unique.
   - Usage example:
     - `SELECT get_cluster_name();`
+
+### Docker Secrets
+
+The database container supports the `_FILE` convention for `POSTGRES_PASSWORD`.
+If `POSTGRES_PASSWORD_FILE` is set, the startup script reads that file and uses
+its contents as `POSTGRES_PASSWORD`. Setting both `POSTGRES_PASSWORD` and
+`POSTGRES_PASSWORD_FILE` to non-empty values is an error.

--- a/console/db/pg_start.sh
+++ b/console/db/pg_start.sh
@@ -5,6 +5,28 @@ log() {
   echo "$(date +'%Y-%m-%d %H:%M:%S') - $1"
 }
 
+# file_env VAR — if ${VAR}_FILE is set, replace ${VAR} with the file's contents.
+# Mirrors the convention used by the official postgres image so this custom
+# console_db container can consume Docker Secrets mounted under /run/secrets.
+file_env() {
+  local var="$1"
+  local fileVar="${var}_FILE"
+  if [ -n "${!var:-}" ] && [ -n "${!fileVar:-}" ]; then
+    log "error: both $var and $fileVar are set; choose one"
+    exit 1
+  fi
+  if [ -n "${!fileVar:-}" ]; then
+    if [ ! -r "${!fileVar}" ]; then
+      log "error: secret file '${!fileVar}' for $var is not readable"
+      exit 1
+    fi
+    # $(cat ...) trims trailing newlines, matching the postgres image.
+    export "$var=$(cat "${!fileVar}")"
+  fi
+}
+
+file_env POSTGRES_PASSWORD
+
 # Ensure the directory exists and has the correct permissions
 mkdir -p ${PGDATA} ${PG_UNIX_SOCKET_DIR} /etc/postgresql/${POSTGRES_VERSION}/main
 chown -R postgres:postgres ${PGDATA} ${PG_UNIX_SOCKET_DIR} /etc/postgresql/${POSTGRES_VERSION}/main

--- a/console/docker-compose.secrets.yml
+++ b/console/docker-compose.secrets.yml
@@ -1,0 +1,62 @@
+---
+# Docker Secrets override.
+#
+# Layer this on top of docker-compose.yml (or docker-compose.caddy.yml) to feed
+# sensitive values into the console via files mounted under /run/secrets,
+# instead of plain-text env vars in .env. The autobase images honor the
+# `_FILE` convention used by the official postgres image: if `FOO_FILE` is set,
+# its file contents are loaded as `FOO`.
+#
+# Usage (with the standalone compose file):
+#
+#   mkdir -p ./secrets && chmod 700 ./secrets
+#   printf '%s' 'your-secret-token' > ./secrets/auth_token
+#   printf '%s' 'your-db-password'  > ./secrets/db_password
+#   chmod 600 ./secrets/*
+#   docker compose -f docker-compose.yml -f docker-compose.secrets.yml up -d
+#
+# With the Caddy variant: swap docker-compose.yml for docker-compose.caddy.yml.
+#
+# In a Swarm deployment, replace the `file:` sources below with
+# `external: true` and create the secrets with `docker secret create`.
+
+services:
+  autobase-console-api:
+    environment:
+      PG_CONSOLE_AUTHORIZATION_TOKEN: ""
+      PG_CONSOLE_AUTHORIZATION_TOKEN_FILE: /run/secrets/console_auth_token
+      PG_CONSOLE_DB_PASSWORD_FILE: /run/secrets/console_db_password
+    secrets:
+      - console_auth_token
+      - console_db_password
+    healthcheck:
+      # Read the bearer token from the mounted secret at exec time so the
+      # cleartext value never appears in the container's environment or in
+      # `docker inspect` output. `$$` escapes `$` past compose interpolation.
+      test: ["CMD-SHELL",
+             "curl -fsS -H 'accept: application/json' \
+              -H \"Authorization: Bearer $$(cat /run/secrets/console_auth_token)\" \
+              http://localhost:8080/api/v1/version"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  autobase-console-ui:
+    environment:
+      PG_CONSOLE_AUTHORIZATION_TOKEN: ""
+      PG_CONSOLE_AUTHORIZATION_TOKEN_FILE: /run/secrets/console_auth_token
+    secrets:
+      - console_auth_token
+
+  autobase-console-db:
+    environment:
+      POSTGRES_PASSWORD: ""
+      POSTGRES_PASSWORD_FILE: /run/secrets/console_db_password
+    secrets:
+      - console_db_password
+
+secrets:
+  console_auth_token:
+    file: ./secrets/auth_token
+  console_db_password:
+    file: ./secrets/db_password

--- a/console/service/README.md
+++ b/console/service/README.md
@@ -75,6 +75,12 @@ PG_CONSOLE_DBDESK_STUDIO_SSLMODE      String              require               
 PG_CONSOLE_DBDESK_STUDIO_TIMEOUT      Duration            5s                                               HTTP timeout for dbdesk-studio health and registration requests
 ```
 
+### Docker Secrets
+
+The service supports the `_FILE` convention for all `PG_CONSOLE_*` environment variables.
+If `PG_CONSOLE_FOO_FILE` is set, the service reads that file and uses its contents as `PG_CONSOLE_FOO`.
+Setting both `PG_CONSOLE_FOO` and `PG_CONSOLE_FOO_FILE` to non-empty values is an error.
+
 ## Project structure
 ```
 |-api - Swagger specification

--- a/console/service/internal/configuration/config.go
+++ b/console/service/internal/configuration/config.go
@@ -66,6 +66,10 @@ const cfgPrefix = "PG_CONSOLE"
 func ReadConfig() (*Config, error) {
 	cfg := Config{}
 
+	if err := resolveFileSecrets(cfgPrefix); err != nil {
+		return nil, fmt.Errorf("failed to resolve file-backed secrets: %s", err.Error())
+	}
+
 	err := envconfig.Process(cfgPrefix, &cfg)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse config: %s", err.Error())
@@ -80,4 +84,23 @@ func PrintUsage() {
 	if err != nil {
 		fmt.Printf("failed to print envconfig usage: %s", err.Error())
 	}
+}
+
+// Redacted returns a copy of the config safe for logging. Secret-bearing
+// fields are masked: non-empty values become "[REDACTED]", empty values become
+// "[unset]". This preserves the diagnostic value of the startup config dump
+// (operators can confirm whether a secret was loaded at all) without writing
+// the cleartext value to logs.
+func (c *Config) Redacted() Config {
+	mask := func(v string) string {
+		if v == "" {
+			return "[unset]"
+		}
+		return "[REDACTED]"
+	}
+	out := *c
+	out.Authorization.Token = mask(out.Authorization.Token)
+	out.Db.Password = mask(out.Db.Password)
+	out.EncryptionKey = mask(out.EncryptionKey)
+	return out
 }

--- a/console/service/internal/configuration/secrets.go
+++ b/console/service/internal/configuration/secrets.go
@@ -1,0 +1,48 @@
+package configuration
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+// resolveFileSecrets implements the Docker `_FILE` convention used by official
+// images such as postgres and mysql. For every environment variable named
+// `<prefix>_..._FILE`, the file at that path is read and its contents are used
+// as the value of the corresponding base variable (with `_FILE` stripped).
+//
+// If both the base variable and its `_FILE` counterpart are set to non-empty
+// values an error is returned, mirroring the postgres image's behavior. A
+// single trailing newline (optionally preceded by `\r`) is trimmed from the
+// file contents, since Docker secret files commonly include one.
+func resolveFileSecrets(prefix string) error {
+	suffix := "_FILE"
+	for _, kv := range os.Environ() {
+		eq := strings.IndexByte(kv, '=')
+		if eq < 0 {
+			continue
+		}
+		key, path := kv[:eq], kv[eq+1:]
+		if path == "" {
+			continue
+		}
+		if !strings.HasPrefix(key, prefix+"_") || !strings.HasSuffix(key, suffix) {
+			continue
+		}
+		base := strings.TrimSuffix(key, suffix)
+		if existing, ok := os.LookupEnv(base); ok && existing != "" {
+			return fmt.Errorf("both %s and %s are set; choose one", base, key)
+		}
+
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return fmt.Errorf("failed to read secret file for %s: %w", key, err)
+		}
+		value := strings.TrimSuffix(string(data), "\n")
+		value = strings.TrimSuffix(value, "\r")
+		if err := os.Setenv(base, value); err != nil {
+			return fmt.Errorf("failed to set %s from %s: %w", base, key, err)
+		}
+	}
+	return nil
+}

--- a/console/service/internal/configuration/secrets_test.go
+++ b/console/service/internal/configuration/secrets_test.go
@@ -1,0 +1,150 @@
+package configuration
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+const testPrefix = "PG_CONSOLE_TEST"
+
+func writeSecret(t *testing.T, dir, name, content string) string {
+	t.Helper()
+	p := filepath.Join(dir, name)
+	if err := os.WriteFile(p, []byte(content), 0o600); err != nil {
+		t.Fatalf("write secret: %v", err)
+	}
+	return p
+}
+
+func TestResolveFileSecrets_ReadsFileIntoBaseVar(t *testing.T) {
+	dir := t.TempDir()
+	path := writeSecret(t, dir, "token", "s3cret\n")
+	t.Setenv(testPrefix+"_AUTHORIZATION_TOKEN_FILE", path)
+	t.Setenv(testPrefix+"_AUTHORIZATION_TOKEN", "")
+
+	if err := resolveFileSecrets(testPrefix); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := os.Getenv(testPrefix + "_AUTHORIZATION_TOKEN"); got != "s3cret" {
+		t.Fatalf("expected trimmed secret 's3cret', got %q", got)
+	}
+}
+
+func TestResolveFileSecrets_TrimsCRLF(t *testing.T) {
+	dir := t.TempDir()
+	path := writeSecret(t, dir, "token", "s3cret\r\n")
+	t.Setenv(testPrefix+"_AUTHORIZATION_TOKEN_FILE", path)
+	t.Setenv(testPrefix+"_AUTHORIZATION_TOKEN", "")
+
+	if err := resolveFileSecrets(testPrefix); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := os.Getenv(testPrefix + "_AUTHORIZATION_TOKEN"); got != "s3cret" {
+		t.Fatalf("expected CRLF trim to yield 's3cret', got %q", got)
+	}
+}
+
+func TestResolveFileSecrets_PreservesInternalNewlines(t *testing.T) {
+	dir := t.TempDir()
+	path := writeSecret(t, dir, "key", "line1\nline2\n")
+	t.Setenv(testPrefix+"_ENCRYPTIONKEY_FILE", path)
+	t.Setenv(testPrefix+"_ENCRYPTIONKEY", "")
+
+	if err := resolveFileSecrets(testPrefix); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := os.Getenv(testPrefix + "_ENCRYPTIONKEY"); got != "line1\nline2" {
+		t.Fatalf("only trailing newline should be trimmed, got %q", got)
+	}
+}
+
+func TestResolveFileSecrets_ConflictErrors(t *testing.T) {
+	dir := t.TempDir()
+	path := writeSecret(t, dir, "token", "from-file")
+	t.Setenv(testPrefix+"_AUTHORIZATION_TOKEN_FILE", path)
+	t.Setenv(testPrefix+"_AUTHORIZATION_TOKEN", "from-env")
+
+	if err := resolveFileSecrets(testPrefix); err == nil {
+		t.Fatalf("expected conflict error when both var and _FILE are set")
+	}
+}
+
+func TestResolveFileSecrets_MissingFileErrors(t *testing.T) {
+	t.Setenv(testPrefix+"_AUTHORIZATION_TOKEN_FILE", "/nonexistent/path/to/secret")
+	t.Setenv(testPrefix+"_AUTHORIZATION_TOKEN", "")
+
+	if err := resolveFileSecrets(testPrefix); err == nil {
+		t.Fatalf("expected error when secret file is missing")
+	}
+}
+
+func TestResolveFileSecrets_NoopWhenFileVarUnset(t *testing.T) {
+	t.Setenv(testPrefix+"_AUTHORIZATION_TOKEN", "stays")
+
+	if err := resolveFileSecrets(testPrefix); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := os.Getenv(testPrefix + "_AUTHORIZATION_TOKEN"); got != "stays" {
+		t.Fatalf("expected base var to remain 'stays', got %q", got)
+	}
+}
+
+func TestResolveFileSecrets_IgnoresOtherPrefixes(t *testing.T) {
+	dir := t.TempDir()
+	path := writeSecret(t, dir, "x", "value")
+	t.Setenv("UNRELATED_TOKEN_FILE", path)
+	t.Setenv("UNRELATED_TOKEN", "")
+
+	if err := resolveFileSecrets(testPrefix); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := os.Getenv("UNRELATED_TOKEN"); got != "" {
+		t.Fatalf("expected unrelated prefix to be left alone, got %q", got)
+	}
+}
+
+func TestResolveFileSecrets_EmptyFileVarSkipped(t *testing.T) {
+	t.Setenv(testPrefix+"_AUTHORIZATION_TOKEN_FILE", "")
+	t.Setenv(testPrefix+"_AUTHORIZATION_TOKEN", "kept")
+
+	if err := resolveFileSecrets(testPrefix); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := os.Getenv(testPrefix + "_AUTHORIZATION_TOKEN"); got != "kept" {
+		t.Fatalf("expected base var to be preserved when _FILE is empty, got %q", got)
+	}
+}
+
+func TestRedacted_MasksSecrets(t *testing.T) {
+	c := Config{}
+	c.Authorization.Token = "super-secret-token"
+	c.Db.Password = "super-secret-pw"
+	c.EncryptionKey = "super-secret-key"
+	c.Db.Host = "localhost"
+
+	r := c.Redacted()
+	if r.Authorization.Token != "[REDACTED]" {
+		t.Errorf("token not redacted: %q", r.Authorization.Token)
+	}
+	if r.Db.Password != "[REDACTED]" {
+		t.Errorf("password not redacted: %q", r.Db.Password)
+	}
+	if r.EncryptionKey != "[REDACTED]" {
+		t.Errorf("encryption key not redacted: %q", r.EncryptionKey)
+	}
+	if r.Db.Host != "localhost" {
+		t.Errorf("non-secret field altered: %q", r.Db.Host)
+	}
+	if c.Authorization.Token != "super-secret-token" {
+		t.Errorf("Redacted mutated the receiver: %q", c.Authorization.Token)
+	}
+}
+
+func TestRedacted_EmptyShowsUnset(t *testing.T) {
+	c := Config{}
+	r := c.Redacted()
+	if r.Authorization.Token != "[unset]" {
+		t.Errorf("expected [unset] for empty token, got %q", r.Authorization.Token)
+	}
+}

--- a/console/service/main.go
+++ b/console/service/main.go
@@ -45,7 +45,7 @@ func main() {
 
 		return
 	}
-	log.Info().Interface("config", cfg).Msg("config was parsed")
+	log.Info().Interface("config", cfg.Redacted()).Msg("config was parsed")
 
 	l, err := zerolog.ParseLevel(cfg.Logger.Level)
 	if err != nil {

--- a/console/ui/README.md
+++ b/console/ui/README.md
@@ -81,6 +81,15 @@ There are several env variables that configure UI:
 
 The UI communicates with the API using the relative path /api/v1 through the Nginx reverse proxy host specified by PG_CONSOLE_API_HOST. If needed, you can override this by setting the PG_CONSOLE_API_URL variable.
 
+### Docker Secrets
+
+The UI container supports the `_FILE` convention for
+`PG_CONSOLE_AUTHORIZATION_TOKEN` and `VITE_AUTH_TOKEN`. If
+`PG_CONSOLE_AUTHORIZATION_TOKEN_FILE` or `VITE_AUTH_TOKEN_FILE` is set, the
+entrypoint reads the file and uses its contents as the corresponding variable.
+Setting both the base variable and its `_FILE` variant to non-empty values is an
+error.
+
 ## Architecture
 
 UI uses [Feature-Sliced Design](https://feature-sliced.design/) v2 approach to implement architecture.

--- a/console/ui/env.sh
+++ b/console/ui/env.sh
@@ -3,6 +3,35 @@
 SEARCH_DIR="/usr/share/nginx/html/"
 NGINX_CONF="/etc/nginx/nginx.conf"
 
+# file_env VAR — if ${VAR}_FILE is set, replace ${VAR} with the file's contents.
+# Mirrors the convention used by the official postgres/mysql images so the
+# console can consume Docker Secrets mounted under /run/secrets.
+file_env() {
+    var="$1"
+    fileVar="${var}_FILE"
+    eval "varVal=\${$var-}"
+    eval "fileVarVal=\${$fileVar-}"
+    if [ -n "$varVal" ] && [ -n "$fileVarVal" ]; then
+        echo "error: both $var and $fileVar are set; choose one" >&2
+        exit 1
+    fi
+    if [ -n "$fileVarVal" ]; then
+        if [ ! -r "$fileVarVal" ]; then
+            echo "error: secret file '$fileVarVal' for $var is not readable" >&2
+            exit 1
+        fi
+        # $(cat ...) trims any trailing newlines per POSIX, matching the
+        # postgres image's file_env behavior.
+        secretVal=$(cat "$fileVarVal")
+        export "$var=$secretVal"
+    fi
+    unset varVal fileVarVal secretVal
+}
+
+# Resolve Docker Secret-backed env vars before deriving downstream values.
+file_env PG_CONSOLE_AUTHORIZATION_TOKEN
+file_env VITE_AUTH_TOKEN
+
 # Set default values for environment variables if they are not set
 export VITE_API_URL=${VITE_API_URL:-${PG_CONSOLE_API_URL:-"/api/v1"}}
 export VITE_AUTH_TOKEN=${VITE_AUTH_TOKEN:-${PG_CONSOLE_AUTHORIZATION_TOKEN:-"auth_token"}}


### PR DESCRIPTION
Related to #1480

Adopt the convention popularized by the official postgres image so the console can consume sensitive values (auth token, database password) from files mounted under /run/secrets instead of plain-text env vars in .env.

For any FOO, if FOO_FILE is set the file's contents are loaded as FOO. A single trailing newline is trimmed. Setting both FOO and FOO_FILE non-empty is an error.

- Go API: resolveFileSecrets sweeps PG_CONSOLE_*_FILE env vars before envconfig.Process runs; covers AUTHORIZATION_TOKEN, DB_PASSWORD, and ENCRYPTIONKEY uniformly.
- UI: POSIX-sh file_env helper in env.sh applied to PG_CONSOLE_AUTHORIZATION_TOKEN so the value the script injects into the built JS comes from the secret file.
- DB: bash file_env helper in pg_start.sh applied to POSTGRES_PASSWORD so the ALTER USER statement sources its value from the secret file.
- docker-compose.secrets.yml: opt-in override demonstrating Docker Secrets; also overrides the API healthcheck to read the bearer token from the mounted secret at exec time, so the cleartext never appears in the container's environment or `docker inspect` output.
- Config.Redacted(): the startup config dump in main.go was writing secret values to logs in cleartext, which defeats the purpose of using Docker Secrets. The logged copy now masks Token/Password/EncryptionKey as "[REDACTED]" (non-empty) or "[unset]" (empty).

End-to-end verified by building all three console images locally, bringing the stack up with the secrets override, and confirming: API resolves both secrets, DB password is enforced over TCP (scram-sha-256), bearer auth works with the file-backed token, conflict and missing-file paths fail cleanly, and the cleartext values no longer appear in logs.

Note: console/db/Dockerfile bakes ENV POSTGRES_PASSWORD=postgres-pass, so adopters must explicitly set POSTGRES_PASSWORD: "" alongside _FILE (the override file does this) to avoid hitting the conflict guard. Out of scope to remove that Dockerfile default here.