### PR TITLE
fix owner of /var/log/pgbouncer for pgbouncer.service

### DIFF
--- a/automation/roles/pgbouncer/templates/pgbouncer.service.j2
+++ b/automation/roles/pgbouncer/templates/pgbouncer.service.j2
@@ -16,7 +16,7 @@ ExecStart=/usr/sbin/pgbouncer -d {{ pgbouncer_conf_dir }}/pgbouncer{{ '-%d' % (i
 {% endif %}
 {% if ansible_os_family == "RedHat" %}
 PermissionsStartOnly=true
-ExecStartPre=/usr/bin/chown -R postgres: /var/log/pgbouncer
+ExecStartPre=/usr/bin/chown -R postgres: {{ pgbouncer_log_dir }}
 ExecStart=/usr/bin/pgbouncer -d {{ pgbouncer_conf_dir }}/pgbouncer{{ '-%d' % (idx + 1) if idx > 0 else '' }}.ini
 {% endif %}
 ExecReload=/bin/kill -SIGHUP $MAINPID

--- a/automation/roles/pgbouncer/templates/pgbouncer.service.j2
+++ b/automation/roles/pgbouncer/templates/pgbouncer.service.j2
@@ -15,6 +15,8 @@ RuntimeDirectoryMode=0755
 ExecStart=/usr/sbin/pgbouncer -d {{ pgbouncer_conf_dir }}/pgbouncer{{ '-%d' % (idx + 1) if idx > 0 else '' }}.ini
 {% endif %}
 {% if ansible_os_family == "RedHat" %}
+PermissionsStartOnly=true
+ExecStartPre=/usr/bin/chown -R postgres: /var/log/pgbouncer
 ExecStart=/usr/bin/pgbouncer -d {{ pgbouncer_conf_dir }}/pgbouncer{{ '-%d' % (idx + 1) if idx > 0 else '' }}.ini
 {% endif %}
 ExecReload=/bin/kill -SIGHUP $MAINPID


### PR DESCRIPTION
Fixes problem with owner on `/var/log/pgbouncer` after pgbouncer package's update on RH-based distros.
Every time pgbouncer package updates on AlmaLinux 8/9, the owner of `/var/log/pgbouncer` directory changes to `pgbouncer`, and it prevents running `pgbouncer.service` because it needs the directory have to belongs to `postgres` user.