### PR TITLE
Add restart_pgcluster playbook

### DIFF
--- a/automation/README.md
+++ b/automation/README.md
@@ -95,6 +95,7 @@ Autobase adheres to a modular design separating atomic logic (roles) and orchest
 #### Maintenance
 
 - `config_pgcluster` – Reconfigure PostgreSQL cluster settings (users, databases, extensions, etc.) after the initial deployment.
+- `restart_pgcluster` – Restart PostgreSQL cluster services: replicas are restarted one by one, then a switchover is performed before restarting services on the former primary.
 - `update_pgcluster` – Perform rolling updates of PostgreSQL or system packages with minimal downtime.
 - `pg_upgrade` – Perform a major version in-place upgrade of PostgreSQL with minimal downtime.
   - `pg_upgrade_rollback` - Performs a rollback of a PostgreSQL upgrade (if possible).

--- a/automation/molecule/default/converge.yml
+++ b/automation/molecule/default/converge.yml
@@ -126,7 +126,7 @@
   ansible.builtin.import_playbook: ../../playbooks/deploy_pgcluster.yml
 
 - name: Config PostgreSQL Cluster test
-  ansible.builtin.import_playbook: ../../playbooks/config_pgcluster.yml
+  ansible.builtin.import_playbook: ../../playbooks/restart_pgcluster.yml
 
-- name: Update PostgreSQL Cluster test
-  ansible.builtin.import_playbook: ../../playbooks/update_pgcluster.yml
+#- name: Update PostgreSQL Cluster test
+#  ansible.builtin.import_playbook: ../../playbooks/update_pgcluster.yml

--- a/automation/molecule/default/converge.yml
+++ b/automation/molecule/default/converge.yml
@@ -126,7 +126,7 @@
   ansible.builtin.import_playbook: ../../playbooks/deploy_pgcluster.yml
 
 - name: Config PostgreSQL Cluster test
-  ansible.builtin.import_playbook: ../../playbooks/restart_pgcluster.yml
+  ansible.builtin.import_playbook: ../../playbooks/config_pgcluster.yml
 
-#- name: Update PostgreSQL Cluster test
-#  ansible.builtin.import_playbook: ../../playbooks/update_pgcluster.yml
+- name: Update PostgreSQL Cluster test
+  ansible.builtin.import_playbook: ../../playbooks/update_pgcluster.yml

--- a/automation/playbooks/add_node.yml
+++ b/automation/playbooks/add_node.yml
@@ -1,5 +1,5 @@
 ---
-- name: vitabaks.autobase.add_node | PostgreSQL HA Cluster Scaling (add a new node)
+- name: vitabaks.autobase.add_node | PostgreSQL Cluster Scaling (add a new node)
   hosts: localhost
   gather_facts: true
   any_errors_fatal: true

--- a/automation/playbooks/config_pgcluster.yml
+++ b/automation/playbooks/config_pgcluster.yml
@@ -12,7 +12,7 @@
       tags: always
 
     - name: Define bind_address
-      ansible.builtin.include_role:
+      ansible.builtin.import_role:
         name: vitabaks.autobase.bind_address
       tags: always
 
@@ -41,6 +41,7 @@
       environment:
         no_proxy: "{{ patroni_bind_address | default(bind_address, true) }}"
       when: inventory_hostname in groups['postgres_cluster']
+      tags: always
 
     # Stop, if no healthy Patroni leader node
     - name: The Patroni cluster is unhealthy
@@ -55,6 +56,7 @@
             | selectattr('value.patroni_leader_result.status', 'defined')
             | selectattr('value.patroni_leader_result.status', 'equalto', 200)
             | list | length) == 0
+      tags: always
 
   roles:
     - role: vitabaks.autobase.pre_checks
@@ -62,6 +64,7 @@
         minimal_ansible_version: 2.17.0
         timescale_minimal_pg_version: 12 # if enable_timescale is defined
       when: inventory_hostname in groups['postgres_cluster']
+      tags: always
 
   tasks:
     - name: '[Prepare] Add host to group "primary" (in-memory inventory)'
@@ -73,6 +76,7 @@
       loop: "{{ groups['postgres_cluster'] }}"
       changed_when: false
       check_mode: false
+      tags: always
 
     - name: '[Prepare] Add hosts to group "secondary" (in-memory inventory)'
       ansible.builtin.add_host:
@@ -83,6 +87,7 @@
       loop: "{{ groups['postgres_cluster'] }}"
       changed_when: false
       check_mode: false
+      tags: always
 
     - name: "Print Patroni Cluster info"
       ansible.builtin.debug:
@@ -90,6 +95,7 @@
           - "Cluster Name: {{ patroni_cluster_name | default('postgres-cluster') }}"
           - "Cluster Leader: {{ ansible_hostname }}"
       when: inventory_hostname in groups['primary'] | default([])
+      tags: always
 
     # if 'cloud_provider' is 'aws', 'gcp', or 'azure'
     # set_fact: 'pgbackrest_install' to configure Postgres backups if not disabled explicitly.
@@ -100,8 +106,7 @@
         - not (pgbackrest_install | default(false) | bool or wal_g_install | default(false) | bool)
         - cloud_provider | default('') | lower in ['aws', 'gcp', 'azure']
         - pgbackrest_auto_conf | default(true) | bool # to be able to disable auto backup settings
-  tags:
-    - always
+      tags: always
 
 - name: vitabaks.autobase.config_pgcluster | Configure PostgreSQL Cluster
   hosts: "primary:secondary"
@@ -197,12 +202,12 @@
 
   tasks:
     - name: Configure patroni
-      ansible.builtin.include_role:
+      ansible.builtin.import_role:
         name: vitabaks.autobase.patroni
         tasks_from: config
 
     - name: Configure pgbouncer
-      ansible.builtin.include_role:
+      ansible.builtin.import_role:
         name: vitabaks.autobase.pgbouncer
         tasks_from: config
       when: pgbouncer_install | default(true) | bool
@@ -229,102 +234,17 @@
       when: pgbackrest_install | default(false) | bool
   tasks:
     - name: Create pgbackrest stanza (if missing)
-      ansible.builtin.include_role:
+      ansible.builtin.import_role:
         name: vitabaks.autobase.pgbackrest
         tasks_from: stanza_create
       when: pgbackrest_install | default(false) | bool
 
-- name: vitabaks.autobase.config_pgcluster | Restart patroni on secondary after config settings if need
-  hosts: secondary
-  serial: 1 # restart replicas one by one
-  gather_facts: false
-  become: true
-  become_method: sudo
-  any_errors_fatal: true
-  tasks:
-    - name: Stop read-only traffic
-      ansible.builtin.include_role:
-        name: vitabaks.autobase.update
-        tasks_from: stop_traffic
-      when:
-        - pending_restart | default(false) | bool
-        - pg_pending_restart_settings | default('') | length > 0
-
-    - name: Stop Services
-      ansible.builtin.include_role:
-        name: vitabaks.autobase.update
-        tasks_from: stop_services
-      when:
-        - pending_restart | default(false) | bool
-        - pg_pending_restart_settings | default('') | length > 0
-
-    - name: Start Services
-      ansible.builtin.include_role:
-        name: vitabaks.autobase.update
-        tasks_from: start_services
-      when:
-        - pending_restart | default(false) | bool
-        - pg_pending_restart_settings | default('') | length > 0
-
-    - name: Start read-only traffic
-      ansible.builtin.include_role:
-        name: vitabaks.autobase.update
-        tasks_from: start_traffic
-      when:
-        - pending_restart | default(false) | bool
-        - pg_pending_restart_settings | default('') | length > 0
-  tags:
-    - patroni_conf
-
-- name: vitabaks.autobase.config_pgcluster | Restart patroni on master after config settings if need
-  hosts: primary
-  gather_facts: false
-  become: true
-  become_method: sudo
-  any_errors_fatal: true
-  environment: "{{ proxy_env | default({}) }}"
-  tasks:
-    - name: Switchover Patroni leader role
-      ansible.builtin.include_role:
-        name: vitabaks.autobase.update
-        tasks_from: switchover
-      when:
-        - pending_restart | default(false) | bool
-        - pg_pending_restart_settings | default('') | length > 0
-
-    - name: Stop read-only traffic
-      ansible.builtin.include_role:
-        name: vitabaks.autobase.update
-        tasks_from: stop_traffic
-      when:
-        - pending_restart | default(false) | bool
-        - pg_pending_restart_settings | default('') | length > 0
-
-    - name: Stop Services
-      ansible.builtin.include_role:
-        name: vitabaks.autobase.update
-        tasks_from: stop_services
-      when:
-        - pending_restart | default(false) | bool
-        - pg_pending_restart_settings | default('') | length > 0
-
-    - name: Start Services
-      ansible.builtin.include_role:
-        name: vitabaks.autobase.update
-        tasks_from: start_services
-      when:
-        - pending_restart | default(false) | bool
-        - pg_pending_restart_settings | default('') | length > 0
-
-    - name: Start read-only traffic
-      ansible.builtin.include_role:
-        name: vitabaks.autobase.update
-        tasks_from: start_traffic
-      when:
-        - pending_restart | default(false) | bool
-        - pg_pending_restart_settings | default('') | length > 0
-  tags:
-    - patroni_conf
+- name: Restart PostgreSQL Cluster if pending restart is required
+  ansible.builtin.import_playbook: restart_pgcluster.yml
+  when:
+    - pending_restart | default(false) | bool
+    - pg_pending_restart_settings | default('') | length > 0
+  tags: patroni_conf
 
 - name: vitabaks.autobase.config_pgcluster | Configure PostgreSQL Cluster and info
   hosts: primary

--- a/automation/playbooks/config_pgcluster.yml
+++ b/automation/playbooks/config_pgcluster.yml
@@ -51,10 +51,10 @@
           Please ensure the cluster is up and node responds on REST API port ({{ patroni_restapi_port | default('8008') }}).
       when:
         - inventory_hostname == groups['postgres_cluster'][0]
-        - (hostvars
-            | dict2items
-            | selectattr('value.patroni_leader_result.status', 'defined')
-            | selectattr('value.patroni_leader_result.status', 'equalto', 200)
+        - (groups.get('postgres_cluster', [])
+            | map('extract', hostvars)
+            | selectattr('patroni_leader_result.status', 'defined')
+            | selectattr('patroni_leader_result.status', 'equalto', 200)
             | list | length) == 0
       tags: always
 

--- a/automation/playbooks/config_pgcluster.yml
+++ b/automation/playbooks/config_pgcluster.yml
@@ -1,5 +1,5 @@
 ---
-- name: vitabaks.autobase.config_pgcluster | Configure PostgreSQL HA Cluster (based on "Patroni")
+- name: vitabaks.autobase.config_pgcluster | Configure PostgreSQL Cluster
   hosts: postgres_cluster:etcd_cluster
   become: true
   become_method: sudo

--- a/automation/playbooks/config_pgcluster.yml
+++ b/automation/playbooks/config_pgcluster.yml
@@ -247,13 +247,31 @@
   tags: patroni_conf
 
 - name: vitabaks.autobase.config_pgcluster | Configure PostgreSQL Cluster and info
-  hosts: primary
+  hosts: postgres_cluster
   become: true
   become_method: sudo
   gather_facts: true
   any_errors_fatal: true
+  pre_tasks:
+    - name: "Get current Patroni Cluster Leader Node"
+      ansible.builtin.uri:
+        url: >-
+          {{ patroni_restapi_protocol | default('https') }}://{{ patroni_restapi_connect_addr
+            | default(patroni_bind_address | default(bind_address, true), true) }}:{{ patroni_restapi_port
+            | default('8008') }}/leader
+        status_code: 200
+        ca_path: "{{ patroni_restapi_cafile | default(omit, true) }}"
+      register: current_patroni_leader_result
+      changed_when: false
+      failed_when: false
+      check_mode: false
+      environment:
+        no_proxy: "{{ patroni_bind_address | default(bind_address, true) }}"
+      tags: always
   roles:
     - role: vitabaks.autobase.postgresql_extensions
+      when: current_patroni_leader_result.status | default(0) == 200
 
     # finish (info)
     - role: vitabaks.autobase.deploy_finish
+      when: current_patroni_leader_result.status | default(0) == 200

--- a/automation/playbooks/deploy_pgcluster.yml
+++ b/automation/playbooks/deploy_pgcluster.yml
@@ -1,5 +1,5 @@
 ---
-- name: vitabaks.autobase.deploy_pgcluster | Deploy PostgreSQL HA Cluster (based on "Patroni")
+- name: vitabaks.autobase.deploy_pgcluster | Deploy PostgreSQL Cluster
   hosts: localhost
   gather_facts: true
   any_errors_fatal: true

--- a/automation/playbooks/remove_cluster.yml
+++ b/automation/playbooks/remove_cluster.yml
@@ -1,5 +1,5 @@
 ---
-- name: vitabaks.autobase.remove_cluster | Remove PostgreSQL HA Cluster
+- name: vitabaks.autobase.remove_cluster | Remove PostgreSQL Cluster
   hosts: postgres_cluster:pgbackrest
   become: true
   gather_facts: true

--- a/automation/playbooks/restart_pgcluster.yml
+++ b/automation/playbooks/restart_pgcluster.yml
@@ -15,16 +15,11 @@
     - name: Define bind_address
       ansible.builtin.import_role:
         name: vitabaks.autobase.bind_address
-      when: bind_address is not defined or bind_address | string | length < 1
+      when: bind_address is not defined
 
     - name: Set default variables
       ansible.builtin.import_role:
         name: vitabaks.autobase.common
-
-    - name: "[Prepare] Set maintenance variable"
-      ansible.builtin.set_fact:
-        postgresql_cluster_maintenance: true
-      when: postgresql_cluster_maintenance is not defined
 
     - name: "[Prepare] Get Patroni Cluster Leader Node"
       ansible.builtin.uri:
@@ -81,17 +76,6 @@
       changed_when: false
       check_mode: false
 
-    - name: Get current Patroni passwords
-      ansible.builtin.import_role:
-        name: vitabaks.autobase.pre_checks
-        tasks_from: passwords
-      vars:
-        source_group: primary
-      when:
-        - patroni_superuser_password | default('') | length < 1 or
-          patroni_replication_password | default('') | length < 1 or
-          patroni_restapi_password | default('') | length < 1
-
     - name: "Print Patroni Cluster info"
       ansible.builtin.debug:
         msg:
@@ -100,6 +84,15 @@
       when:
         - groups.get('primary', []) | length > 0
         - inventory_hostname in groups['primary']
+
+    - name: Get current Patroni passwords
+      ansible.builtin.import_role:
+        name: vitabaks.autobase.pre_checks
+        tasks_from: passwords
+      vars:
+        source_group: "source_cluster"
+        postgresql_cluster_maintenance: true
+      when: patroni_superuser_password | default('') | length < 1
 
 - name: vitabaks.autobase.restart_pgcluster | Restart patroni on secondary
   hosts: secondary

--- a/automation/playbooks/restart_pgcluster.yml
+++ b/automation/playbooks/restart_pgcluster.yml
@@ -42,6 +42,16 @@
             | selectattr('patroni_leader_result.status', 'equalto', 200)
             | list | length) == 0
 
+    - name: "[Prepare] Set Patroni leader result variable"
+      ansible.builtin.set_fact:
+        leader_result: >-
+          {{
+            restart_patroni_leader_result
+            if restart_patroni_leader_result.status is defined
+            else patroni_leader_result | default({})
+          }}
+      changed_when: false
+
     - name: The Patroni cluster is unhealthy
       ansible.builtin.fail:
         msg: >
@@ -51,8 +61,8 @@
         - inventory_hostname == groups['postgres_cluster'][0]
         - (groups.get('postgres_cluster', [])
             | map('extract', hostvars)
-            | selectattr('restart_patroni_leader_result.status', 'defined')
-            | selectattr('restart_patroni_leader_result.status', 'equalto', 200)
+            | selectattr('leader_result.status', 'defined')
+            | selectattr('leader_result.status', 'equalto', 200)
             | list | length) == 0
 
     - name: '[Prepare] Add host to group "primary" (in-memory inventory)'
@@ -62,7 +72,7 @@
         postgresql_exists: true
       when:
         - groups.get('primary', []) | length < 1
-        - (hostvars[item]['restart_patroni_leader_result']['status'] | default(hostvars[item]['patroni_leader_result']['status'] | default(0))) == 200
+        - hostvars[item]['leader_result']['status'] | default(0) == 200
       loop: "{{ groups['postgres_cluster'] }}"
       changed_when: false
       check_mode: false
@@ -74,7 +84,7 @@
         postgresql_exists: true
       when:
         - groups.get('secondary', []) | length < 1
-        - (hostvars[item]['restart_patroni_leader_result']['status'] | default(hostvars[item]['patroni_leader_result']['status'] | default(0))) == 503
+        - hostvars[item]['leader_result']['status'] | default(0) == 503
       loop: "{{ groups['postgres_cluster'] }}"
       changed_when: false
       check_mode: false

--- a/automation/playbooks/restart_pgcluster.yml
+++ b/automation/playbooks/restart_pgcluster.yml
@@ -29,13 +29,18 @@
             | default('8008') }}/leader
         status_code: 200
         ca_path: "{{ patroni_restapi_cafile | default(omit, true) }}"
-      register: patroni_leader_result
+      register: restart_patroni_leader_result
       changed_when: false
       failed_when: false
       check_mode: false
       environment:
         no_proxy: "{{ patroni_bind_address | default(bind_address, true) }}"
-      when: patroni_leader_result is not defined
+      when:
+        - (groups.get('postgres_cluster', [])
+            | map('extract', hostvars)
+            | selectattr('patroni_leader_result.status', 'defined')
+            | selectattr('patroni_leader_result.status', 'equalto', 200)
+            | list | length) == 0
 
     - name: The Patroni cluster is unhealthy
       ansible.builtin.fail:
@@ -44,10 +49,10 @@
           Please ensure the cluster is up and node responds on REST API port ({{ patroni_restapi_port | default('8008') }}).
       when:
         - inventory_hostname == groups['postgres_cluster'][0]
-        - (hostvars
-            | dict2items
-            | selectattr('value.patroni_leader_result.status', 'defined')
-            | selectattr('value.patroni_leader_result.status', 'equalto', 200)
+        - (groups.get('postgres_cluster', [])
+            | map('extract', hostvars)
+            | selectattr('restart_patroni_leader_result.status', 'defined')
+            | selectattr('restart_patroni_leader_result.status', 'equalto', 200)
             | list | length) == 0
 
     - name: '[Prepare] Add host to group "primary" (in-memory inventory)'
@@ -57,8 +62,7 @@
         postgresql_exists: true
       when:
         - groups.get('primary', []) | length < 1
-        - hostvars[item]['patroni_leader_result'] is defined
-        - hostvars[item]['patroni_leader_result']['status'] == 200
+        - (hostvars[item]['restart_patroni_leader_result']['status'] | default(hostvars[item]['patroni_leader_result']['status'] | default(0))) == 200
       loop: "{{ groups['postgres_cluster'] }}"
       changed_when: false
       check_mode: false
@@ -70,8 +74,7 @@
         postgresql_exists: true
       when:
         - groups.get('secondary', []) | length < 1
-        - hostvars[item]['patroni_leader_result'] is defined
-        - hostvars[item]['patroni_leader_result']['status'] == 503
+        - (hostvars[item]['restart_patroni_leader_result']['status'] | default(hostvars[item]['patroni_leader_result']['status'] | default(0))) == 503
       loop: "{{ groups['postgres_cluster'] }}"
       changed_when: false
       check_mode: false

--- a/automation/playbooks/restart_pgcluster.yml
+++ b/automation/playbooks/restart_pgcluster.yml
@@ -147,11 +147,13 @@
       ansible.builtin.import_role:
         name: vitabaks.autobase.update
         tasks_from: switchover
+      when: groups.get('secondary', []) | length > 0
 
     - name: Stop read-only traffic
       ansible.builtin.import_role:
         name: vitabaks.autobase.update
         tasks_from: stop_traffic
+      when: groups.get('secondary', []) | length > 0
 
     - name: Stop Services
       ansible.builtin.import_role:
@@ -167,3 +169,4 @@
       ansible.builtin.import_role:
         name: vitabaks.autobase.update
         tasks_from: start_traffic
+      when: groups.get('secondary', []) | length > 0

--- a/automation/playbooks/restart_pgcluster.yml
+++ b/automation/playbooks/restart_pgcluster.yml
@@ -1,0 +1,163 @@
+---
+- name: vitabaks.autobase.restart_pgcluster | Restart PostgreSQL HA Cluster
+  hosts: postgres_cluster
+  gather_facts: true
+  become: true
+  become_method: sudo
+  any_errors_fatal: true
+  tasks:
+    - name: Gather package facts
+      ansible.builtin.package_facts:
+        manager: auto
+      check_mode: false
+      when: ansible_facts.packages is not defined
+
+    - name: Define bind_address
+      ansible.builtin.import_role:
+        name: vitabaks.autobase.bind_address
+      when: bind_address is not defined or bind_address | string | length < 1
+
+    - name: Set default variables
+      ansible.builtin.import_role:
+        name: vitabaks.autobase.common
+
+    - name: "[Prepare] Set maintenance variable"
+      ansible.builtin.set_fact:
+        postgresql_cluster_maintenance: true
+      when: postgresql_cluster_maintenance is not defined
+
+    - name: "[Prepare] Get Patroni Cluster Leader Node"
+      ansible.builtin.uri:
+        url: >-
+          {{ patroni_restapi_protocol | default('https') }}://{{ patroni_restapi_connect_addr
+            | default(patroni_bind_address | default(bind_address, true), true) }}:{{ patroni_restapi_port
+            | default('8008') }}/leader
+        status_code: 200
+        ca_path: "{{ patroni_restapi_cafile | default(omit, true) }}"
+      register: patroni_leader_result
+      changed_when: false
+      failed_when: false
+      check_mode: false
+      environment:
+        no_proxy: "{{ patroni_bind_address | default(bind_address, true) }}"
+      when: patroni_leader_result is not defined
+
+    - name: The Patroni cluster is unhealthy
+      ansible.builtin.fail:
+        msg: >
+          No healthy leader node detected in cluster '{{ patroni_cluster_name | default('postgres-cluster') }}'.
+          Please ensure the cluster is up and node responds on REST API port ({{ patroni_restapi_port | default('8008') }}).
+      when:
+        - inventory_hostname == groups['postgres_cluster'][0]
+        - (hostvars
+            | dict2items
+            | selectattr('value.patroni_leader_result.status', 'defined')
+            | selectattr('value.patroni_leader_result.status', 'equalto', 200)
+            | list | length) == 0
+
+    - name: '[Prepare] Add host to group "primary" (in-memory inventory)'
+      ansible.builtin.add_host:
+        name: "{{ item }}"
+        groups: primary
+        postgresql_exists: true
+      when:
+        - groups.get('primary', []) | length < 1
+        - hostvars[item]['patroni_leader_result'] is defined
+        - hostvars[item]['patroni_leader_result']['status'] == 200
+      loop: "{{ groups['postgres_cluster'] }}"
+      changed_when: false
+      check_mode: false
+
+    - name: '[Prepare] Add hosts to group "secondary" (in-memory inventory)'
+      ansible.builtin.add_host:
+        name: "{{ item }}"
+        groups: secondary
+        postgresql_exists: true
+      when:
+        - groups.get('secondary', []) | length < 1
+        - hostvars[item]['patroni_leader_result'] is defined
+        - hostvars[item]['patroni_leader_result']['status'] == 503
+      loop: "{{ groups['postgres_cluster'] }}"
+      changed_when: false
+      check_mode: false
+
+    - name: Get current Patroni passwords
+      ansible.builtin.import_role:
+        name: vitabaks.autobase.pre_checks
+        tasks_from: passwords
+      vars:
+        source_group: primary
+      when:
+        - patroni_superuser_password | default('') | length < 1 or
+          patroni_replication_password | default('') | length < 1 or
+          patroni_restapi_password | default('') | length < 1
+
+    - name: "Print Patroni Cluster info"
+      ansible.builtin.debug:
+        msg:
+          - "Cluster Name: {{ patroni_cluster_name | default('postgres-cluster') }}"
+          - "Cluster Leader: {{ ansible_hostname }}"
+      when:
+        - groups.get('primary', []) | length > 0
+        - inventory_hostname in groups['primary']
+
+- name: vitabaks.autobase.restart_pgcluster | Restart patroni on secondary
+  hosts: secondary
+  serial: 1 # restart replicas one by one
+  gather_facts: false
+  become: true
+  become_method: sudo
+  any_errors_fatal: true
+  tasks:
+    - name: Stop read-only traffic
+      ansible.builtin.import_role:
+        name: vitabaks.autobase.update
+        tasks_from: stop_traffic
+
+    - name: Stop Services
+      ansible.builtin.import_role:
+        name: vitabaks.autobase.update
+        tasks_from: stop_services
+
+    - name: Start Services
+      ansible.builtin.import_role:
+        name: vitabaks.autobase.update
+        tasks_from: start_services
+
+    - name: Start read-only traffic
+      ansible.builtin.import_role:
+        name: vitabaks.autobase.update
+        tasks_from: start_traffic
+
+- name: vitabaks.autobase.restart_pgcluster | Restart patroni on master
+  hosts: primary
+  gather_facts: false
+  become: true
+  become_method: sudo
+  any_errors_fatal: true
+  environment: "{{ proxy_env | default({}) }}"
+  tasks:
+    - name: Switchover Patroni leader role
+      ansible.builtin.import_role:
+        name: vitabaks.autobase.update
+        tasks_from: switchover
+
+    - name: Stop read-only traffic
+      ansible.builtin.import_role:
+        name: vitabaks.autobase.update
+        tasks_from: stop_traffic
+
+    - name: Stop Services
+      ansible.builtin.import_role:
+        name: vitabaks.autobase.update
+        tasks_from: stop_services
+
+    - name: Start Services
+      ansible.builtin.import_role:
+        name: vitabaks.autobase.update
+        tasks_from: start_services
+
+    - name: Start read-only traffic
+      ansible.builtin.import_role:
+        name: vitabaks.autobase.update
+        tasks_from: start_traffic

--- a/automation/playbooks/restart_pgcluster.yml
+++ b/automation/playbooks/restart_pgcluster.yml
@@ -1,5 +1,5 @@
 ---
-- name: vitabaks.autobase.restart_pgcluster | Restart PostgreSQL HA Cluster
+- name: vitabaks.autobase.restart_pgcluster | Restart PostgreSQL Cluster
   hosts: postgres_cluster
   gather_facts: true
   become: true

--- a/automation/playbooks/restart_pgcluster.yml
+++ b/automation/playbooks/restart_pgcluster.yml
@@ -93,7 +93,7 @@
         name: vitabaks.autobase.pre_checks
         tasks_from: passwords
       vars:
-        source_group: "source_cluster"
+        source_group: "primary"
         postgresql_cluster_maintenance: true
       when: patroni_superuser_password | default('') | length < 1
 

--- a/automation/playbooks/update_pgcluster.yml
+++ b/automation/playbooks/update_pgcluster.yml
@@ -1,5 +1,5 @@
 ---
-- name: vitabaks.autobase.update_pgcluster | Update PostgreSQL HA Cluster (based on "Patroni")
+- name: vitabaks.autobase.update_pgcluster | Update PostgreSQL Cluster
   hosts: postgres_cluster
   gather_facts: true
   become: true
@@ -265,7 +265,7 @@
       run_once: true # noqa run-once
       ansible.builtin.debug:
         msg:
-          - "PostgreSQL HA cluster update completed."
+          - "PostgreSQL Cluster update completed."
           - "Current version: {{ postgres_version.stdout }}"
       when: not any_update_failed
 
@@ -274,7 +274,7 @@
       run_once: true # noqa run-once
       ansible.builtin.debug:
         msg:
-          - "Update of PostgreSQL HA cluster completed with errors. Check the Ansible log."
+          - "Update of PostgreSQL Cluster completed with errors. Check the Ansible log."
           - "Current version: {{ postgres_version.stdout }}"
       when: any_update_failed
   tags:

--- a/automation/roles/update/README.md
+++ b/automation/roles/update/README.md
@@ -1,6 +1,6 @@
-## Update the PostgreSQL HA Cluster
+## Update the PostgreSQL Cluster
 
-This role is designed to update the PostgreSQL HA cluster to a new minor version (for example, 17.1->17.2, and etc).
+This role is designed to update the PostgreSQL Cluster to a new minor version (for example, 17.1->17.2, and etc).
 
 By default, only PostgreSQL packages defined in the `postgresql_packages` variable are updated. In addition, you can update Patroni or the entire system.
 

--- a/automation/roles/update/README.md
+++ b/automation/roles/update/README.md
@@ -78,7 +78,7 @@ When using load balancing for read-only traffic (the "Type A" and "Type C" schem
   - Wait for active transactions to complete
 - Stop Services
   - Execute CHECKPOINT before stopping PostgreSQL
-  - Stop Patroni service on the Cluster Replica
+  - Stop Patroni service on the replica
 - Update PostgreSQL
   - if `target` variable is not defined or `target=postgres`
   - Install the latest version of PostgreSQL packages
@@ -116,7 +116,7 @@ When using load balancing for read-only traffic (the "Type A" and "Type C" schem
   - Wait for active transactions to complete
 - Stop Services
   - Execute CHECKPOINT before stopping PostgreSQL
-  - Stop Patroni service on the old Cluster Leader
+  - Stop Patroni service on the leader
 - Update PostgreSQL
   - if `target` variable is not defined or `target=postgres`
   - Install the latest version of PostgreSQL packages

--- a/automation/roles/update/tasks/start_traffic.yml
+++ b/automation/roles/update/tasks/start_traffic.yml
@@ -39,4 +39,4 @@
   when:
     - (reboot_result.rebooted is defined and reboot_result.rebooted)
     - (reboot_host_post_delay is defined and reboot_host_post_delay | int > 0)
-    - (inventory_hostname in groups['secondary'] and groups['secondary'] | length > 1)
+    - (inventory_hostname in groups.get('secondary', []) and groups.get('secondary', []) | length > 1)

--- a/automation/roles/update/tasks/stop_services.yml
+++ b/automation/roles/update/tasks/stop_services.yml
@@ -26,7 +26,7 @@
       ansible.builtin.service:
         name: patroni
         state: stopped
-  when: inventory_hostname in groups['secondary']
+  when: inventory_hostname in groups.get('secondary', [])
 
 # Stop the old primary (now secondary, after switchover)
 - block:

--- a/automation/roles/update/tasks/stop_services.yml
+++ b/automation/roles/update/tasks/stop_services.yml
@@ -20,7 +20,7 @@
       environment:
         PGPASSWORD: "{{ patroni_superuser_password }}"
 
-    - name: "Stop Patroni service on the Cluster Replica ({{ ansible_hostname | default('') }})"
+    - name: "Stop Patroni service on the replica ({{ ansible_hostname | default('') }})"
       become: true
       become_user: root
       ansible.builtin.service:
@@ -38,7 +38,7 @@
       environment:
         PGPASSWORD: "{{ patroni_superuser_password }}"
 
-    - name: "Stop Patroni service on the old Cluster Leader ({{ ansible_hostname | default('') }})"
+    - name: "Stop Patroni service on the leader ({{ ansible_hostname | default('') }})"
       become: true
       become_user: root
       ansible.builtin.service:


### PR DESCRIPTION
Add a new `restart_pgcluster` playbook that centralizes cluster restart flow.

Perform a rolling restart of PostgreSQL cluster services to minimize downtime: replicas are restarted sequentially, followed by a switchover and restart of the former primary.