### PR TITLE
Add postgresql_index_maintenance_cron_jobs variable

### DIFF
--- a/automation/playbooks/add_node.yml
+++ b/automation/playbooks/add_node.yml
@@ -341,7 +341,7 @@
         (cluster_vip is defined and cluster_vip | length > 0)
 
     - role: vitabaks.autobase.postgresql_index_maintenance
-      when: postgresql_index_maintenance_enabled | default(false) | bool
+      when: postgresql_index_maintenance_enabled | default(postgresql_index_maintenance.enabled | default(false)) | bool
 
     - role: vitabaks.autobase.netdata
 

--- a/automation/playbooks/config_pgcluster.yml
+++ b/automation/playbooks/config_pgcluster.yml
@@ -195,7 +195,7 @@
       when: inventory_hostname in groups['primary']
 
     - role: vitabaks.autobase.postgresql_index_maintenance
-      when: postgresql_index_maintenance_enabled | default(false) | bool
+      when: postgresql_index_maintenance_enabled | default(postgresql_index_maintenance.enabled | default(false)) | bool
 
     - role: vitabaks.autobase.wal_g
       when: wal_g_install | default(false) | bool

--- a/automation/playbooks/deploy_pgcluster.yml
+++ b/automation/playbooks/deploy_pgcluster.yml
@@ -341,7 +341,7 @@
       when: inventory_hostname == groups['master'][0]
 
     - role: vitabaks.autobase.postgresql_index_maintenance
-      when: postgresql_index_maintenance_enabled | default(false) | bool
+      when: postgresql_index_maintenance_enabled | default(postgresql_index_maintenance.enabled | default(false)) | bool
 
     - role: vitabaks.autobase.netdata
 

--- a/automation/roles/common/defaults/main.yml
+++ b/automation/roles/common/defaults/main.yml
@@ -491,7 +491,8 @@ postgresql_index_maintenance:
   bloat_threshold: 30 # percentage of bloat for reindexing
   size_threshold: 1024 # index size in MB for reindexing
   jobs: 1 # number of parallel workers (no more than max_parallel_workers parameter)
-  cron_jobs:
+
+postgresql_index_maintenance_cron_jobs:
   - name: "pg_auto_reindexer: weekdays"
     user: "root"
     file: "/etc/cron.d/pg_auto_reindexer"

--- a/automation/roles/common/defaults/main.yml
+++ b/automation/roles/common/defaults/main.yml
@@ -501,6 +501,7 @@ postgresql_index_maintenance_cron_jobs:
     day: "*"
     month: "*"
     weekday: "1-5"
+    state: "{{ 'present' if postgresql_index_maintenance.enabled | bool else 'absent' }}"
     job: "/usr/local/bin/pg_auto_reindexer --jobs={{ postgresql_index_maintenance.jobs }} --index-bloat={{ postgresql_index_maintenance.bloat_threshold }} --index-maxsize={{ postgresql_index_maintenance.size_threshold }} --maintenance-start={{ postgresql_index_maintenance.start }} --maintenance-stop={{ postgresql_index_maintenance.stop }}" # yamllint disable rule:line-length
   - name: "pg_auto_reindexer: weekends"
     user: "root"
@@ -510,6 +511,7 @@ postgresql_index_maintenance_cron_jobs:
     day: "*"
     month: "*"
     weekday: "6,0"
+    state: "{{ 'present' if postgresql_index_maintenance.enabled | bool else 'absent' }}"
     job: "/usr/local/bin/pg_auto_reindexer --jobs={{ postgresql_index_maintenance.jobs }} --index-bloat={{ postgresql_index_maintenance.bloat_threshold }} --index-minsize={{ postgresql_index_maintenance.size_threshold }} --maintenance-start={{ postgresql_index_maintenance.start }} --maintenance-stop={{ postgresql_index_maintenance.stop }}" # yamllint disable rule:line-length
 
 ############################################################

--- a/automation/roles/postgresql_index_maintenance/README.md
+++ b/automation/roles/postgresql_index_maintenance/README.md
@@ -12,7 +12,7 @@ Installs [pg_auto_reindexer](https://github.com/vitabaks/pg_auto_reindexer) and 
 | `postgresql_index_maintenance.bloat_threshold` | `30` | Index bloat threshold in percent (`--index-bloat`). |
 | `postgresql_index_maintenance.size_threshold` | `1024` | Index size threshold in MB (used as `--index-maxsize` for weekdays and `--index-minsize` for weekends jobs). |
 | `postgresql_index_maintenance.jobs` | `1` | Number of parallel workers (`--jobs`). |
-| `postgresql_index_maintenance.cron_jobs` | `[...]` | Cron job definitions used by the `cron` role. Default cron schedule and options follow the upstream project README examples. |
+| `postgresql_index_maintenance.cron_jobs` | `[...]` | Cron job definitions used by the `cron` role. Default jobs set `state` to `present` when `postgresql_index_maintenance.enabled` is true, otherwise `absent`. |
 
 Note: For PostgreSQL 11 and below the role installs the `pg_repack` package.
 

--- a/automation/roles/postgresql_index_maintenance/tasks/main.yml
+++ b/automation/roles/postgresql_index_maintenance/tasks/main.yml
@@ -40,5 +40,5 @@
   ansible.builtin.include_role:
     name: vitabaks.autobase.cron
   vars:
-    cron_jobs: "{{ postgresql_index_maintenance.cron_jobs }}"
+    cron_jobs: "{{ postgresql_index_maintenance.cron_jobs | default(postgresql_index_maintenance_cron_jobs) }}"
   tags: pg_auto_reindexer, pg_auto_reindexer_cron

--- a/automation/roles/pre_checks/tasks/main.yml
+++ b/automation/roles/pre_checks/tasks/main.yml
@@ -89,5 +89,5 @@
       Variables 'postgresql_index_maintenance.start' and 'postgresql_index_maintenance.stop'
       must be in HHMM format (e.g. 0000, 0130, 2359).
   when:
-    - postgresql_index_maintenance_enabled | default(false) | bool
+    - postgresql_index_maintenance_enabled | default(postgresql_index_maintenance.enabled | default(false)) | bool
     - inventory_hostname == groups['postgres_cluster'][0] # run once


### PR DESCRIPTION
1. Introduce `postgresql_index_maintenance_cron_jobs` in role defaults and update the tasks to use `postgresql_index_maintenance.cron_jobs` with a fallback to the new variable. 
This ensures compatibility with both variable names and avoids conflicts when configuring cron jobs for the index maintenance role.
2. Add a conditional `state` to the postgresql_index_maintenance cron job defaults so the weekday and weekend jobs are present only when `postgresql_index_maintenance.enabled` is true (absent otherwise).