### PR TITLE
feat/haproxy shutdown sessions toggle

### DIFF
--- a/automation/molecule/tests/roles/confd/variables/default_server.yml
+++ b/automation/molecule/tests/roles/confd/variables/default_server.yml
@@ -1,0 +1,101 @@
+---
+# 🚀 Render the real confd haproxy.tmpl.j2 template and assert the default-server
+# directive reacts to haproxy_default_server.
+# 🎯 Guards issue #1516 for the confd-managed copy: on_marked_down="" must drop
+# "on-marked-down shutdown-sessions"; the default must keep it.
+
+# 📂 Ensure tmp directory exists
+- name: Molecule.tests.roles.confd.variables.default_server | Ensure tmp directory exists
+  run_once: true
+  delegate_to: localhost
+  ansible.builtin.file:
+    path: "./tmp"
+    state: directory
+
+# 🔧 Baseline scalar vars required to render the template
+# (confd renders server entries via Go templating inside {% raw %}, so no
+# postgres_cluster inventory is needed here.)
+- name: Molecule.tests.roles.confd.variables.default_server | Set baseline render vars
+  run_once: true
+  delegate_to: localhost
+  ansible.builtin.set_fact:
+    haproxy_maxconn: { global: 100000, master: 10000, replica: 10000 }
+    haproxy_timeout: { client: "60m", server: "60m" }
+    haproxy_listen_port: { master: 5000, replicas: 5001, replicas_sync: 5002, replicas_async: 5003, stats: 7000 }
+    haproxy_bind_address: 10.0.0.10
+    cluster_vip: ""
+    patroni_restapi_protocol: http
+    pgbouncer_install: false
+    pgbouncer_listen_port: 6432
+    patroni_maximum_lag_on_replica: "100MB"
+    confd_default_server_template: "{{ playbook_dir }}/../../roles/confd/templates/haproxy.tmpl.j2"
+
+- name: Molecule.tests.roles.confd.variables.default_server | Set haproxy_default_server (default)
+  run_once: true
+  delegate_to: localhost
+  ansible.builtin.set_fact:
+    haproxy_default_server:
+      inter: "3s"
+      fastinter: "1s"
+      fall: 3
+      rise_master: 4
+      rise_replica: 2
+      on_marked_down: "shutdown-sessions"
+
+- name: Molecule.tests.roles.confd.variables.default_server | Render default config
+  run_once: true
+  delegate_to: localhost
+  ansible.builtin.template:
+    src: "{{ confd_default_server_template }}"
+    dest: "./tmp/haproxy.tmpl.default_server.default.cfg"
+
+- name: Molecule.tests.roles.confd.variables.default_server | Read default-server lines (default)
+  run_once: true
+  delegate_to: localhost
+  ansible.builtin.shell: "grep 'default-server' ./tmp/haproxy.tmpl.default_server.default.cfg"
+  register: confd_ds_default
+  changed_when: false
+
+- name: Molecule.tests.roles.confd.variables.default_server | Validate default keeps shutdown-sessions
+  run_once: true
+  ansible.builtin.assert:
+    that:
+      - confd_ds_default.stdout_lines | length == 4
+      - confd_ds_default.stdout_lines | select('search', 'on-marked-down shutdown-sessions') | list | length == 4
+    fail_msg: "Default confd render must emit 'on-marked-down shutdown-sessions' on every default-server line."
+    success_msg: "Default confd render keeps shutdown-sessions."
+
+- name: Molecule.tests.roles.confd.variables.default_server | Set haproxy_default_server (on_marked_down="")
+  run_once: true
+  delegate_to: localhost
+  ansible.builtin.set_fact:
+    haproxy_default_server:
+      inter: "3s"
+      fastinter: "1s"
+      fall: 3
+      rise_master: 4
+      rise_replica: 2
+      on_marked_down: ""
+
+- name: Molecule.tests.roles.confd.variables.default_server | Render config with on_marked_down=""
+  run_once: true
+  delegate_to: localhost
+  ansible.builtin.template:
+    src: "{{ confd_default_server_template }}"
+    dest: "./tmp/haproxy.tmpl.default_server.keep.cfg"
+
+- name: Molecule.tests.roles.confd.variables.default_server | Read default-server lines (keep)
+  run_once: true
+  delegate_to: localhost
+  ansible.builtin.shell: "grep 'default-server' ./tmp/haproxy.tmpl.default_server.keep.cfg"
+  register: confd_ds_keep
+  changed_when: false
+
+- name: Molecule.tests.roles.confd.variables.default_server | Validate on_marked_down="" drops the directive
+  run_once: true
+  ansible.builtin.assert:
+    that:
+      - confd_ds_keep.stdout_lines | length == 4
+      - confd_ds_keep.stdout_lines | select('search', 'on-marked-down') | list | length == 0
+    fail_msg: "on_marked_down='' must remove 'on-marked-down' from every confd default-server line."
+    success_msg: "on_marked_down='' drops on-marked-down in confd template (#1516)."

--- a/automation/molecule/tests/roles/haproxy/variables/default_server.yml
+++ b/automation/molecule/tests/roles/haproxy/variables/default_server.yml
@@ -1,0 +1,125 @@
+---
+# 🚀 Render the real haproxy.cfg.j2 template and assert the default-server
+# directive reacts to haproxy_default_server.
+# 🎯 Guards issue #1516: on_marked_down="" must drop "on-marked-down
+# shutdown-sessions" so active sessions survive a replica markdown, while the
+# default must keep it.
+
+# 📂 Ensure tmp directory exists
+- name: Molecule.tests.roles.haproxy.variables.default_server | Ensure tmp directory exists
+  run_once: true
+  delegate_to: localhost
+  ansible.builtin.file:
+    path: "./tmp"
+    state: directory
+
+# 🔧 Register fake backends so the template's server loop has hosts to iterate
+- name: Molecule.tests.roles.haproxy.variables.default_server | Register fake backends
+  run_once: true
+  ansible.builtin.add_host:
+    name: "{{ default_server_host_item }}"
+    groups: postgres_cluster
+    ansible_hostname: "{{ default_server_host_item }}"
+    bind_address: "10.0.0.{{ default_server_host_item[-1] }}"
+  loop:
+    - pg_ds_test_1
+    - pg_ds_test_2
+  loop_control:
+    loop_var: default_server_host_item
+
+# 🔧 Baseline scalar vars required to render the template
+- name: Molecule.tests.roles.haproxy.variables.default_server | Set baseline render vars
+  run_once: true
+  delegate_to: localhost
+  ansible.builtin.set_fact:
+    haproxy_maxconn: { global: 100000, master: 10000, replica: 10000 }
+    haproxy_timeout: { client: "60m", server: "60m" }
+    haproxy_listen_port: { master: 5000, replicas: 5001, replicas_sync: 5002, replicas_async: 5003, stats: 7000 }
+    haproxy_bind_address: 10.0.0.10
+    cluster_vip: ""
+    patroni_restapi_protocol: http
+    patroni_restapi_port: 8008
+    pgbouncer_install: false
+    postgresql_port: 5432
+    patroni_maximum_lag_on_replica: "100MB"
+    default_server_template: "{{ playbook_dir }}/../../roles/haproxy/templates/haproxy.cfg.j2"
+
+# ===============================================
+# 💻 Case: default on_marked_down (shutdown-sessions)
+# ===============================================
+
+- name: Molecule.tests.roles.haproxy.variables.default_server | Set haproxy_default_server (default)
+  run_once: true
+  delegate_to: localhost
+  ansible.builtin.set_fact:
+    haproxy_default_server:
+      inter: "3s"
+      fastinter: "1s"
+      fall: 3
+      rise_master: 4
+      rise_replica: 2
+      on_marked_down: "shutdown-sessions"
+
+- name: Molecule.tests.roles.haproxy.variables.default_server | Render default config
+  run_once: true
+  delegate_to: localhost
+  ansible.builtin.template:
+    src: "{{ default_server_template }}"
+    dest: "./tmp/haproxy.default_server.default.cfg"
+
+- name: Molecule.tests.roles.haproxy.variables.default_server | Read default-server lines (default)
+  run_once: true
+  delegate_to: localhost
+  ansible.builtin.shell: "grep 'default-server' ./tmp/haproxy.default_server.default.cfg"
+  register: ds_default
+  changed_when: false
+
+- name: Molecule.tests.roles.haproxy.variables.default_server | Validate default keeps shutdown-sessions
+  run_once: true
+  ansible.builtin.assert:
+    that:
+      - ds_default.stdout_lines | length == 4
+      - ds_default.stdout_lines | select('search', 'on-marked-down shutdown-sessions') | list | length == 4
+      - ds_default.stdout_lines | select('search', 'rise 4') | list | length == 1
+      - ds_default.stdout_lines | select('search', 'rise 2') | list | length == 3
+    fail_msg: "Default render must emit 'on-marked-down shutdown-sessions' on every default-server line."
+    success_msg: "Default render keeps shutdown-sessions (master rise 4, replicas rise 2)."
+
+# ===============================================
+# 💻 Case: on_marked_down="" (sessions preserved)
+# ===============================================
+
+- name: Molecule.tests.roles.haproxy.variables.default_server | Set haproxy_default_server (on_marked_down="")
+  run_once: true
+  delegate_to: localhost
+  ansible.builtin.set_fact:
+    haproxy_default_server:
+      inter: "3s"
+      fastinter: "1s"
+      fall: 3
+      rise_master: 4
+      rise_replica: 2
+      on_marked_down: ""
+
+- name: Molecule.tests.roles.haproxy.variables.default_server | Render config with on_marked_down=""
+  run_once: true
+  delegate_to: localhost
+  ansible.builtin.template:
+    src: "{{ default_server_template }}"
+    dest: "./tmp/haproxy.default_server.keep.cfg"
+
+- name: Molecule.tests.roles.haproxy.variables.default_server | Read default-server lines (keep)
+  run_once: true
+  delegate_to: localhost
+  ansible.builtin.shell: "grep 'default-server' ./tmp/haproxy.default_server.keep.cfg"
+  register: ds_keep
+  changed_when: false
+
+- name: Molecule.tests.roles.haproxy.variables.default_server | Validate on_marked_down="" drops the directive
+  run_once: true
+  ansible.builtin.assert:
+    that:
+      - ds_keep.stdout_lines | length == 4
+      - ds_keep.stdout_lines | select('search', 'on-marked-down') | list | length == 0
+    fail_msg: "on_marked_down='' must remove 'on-marked-down' from every default-server line."
+    success_msg: "on_marked_down='' drops on-marked-down: active sessions survive a markdown (#1516)."

--- a/automation/roles/common/defaults/main.yml
+++ b/automation/roles/common/defaults/main.yml
@@ -51,6 +51,18 @@ haproxy_maxconn:
 haproxy_timeout:
   client: "60m"
   server: "60m"
+# Per-server health-check / failover tuning (applied via 'default-server').
+# 'on_marked_down' controls what happens to active sessions when a backend is
+# marked down: the default "shutdown-sessions" terminates in-flight connections
+# (e.g. long-running queries) on failover. Set it to "" (empty) to keep active
+# sessions alive when a replica is marked down.
+haproxy_default_server:
+  inter: "3s"
+  fastinter: "1s"
+  fall: 3
+  rise_master: 4
+  rise_replica: 2
+  on_marked_down: "shutdown-sessions"
 # Optionally declare log format for haproxy.
 # Uncomment following lines (and remove extra space in front of variable definition) for JSON structured log format.
 # haproxy_log_format: "{

--- a/automation/roles/confd/templates/haproxy.tmpl.j2
+++ b/automation/roles/confd/templates/haproxy.tmpl.j2
@@ -1,3 +1,6 @@
+{% macro default_server(rise) %}
+default-server inter {{ haproxy_default_server.inter }} fastinter {{ haproxy_default_server.fastinter }} fall {{ haproxy_default_server.fall }} rise {{ rise }}{% if haproxy_default_server.on_marked_down | default('') | length > 0 %} on-marked-down {{ haproxy_default_server.on_marked_down }}{% endif %}{% if patroni_restapi_protocol == 'https' %} check-ssl verify none{% endif %}
+{%- endmacro %}
 global
     maxconn {{ haproxy_maxconn.global }}
     log /dev/log    local0
@@ -38,8 +41,7 @@ listen master
     maxconn {{ haproxy_maxconn.master }}
     option httpchk OPTIONS /primary
     http-check expect status 200
-    default-server inter 3s fastinter 1s fall 3 rise 4 on-marked-down shutdown-sessions{% if patroni_restapi_protocol == 'https' %} check-ssl verify none{% endif %}
-
+    {{ default_server(haproxy_default_server.rise_master) }}
 {% if pgbouncer_install|bool %}
 {% raw %}{{range gets "/members/*"}} server {{base .Key}} {{$data := json .Value}}{{base (replace (index (split (index (split $data.conn_url ":") 1) "/") 2) "@" "/" -1)}}:{% endraw %}{{ pgbouncer_listen_port }}{% raw %} check port {{index (split (index (split $data.api_url "/") 2) ":") 1}}
 {{end}}{% endraw %}
@@ -59,8 +61,7 @@ listen master_direct
     maxconn {{ haproxy_maxconn.master }}
     option httpchk OPTIONS /primary
     http-check expect status 200
-    default-server inter 3s fastinter 1s fall 3 rise 4 on-marked-down shutdown-sessions{% if patroni_restapi_protocol == 'https' %} check-ssl verify none{% endif %}
-
+    {{ default_server(haproxy_default_server.rise_master) }}
 {% raw %}{{range gets "/members/*"}} server {{base .Key}} {{$data := json .Value}}{{base (replace (index (split $data.conn_url "/") 2) "@" "/" -1)}} check port {{index (split (index (split $data.api_url "/") 2) ":") 1}}
 {{end}}{% endraw %}
 {% endif %}
@@ -79,8 +80,7 @@ listen replicas
     {% endif %}
     balance roundrobin
     http-check expect status 200
-    default-server inter 3s fastinter 1s fall 3 rise 2 on-marked-down shutdown-sessions{% if patroni_restapi_protocol == 'https' %} check-ssl verify none{% endif %}
-
+    {{ default_server(haproxy_default_server.rise_replica) }}
 {% if pgbouncer_install|bool %}
 {% raw %}{{range gets "/members/*"}} server {{base .Key}} {{$data := json .Value}}{{base (replace (index (split (index (split $data.conn_url ":") 1) "/") 2) "@" "/" -1)}}:{% endraw %}{{ pgbouncer_listen_port }}{% raw %} check port {{index (split (index (split $data.api_url "/") 2) ":") 1}}
 {{end}}{% endraw %}
@@ -105,8 +105,7 @@ listen replicas_direct
     {% endif %}
     balance roundrobin
     http-check expect status 200
-    default-server inter 3s fastinter 1s fall 3 rise 2 on-marked-down shutdown-sessions{% if patroni_restapi_protocol == 'https' %} check-ssl verify none{% endif %}
-
+    {{ default_server(haproxy_default_server.rise_replica) }}
 {% raw %}{{range gets "/members/*"}} server {{base .Key}} {{$data := json .Value}}{{base (replace (index (split $data.conn_url "/") 2) "@" "/" -1)}} check port {{index (split (index (split $data.api_url "/") 2) ":") 1}}
 {{end}}{% endraw %}
 {% endif %}
@@ -125,8 +124,7 @@ listen replicas_sync
     {% endif %}
     balance roundrobin
     http-check expect status 200
-    default-server inter 3s fastinter 1s fall 3 rise 2 on-marked-down shutdown-sessions{% if patroni_restapi_protocol == 'https' %} check-ssl verify none{% endif %}
-
+    {{ default_server(haproxy_default_server.rise_replica) }}
 {% if pgbouncer_install|bool %}
 {% raw %}{{range gets "/members/*"}} server {{base .Key}} {{$data := json .Value}}{{base (replace (index (split (index (split $data.conn_url ":") 1) "/") 2) "@" "/" -1)}}:{% endraw %}{{ pgbouncer_listen_port }}{% raw %} check port {{index (split (index (split $data.api_url "/") 2) ":") 1}}
 {{end}}{% endraw %}
@@ -151,8 +149,7 @@ listen replicas_sync_direct
     {% endif %}
     balance roundrobin
     http-check expect status 200
-    default-server inter 3s fastinter 1s fall 3 rise 2 on-marked-down shutdown-sessions{% if patroni_restapi_protocol == 'https' %} check-ssl verify none{% endif %}
-
+    {{ default_server(haproxy_default_server.rise_replica) }}
 {% raw %}{{range gets "/members/*"}} server {{base .Key}} {{$data := json .Value}}{{base (replace (index (split $data.conn_url "/") 2) "@" "/" -1)}} check port {{index (split (index (split $data.api_url "/") 2) ":") 1}}
 {{end}}{% endraw %}
 {% endif %}
@@ -171,8 +168,7 @@ listen replicas_async
     {% endif %}
     balance roundrobin
     http-check expect status 200
-    default-server inter 3s fastinter 1s fall 3 rise 2 on-marked-down shutdown-sessions{% if patroni_restapi_protocol == 'https' %} check-ssl verify none{% endif %}
-
+    {{ default_server(haproxy_default_server.rise_replica) }}
 {% if pgbouncer_install|bool %}
 {% raw %}{{range gets "/members/*"}} server {{base .Key}} {{$data := json .Value}}{{base (replace (index (split (index (split $data.conn_url ":") 1) "/") 2) "@" "/" -1)}}:{% endraw %}{{ pgbouncer_listen_port }}{% raw %} check port {{index (split (index (split $data.api_url "/") 2) ":") 1}}
 {{end}}{% endraw %}
@@ -197,8 +193,7 @@ listen replicas_async_direct
     {% endif %}
     balance roundrobin
     http-check expect status 200
-    default-server inter 3s fastinter 1s fall 3 rise 2 on-marked-down shutdown-sessions{% if patroni_restapi_protocol == 'https' %} check-ssl verify none{% endif %}
-
+    {{ default_server(haproxy_default_server.rise_replica) }}
 {% raw %}{{range gets "/members/*"}} server {{base .Key}} {{$data := json .Value}}{{base (replace (index (split $data.conn_url "/") 2) "@" "/" -1)}} check port {{index (split (index (split $data.api_url "/") 2) ":") 1}}
 {{end}}{% endraw %}
 {% endif %}

--- a/automation/roles/haproxy/README.md
+++ b/automation/roles/haproxy/README.md
@@ -49,6 +49,19 @@ Note:
 | `haproxy_timeout.client` | `"60m"` | Client connection timeout |
 | `haproxy_timeout.server` | `"60m"` | Server connection timeout |
 
+### Health Check / Failover Tuning
+
+These map to the `default-server` directive applied to every backend.
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `haproxy_default_server.inter` | `"3s"` | Interval between health checks |
+| `haproxy_default_server.fastinter` | `"1s"` | Check interval while a server is in transition (up↔down) |
+| `haproxy_default_server.fall` | `3` | Failed checks before a server is marked down |
+| `haproxy_default_server.rise_master` | `4` | Successful checks before the master backend is marked up |
+| `haproxy_default_server.rise_replica` | `2` | Successful checks before a replica backend is marked up |
+| `haproxy_default_server.on_marked_down` | `"shutdown-sessions"` | Action when a server is marked down. The default terminates in-flight sessions on failover. Set to `""` to **keep active sessions alive** (e.g. preserve long-running queries) when a replica is marked down. |
+
 ### Advanced Configuration
 
 | Variable | Default | Description |

--- a/automation/roles/haproxy/templates/haproxy.cfg.j2
+++ b/automation/roles/haproxy/templates/haproxy.cfg.j2
@@ -1,3 +1,6 @@
+{% macro default_server(rise) %}
+default-server inter {{ haproxy_default_server.inter }} fastinter {{ haproxy_default_server.fastinter }} fall {{ haproxy_default_server.fall }} rise {{ rise }}{% if haproxy_default_server.on_marked_down | default('') | length > 0 %} on-marked-down {{ haproxy_default_server.on_marked_down }}{% endif %}{% if patroni_restapi_protocol == 'https' %} check-ssl verify none{% endif %}
+{%- endmacro %}
 global
     maxconn {{ haproxy_maxconn.global }}
     log /dev/log    local0
@@ -38,8 +41,7 @@ listen master
     maxconn {{ haproxy_maxconn.master }}
     option httpchk OPTIONS /primary
     http-check expect status 200
-    default-server inter 3s fastinter 1s fall 3 rise 4 on-marked-down shutdown-sessions{% if patroni_restapi_protocol == 'https' %} check-ssl verify none{% endif %}
-
+    {{ default_server(haproxy_default_server.rise_master) }}
 {% if pgbouncer_install|bool %}
   {% for host in groups['postgres_cluster'] %}
 server {{ hostvars[host]['ansible_hostname'] }} {{ hostvars[host]['patroni_bind_address'] | default(hostvars[host]['bind_address'], true) }}:{{ pgbouncer_listen_port }} check port {{ patroni_restapi_port }}
@@ -61,8 +63,7 @@ listen master_direct
     maxconn {{ haproxy_maxconn.master }}
     option httpchk OPTIONS /primary
     http-check expect status 200
-    default-server inter 3s fastinter 1s fall 3 rise 4 on-marked-down shutdown-sessions{% if patroni_restapi_protocol == 'https' %} check-ssl verify none{% endif %}
-
+    {{ default_server(haproxy_default_server.rise_master) }}
   {% for host in groups['postgres_cluster'] %}
 server {{ hostvars[host]['ansible_hostname'] }} {{ hostvars[host]['patroni_bind_address'] | default(hostvars[host]['bind_address'], true) }}:{{ postgresql_port }} check port {{ patroni_restapi_port }}
   {% endfor %}
@@ -82,8 +83,7 @@ listen replicas
     {% endif %}
     balance roundrobin
     http-check expect status 200
-    default-server inter 3s fastinter 1s fall 3 rise 2 on-marked-down shutdown-sessions{% if patroni_restapi_protocol == 'https' %} check-ssl verify none{% endif %}
-
+    {{ default_server(haproxy_default_server.rise_replica) }}
 {% if pgbouncer_install|bool %}
   {% for host in groups['postgres_cluster'] %}
 server {{ hostvars[host]['ansible_hostname'] }} {{ hostvars[host]['patroni_bind_address'] | default(hostvars[host]['bind_address'], true) }}:{{ pgbouncer_listen_port }} check port {{ patroni_restapi_port }}
@@ -110,8 +110,7 @@ listen replicas_direct
     {% endif %}
     balance roundrobin
     http-check expect status 200
-    default-server inter 3s fastinter 1s fall 3 rise 2 on-marked-down shutdown-sessions{% if patroni_restapi_protocol == 'https' %} check-ssl verify none{% endif %}
-
+    {{ default_server(haproxy_default_server.rise_replica) }}
   {% for host in groups['postgres_cluster'] %}
 server {{ hostvars[host]['ansible_hostname'] }} {{ hostvars[host]['patroni_bind_address'] | default(hostvars[host]['bind_address'], true) }}:{{ postgresql_port }} check port {{ patroni_restapi_port }}
   {% endfor %}
@@ -131,8 +130,7 @@ listen replicas_sync
     {% endif %}
     balance roundrobin
     http-check expect status 200
-    default-server inter 3s fastinter 1s fall 3 rise 2 on-marked-down shutdown-sessions{% if patroni_restapi_protocol == 'https' %} check-ssl verify none{% endif %}
-
+    {{ default_server(haproxy_default_server.rise_replica) }}
 {% if pgbouncer_install|bool %}
   {% for host in groups['postgres_cluster'] %}
 server {{ hostvars[host]['ansible_hostname'] }} {{ hostvars[host]['patroni_bind_address'] | default(hostvars[host]['bind_address'], true) }}:{{ pgbouncer_listen_port }} check port {{ patroni_restapi_port }}
@@ -159,8 +157,7 @@ listen replicas_sync_direct
     {% endif %}
     balance roundrobin
     http-check expect status 200
-    default-server inter 3s fastinter 1s fall 3 rise 2 on-marked-down shutdown-sessions{% if patroni_restapi_protocol == 'https' %} check-ssl verify none{% endif %}
-
+    {{ default_server(haproxy_default_server.rise_replica) }}
   {% for host in groups['postgres_cluster'] %}
 server {{ hostvars[host]['ansible_hostname'] }} {{ hostvars[host]['patroni_bind_address'] | default(hostvars[host]['bind_address'], true) }}:{{ postgresql_port }} check port {{ patroni_restapi_port }}
   {% endfor %}
@@ -180,8 +177,7 @@ listen replicas_async
     {% endif %}
     balance roundrobin
     http-check expect status 200
-    default-server inter 3s fastinter 1s fall 3 rise 2 on-marked-down shutdown-sessions{% if patroni_restapi_protocol == 'https' %} check-ssl verify none{% endif %}
-
+    {{ default_server(haproxy_default_server.rise_replica) }}
 {% if pgbouncer_install|bool %}
   {% for host in groups['postgres_cluster'] %}
 server {{ hostvars[host]['ansible_hostname'] }} {{ hostvars[host]['patroni_bind_address'] | default(hostvars[host]['bind_address'], true) }}:{{ pgbouncer_listen_port }} check port {{ patroni_restapi_port }}
@@ -208,8 +204,7 @@ listen replicas_async_direct
     {% endif %}
     balance roundrobin
     http-check expect status 200
-    default-server inter 3s fastinter 1s fall 3 rise 2 on-marked-down shutdown-sessions{% if patroni_restapi_protocol == 'https' %} check-ssl verify none{% endif %}
-
+    {{ default_server(haproxy_default_server.rise_replica) }}
   {% for host in groups['postgres_cluster'] %}
 server {{ hostvars[host]['ansible_hostname'] }} {{ hostvars[host]['patroni_bind_address'] | default(hostvars[host]['bind_address'], true) }}:{{ postgresql_port }} check port {{ patroni_restapi_port }}
   {% endfor %}


### PR DESCRIPTION
## Summary

Make HAProxy's per-server health-check / failover behavior configurable through a new `haproxy_default_server` variable. The main knob is `on_marked_down`: set it to `""` to drop `on-marked-down shutdown-sessions`, so active sessions survive when a replica is marked down instead of being killed mid-query.

Associates #1516.

## Motivation

The `default-server` line was hardcoded, identically, across both HAProxy templates:

```
default-server inter 3s fastinter 1s fall 3 rise 4 on-marked-down shutdown-sessions
```

A backend is marked **down** as soon as its health check fails a few times in a row — which can happen for harmless reasons, such as a replica briefly falling behind on replication lag or a momentary network blip. The `on-marked-down shutdown-sessions` part tells HAProxy that, the instant this happens, it should immediately drop every open connection to that backend.

The side effect: any query still running on that replica is cut off mid-execution. A long analytics query can die seconds in, just because the replica blipped once. And there was no way to turn this off without editing the role's templates.

## Changes

- **`common/defaults/main.yml`** — add the `haproxy_default_server` dict (defaults below, reproducing the previous hardcoded values exactly).
- **`haproxy/templates/haproxy.cfg.j2`** — replace the 8 hardcoded `default-server` lines with a single `default_server()` Jinja macro. `on-marked-down` is rendered only when `on_marked_down` is non-empty; `check-ssl verify none` is still emitted for HTTPS.
- **`confd/templates/haproxy.tmpl.j2`** — apply the same macro to the confd-managed copy, keeping the dynamic config in sync with the static one.
- **`haproxy/README.md`** — document the new variables.

### Defaults

| Key | Default | Meaning |
|-----|---------|---------|
| `inter` | `3s` | Interval between health checks |
| `fastinter` | `1s` | Check interval while a server is in transition |
| `fall` | `3` | Failed checks before a server is marked down |
| `rise_master` | `4` | Successful checks before the master backend is marked up |
| `rise_replica` | `2` | Successful checks before a replica backend is marked up |
| `on_marked_down` | `shutdown-sessions` | Action on markdown; `""` keeps sessions alive |

### Backward compatibility

With defaults unchanged, the rendered config is byte-identical to before — nothing changes on upgrade.

To preserve long-running queries:

```yaml
haproxy_default_server:
  on_marked_down: ""   # keep active sessions alive on replica markdown
```

The timing knobs (`inter`, `fastinter`, `fall`, `rise_*`) are now tunable as well, for faster or more conservative failover.

## Test plan

### 1. Rendered config is byte-identical to current behavior

Jinja rendered with Ansible's `trim_blocks=True`, compared against `main` across 6 contexts for both templates:

```
PASS [haproxy.cfg.j2/default]          byte-identical to HEAD
PASS [haproxy.cfg.j2/https]            byte-identical to HEAD
PASS [haproxy.cfg.j2/vip]              byte-identical to HEAD
PASS [haproxy.cfg.j2/pgbouncer]        byte-identical to HEAD
PASS [haproxy.cfg.j2/pgbouncer+direct] byte-identical to HEAD
PASS [haproxy.cfg.j2/balancer_tags]    byte-identical to HEAD
PASS [confd/*]                         byte-identical to HEAD  (all 6 contexts)
PASS on_marked_down='' -> no on-marked-down token
PASS custom inter/fall/rise flow through
```

### 2. Generated config validates against real HAProxy 3.0 (`haproxy -c`)

```
default cfg                                  -> rc=0
keep    cfg  (on_marked_down="")             -> rc=0
custom  cfg  (inter 5s fall 5 rise 9/7)      -> rc=0
confd   cfg                                  -> rc=0
negative control (on-marked-down BOGUSVALUE) -> rc=1   # ALERT raised; harness genuinely validates
```

### 3. Live A/B markdown test

Real HAProxy 3.0 + a backend on a docker network. A long-lived TCP session is held through the load balancer, then the backend health check is flipped to failing. Stats CSV confirms `pg1` transitions `UP -> DOWN` in both runs.

| Variant | `default-server` directive | Result after markdown |
|---------|----------------------------|------------------------|
| A (default) | `... on-marked-down shutdown-sessions` | `SESSION_CLOSED after 3.3s` |
| B (`on_marked_down=""`) | `... rise 2` (no directive) | `SESSION_ALIVE after 15.0s` |

Variant A reproduces today's behavior (session killed on markdown); variant B proves a long-running session survives a replica markdown — the behavior requested in #1516.
