### PR TITLE
Disable public IP and public access by default

### DIFF
--- a/automation/roles/cloud_resources/defaults/main.yml
+++ b/automation/roles/cloud_resources/defaults/main.yml
@@ -10,7 +10,7 @@ server_image: "" # (required) OS image for the server. For Azure, use variables 
 server_location: "" # (required) Server location or region.
 server_network: "" # (optional) If provided, the server will be added to this network (needs to be created beforehand).
 server_spot: false # Spot instance. Applicable for AWS, GCP, Azure.
-server_public_ip: true # Determines if a public IP should be assigned to the created instance.
+server_public_ip: false # Determines if a public IP should be assigned to the created instance.
 
 volume_type: "" # Volume type. Defaults: 'gp3' for AWS, 'pd-ssd' for GCP, 'StandardSSD_LRS' for Azure.
 volume_size: 100 # Storage size for the data directory (in gigabytes).
@@ -26,9 +26,9 @@ ssh_key_content: "" # (optional) If provided, the public key content will be add
 
 # Firewall / Security Group
 cloud_firewall: true # Specify 'false' if you don't want to configure Firewall rules, or want to manage them yourself.
-ssh_public_access: true # Allow public ssh access (required for deployment from the public network). Applicable if server_public_ip is set to true.
+ssh_public_access: false # Allow public ssh access (required for deployment from the public network). Applicable if server_public_ip is set to true.
 ssh_public_allowed_ips: "" # (comma-separated list of IP addresses in CIDR format) If empty, then public access is allowed for any IP address.
-netdata_public_access: true # Allow access to the Netdata monitoring from the public network (if 'netdata_install' is 'true').
+netdata_public_access: false # Allow access to the Netdata monitoring from the public network (if 'netdata_install' is 'true').
 netdata_public_allowed_ips: "" # (comma-separated list of IP addresses in CIDR format) If empty, then public access is allowed for any IP address.
 database_public_access: false # Allow access to the database from the public network.
 database_public_allowed_ips: "" # (comma-separated list of IP addresses in CIDR format) If empty, then public access is allowed for any IP address.


### PR DESCRIPTION
Harden default cloud resource settings by disabling public exposure: set `server_public_ip`, `ssh_public_access`, and `netdata_public_access` to false.

These changes make new instances non-public by default while allowing overrides per-deployment.