### PR TITLE
Add install_extensions tag to add_repository tasks

### DIFF
--- a/automation/roles/add_repository/tasks/main.yml
+++ b/automation/roles/add_repository/tasks/main.yml
@@ -185,3 +185,4 @@
 - name: Extensions repository
   ansible.builtin.import_tasks: extensions.yml
   when: installation_method == "packages"
+  tags: add_repo, install_extensions

--- a/automation/tags.md
+++ b/automation/tags.md
@@ -6,6 +6,7 @@
 - - install_extensions
 - install_packages
 - - install_postgres
+- - install_extensions
 - - install_packages_from_file
 - sudo
 - firewall

--- a/automation/tags.md
+++ b/automation/tags.md
@@ -3,6 +3,7 @@
 - add_repo
 - - install_epel_repo
 - - install_postgresql_repo
+- - install_extensions
 - install_packages
 - - install_postgres
 - - install_packages_from_file


### PR DESCRIPTION
Add tags (add_repo, install_extensions) to the Extensions repository import task.