### PR TITLE
feat (UI): Align Operations period selector with refresh controls

### DIFF
--- a/console/ui/src/features/operations-table-buttons/lib/functions.ts
+++ b/console/ui/src/features/operations-table-buttons/lib/functions.ts
@@ -7,7 +7,7 @@ import { DATE_RANGE_VALUES } from '@features/operations-table-buttons/model/cons
 
 export const formatOperationsDate = (date: Date) => startOfDay(date).toISOString();
 
-export const getOperationsTimeNameValue = (name: keyof DATE_RANGE_VALUES) => {
+export const getOperationsTimeNameValue = (name: string) => {
   let value = '';
 
   switch (name) {

--- a/console/ui/src/features/operations-table-buttons/model/types.ts
+++ b/console/ui/src/features/operations-table-buttons/model/types.ts
@@ -1,5 +1,10 @@
+export interface OperationsDateRange {
+  name: string;
+  value: string;
+}
+
 export interface OperationsTableButtonsProps {
   refetch: () => void;
-  startDate: Date;
-  setStartDate: (date: Date) => void;
+  startDate: OperationsDateRange;
+  setStartDate: (date: OperationsDateRange) => void;
 }

--- a/console/ui/src/features/operations-table-buttons/ui/index.tsx
+++ b/console/ui/src/features/operations-table-buttons/ui/index.tsx
@@ -1,8 +1,13 @@
-import { FC } from 'react';
+import { FC, MouseEvent, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { InputAdornment, MenuItem, Stack, TextField, useTheme } from '@mui/material';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import AccessTimeIcon from '@mui/icons-material/AccessTime';
+import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown';
+import Menu from '@mui/material/Menu';
+import MenuItem from '@mui/material/MenuItem';
+import Stack from '@mui/material/Stack';
 import { OperationsTableButtonsProps } from '@features/operations-table-buttons/model/types.ts';
-import CalendarClockIcon from '@shared/assets/calendarClockICon.svg?react';
 import RefreshGroup from '@features/refresh-group';
 import {
   getOperationsDateRangeVariants,
@@ -11,35 +16,70 @@ import {
 
 const OperationsTableButtons: FC<OperationsTableButtonsProps> = ({ refetch, startDate, setStartDate }) => {
   const { t } = useTranslation('operations');
-  const theme = useTheme();
+  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
 
   const rangeOptions = getOperationsDateRangeVariants(t);
+  const selectedRangeLabel = rangeOptions.find((option) => option.value === startDate.name)?.label ?? startDate.name;
 
-  const handleChange = (e) => {
-    setStartDate(getOperationsTimeNameValue(e.target.value));
+  const handleOpen = (e: MouseEvent<HTMLButtonElement>) => setAnchorEl(e.currentTarget);
+  const handleClose = () => setAnchorEl(null);
+  const handlePick = (value: string) => () => {
+    setStartDate(getOperationsTimeNameValue(value));
+    handleClose();
   };
 
   return (
-    <Stack direction="row" justifyContent="space-between" alignItems="center" gap="4px">
-      <TextField
-        select
-        size="small"
-        variant="standard"
-        value={startDate.name}
-        onChange={handleChange}
-        InputProps={{
-          startAdornment: (
-            <InputAdornment position="start">
-              <CalendarClockIcon width="24px" height="24px" style={{ fill: theme.palette.text.primary }} />
-            </InputAdornment>
-          ),
-        }}>
+    <Stack direction="row" justifyContent="flex-end" alignItems="center" gap="8px">
+      <Box
+        sx={(theme) => ({
+          display: 'inline-flex',
+          alignItems: 'stretch',
+          border: `1px solid ${theme.palette.divider}`,
+          borderRadius: 1,
+          backgroundColor: theme.palette.action.hover,
+          overflow: 'hidden',
+        })}>
+        <Button
+          variant="text"
+          size="small"
+          startIcon={<AccessTimeIcon fontSize="small" />}
+          endIcon={<ArrowDropDownIcon fontSize="small" />}
+          onClick={handleOpen}
+          aria-haspopup="menu"
+          aria-expanded={Boolean(anchorEl)}
+          sx={(theme) => ({
+            minHeight: 32,
+            minWidth: 0,
+            paddingLeft: 1,
+            paddingRight: 0.75,
+            color: theme.palette.text.primary,
+            textTransform: 'none',
+            '& .MuiButton-startIcon': {
+              marginLeft: 0,
+              marginRight: 0.75,
+            },
+            '& .MuiButton-endIcon': {
+              marginLeft: 0.5,
+              marginRight: -0.25,
+            },
+            '&:hover': {
+              backgroundColor: theme.palette.action.selected,
+            },
+          })}>
+          {selectedRangeLabel}
+        </Button>
+      </Box>
+      <Menu
+        anchorEl={anchorEl}
+        open={Boolean(anchorEl)}
+        onClose={handleClose}
+        slotProps={{ paper: { sx: { minWidth: 150 } } }}>
         {rangeOptions.map((option) => (
-          <MenuItem key={option.value} value={option.value}>
+          <MenuItem key={option.value} selected={option.value === startDate.name} onClick={handlePick(option.value)} dense>
             {option.label}
           </MenuItem>
         ))}
-      </TextField>
+      </Menu>
       <RefreshGroup context="operations" onRefresh={refetch} />
     </Stack>
   );


### PR DESCRIPTION
Updates the Operations period selector to use a MUI time icon and positions it on the right next to the refresh control for a more consistent toolbar layout.

Related to https://github.com/autobase-tech/autobase/pull/1563

<img width="2914" height="686" alt="image" src="https://github.com/user-attachments/assets/8a60e92e-ce0d-4e21-ae87-c157122e4006" />
