### PR TITLE
Only use public IPs for SSH when ssh_public_access are true

### DIFF
--- a/automation/roles/cloud_resources/defaults/main.yml
+++ b/automation/roles/cloud_resources/defaults/main.yml
@@ -10,7 +10,7 @@ server_image: "" # (required) OS image for the server. For Azure, use variables 
 server_location: "" # (required) Server location or region.
 server_network: "" # (optional) If provided, the server will be added to this network (needs to be created beforehand).
 server_spot: false # Spot instance. Applicable for AWS, GCP, Azure.
-server_public_ip: false # Determines if a public IP should be assigned to the created instance.
+server_public_ip: true # Assign public IPs; set false only when the control host can reach private IPs and outbound egress is provided separately (for example, NAT).
 
 volume_type: "" # Volume type. Defaults: 'gp3' for AWS, 'pd-ssd' for GCP, 'StandardSSD_LRS' for Azure.
 volume_size: 100 # Storage size for the data directory (in gigabytes).

--- a/automation/roles/cloud_resources/tasks/aws.yml
+++ b/automation/roles/cloud_resources/tasks/aws.yml
@@ -250,7 +250,7 @@
     # Determine which IP address (public or private)
     - name: "Set variable: ip_address_type"
       ansible.builtin.set_fact:
-        ip_address_type: "{{ 'public_ip_address' if server_public_ip | bool else 'private_ip_address' }}"
+        ip_address_type: "{{ 'public_ip_address' if (server_public_ip | bool and ssh_public_access | bool) else 'private_ip_address' }}"
 
     # Server and volume
     - block:

--- a/automation/roles/cloud_resources/tasks/azure.yml
+++ b/automation/roles/cloud_resources/tasks/azure.yml
@@ -493,6 +493,8 @@
     label: "{{ server_name | lower }}{{ '%02d' % (idx + 1) }}"
   when:
     - public_ip_address.results | default([]) | length > 0
+    - server_public_ip | bool
+    - ssh_public_access | bool
     - item.state.ip_address is defined
 
 # Check SSH access - via a private IP address (if public IP is not defined)
@@ -507,7 +509,7 @@
     index_var: idx
     label: "{{ server_name | lower }}{{ '%02d' % (idx + 1) }}"
   when:
-    - public_ip_address.results | default([]) | length == 0
+    - not (server_public_ip | bool and ssh_public_access | bool)
     - server_result.results is defined
     - item.ansible_facts.azure_vm.network_profile.network_interfaces[0].properties.ip_configurations[0].private_ip_address is defined
 

--- a/automation/roles/cloud_resources/tasks/digitalocean.yml
+++ b/automation/roles/cloud_resources/tasks/digitalocean.yml
@@ -666,7 +666,7 @@
       {{
         (item.data.droplet.networks.v4
          | selectattr('type', 'equalto',
-           'public' if server_public_ip | bool else 'private')
+           'public' if (server_public_ip | bool and ssh_public_access | bool) else 'private')
          | first).ip_address
       }}
     port: 22

--- a/automation/roles/cloud_resources/tasks/gcp.yml
+++ b/automation/roles/cloud_resources/tasks/gcp.yml
@@ -543,7 +543,7 @@
 # Check SSH access
 - name: Wait for host to be available via SSH
   ansible.builtin.wait_for:
-    host: "{{ item.networkInterfaces[0].accessConfigs[0].natIP if (server_public_ip | bool and ssh_public_access | bool) else item.networkInterfaces[0].networkIP }}"
+    host: "{{ item.networkInterfaces[0].accessConfigs[0].natIP if (server_public_ip | bool and ssh_public_access | bool) else item.networkInterfaces[0].networkIP }}" # yamllint disable rule:line-length
     port: 22
     delay: 5
     timeout: "{{ 1800 if server_type is search('metal') else 300 }}" # 30 min for bare metal, 5 min for VMs

--- a/automation/roles/cloud_resources/tasks/gcp.yml
+++ b/automation/roles/cloud_resources/tasks/gcp.yml
@@ -543,7 +543,7 @@
 # Check SSH access
 - name: Wait for host to be available via SSH
   ansible.builtin.wait_for:
-    host: "{{ item.networkInterfaces[0].accessConfigs[0].natIP if server_public_ip | bool else item.networkInterfaces[0].networkIP }}"
+    host: "{{ item.networkInterfaces[0].accessConfigs[0].natIP if (server_public_ip | bool and ssh_public_access | bool) else item.networkInterfaces[0].networkIP }}"
     port: 22
     delay: 5
     timeout: "{{ 1800 if server_type is search('metal') else 300 }}" # 30 min for bare metal, 5 min for VMs

--- a/automation/roles/cloud_resources/tasks/hetzner.yml
+++ b/automation/roles/cloud_resources/tasks/hetzner.yml
@@ -693,7 +693,7 @@
 # Check SSH access
 - name: Wait for host to be available via SSH
   ansible.builtin.wait_for:
-    host: "{{ item.hcloud_server.ipv4_address if server_public_ip | bool else item.hcloud_server.private_networks_info[0].ip }}"
+    host: "{{ item.hcloud_server.ipv4_address if (server_public_ip | bool and ssh_public_access | bool) else item.hcloud_server.private_networks_info[0].ip }}"
     port: 22
     delay: 5
     timeout: 300

--- a/automation/roles/cloud_resources/tasks/inventory.yml
+++ b/automation/roles/cloud_resources/tasks/inventory.yml
@@ -21,13 +21,13 @@
     groups:
       - postgres_cluster
       - master
-    ansible_ssh_host: "{{ item[server_public_ip | bool | ternary('public_ip', 'private_ip')] }}"
+    ansible_ssh_host: "{{ item[(server_public_ip | bool and ssh_public_access | bool) | ternary('public_ip', 'private_ip')] }}"
     ansible_ssh_private_key_file: "{{ ssh_private_key_file | default(None) }}"
     new_node: "{{ item.new_node | default(omit) }}"
     bind_address: "{{ item.private_ip }}"
   loop: "{{ [ip_addresses[0]] }}" # add the first item in the list
   loop_control:
-    label: "{{ item[server_public_ip | bool | ternary('public_ip', 'private_ip')] }}"
+    label: "{{ item[(server_public_ip | bool and ssh_public_access | bool) | ternary('public_ip', 'private_ip')] }}"
   changed_when: false
 
 - name: "Inventory | Add host to 'postgres_cluster', 'replica' groups"
@@ -36,13 +36,13 @@
     groups:
       - postgres_cluster
       - replica
-    ansible_ssh_host: "{{ item[server_public_ip | bool | ternary('public_ip', 'private_ip')] }}"
+    ansible_ssh_host: "{{ item[(server_public_ip | bool and ssh_public_access | bool) | ternary('public_ip', 'private_ip')] }}"
     ansible_ssh_private_key_file: "{{ ssh_private_key_file | default(None) }}"
     new_node: "{{ item.new_node | default(omit) }}"
     bind_address: "{{ item.private_ip }}"
   loop: "{{ ip_addresses[1:] }}" # start with the 2nd item of the list
   loop_control:
-    label: "{{ item[server_public_ip | bool | ternary('public_ip', 'private_ip')] }}"
+    label: "{{ item[(server_public_ip | bool and ssh_public_access | bool) | ternary('public_ip', 'private_ip')] }}"
   when: ip_addresses | length > 1 # only if there is more than one item
   changed_when: false
 
@@ -50,13 +50,13 @@
   ansible.builtin.add_host:
     name: "{{ item.private_ip }}"
     group: balancers
-    ansible_ssh_host: "{{ item[server_public_ip | bool | ternary('public_ip', 'private_ip')] }}"
+    ansible_ssh_host: "{{ item[(server_public_ip | bool and ssh_public_access | bool) | ternary('public_ip', 'private_ip')] }}"
     ansible_ssh_private_key_file: "{{ ssh_private_key_file | default(None) }}"
     new_node: "{{ item.new_node | default(omit) }}"
     bind_address: "{{ item.private_ip }}"
   loop: "{{ ip_addresses }}"
   loop_control:
-    label: "{{ item[server_public_ip | bool | ternary('public_ip', 'private_ip')] }}"
+    label: "{{ item[(server_public_ip | bool and ssh_public_access | bool) | ternary('public_ip', 'private_ip')] }}"
   changed_when: false
   when: with_haproxy_load_balancing | bool
 
@@ -64,13 +64,13 @@
   ansible.builtin.add_host:
     name: "{{ item.private_ip }}"
     group: etcd_cluster
-    ansible_ssh_host: "{{ item[server_public_ip | bool | ternary('public_ip', 'private_ip')] }}"
+    ansible_ssh_host: "{{ item[(server_public_ip | bool and ssh_public_access | bool) | ternary('public_ip', 'private_ip')] }}"
     ansible_ssh_private_key_file: "{{ ssh_private_key_file | default(None) }}"
     new_node: "{{ item.new_node | default(omit) }}"
     bind_address: "{{ item.private_ip }}"
   loop: "{{ ip_addresses[:7] }}" # no more than 7 servers for the etcd cluster
   loop_control:
-    label: "{{ item[server_public_ip | bool | ternary('public_ip', 'private_ip')] }}"
+    label: "{{ item[(server_public_ip | bool and ssh_public_access | bool) | ternary('public_ip', 'private_ip')] }}"
   changed_when: false
   when: not dcs_exists | bool and dcs_type == "etcd"
 
@@ -79,12 +79,12 @@
     name: "{{ item.private_ip }}"
     group: consul_instances
     consul_node_role: "{{ 'server' if not dcs_exists | default(false) else 'client' }}"
-    ansible_ssh_host: "{{ item[server_public_ip | bool | ternary('public_ip', 'private_ip')] }}"
+    ansible_ssh_host: "{{ item[(server_public_ip | bool and ssh_public_access | bool) | ternary('public_ip', 'private_ip')] }}"
     ansible_ssh_private_key_file: "{{ ssh_private_key_file | default(None) }}"
     new_node: "{{ item.new_node | default(omit) }}"
     bind_address: "{{ item.private_ip }}"
   loop: "{{ ip_addresses }}"
   loop_control:
-    label: "{{ item[server_public_ip | bool | ternary('public_ip', 'private_ip')] }}"
+    label: "{{ item[(server_public_ip | bool and ssh_public_access | bool) | ternary('public_ip', 'private_ip')] }}"
   changed_when: false
   when: dcs_type == "consul"


### PR DESCRIPTION
Only use public IPs for SSH when both `server_public_ip` and `ssh_public_access` are true

Updated default to enable server_public_ip by default and adjusted IP selection logic across providers and inventory to combine server_public_ip with ssh_public_access. This ensures Ansible uses public addresses only when public SSH access is explicitly allowed, otherwise private IPs are used.

Fixed:

```
TASK [Update apt cache] ********************************************************
[WARNING]: Failed to update cache after 1 retries due to , retrying
[WARNING]: Sleeping for 1 seconds, before attempting to refresh the cache again
[WARNING]: Failed to update cache after 2 retries due to , retrying
[WARNING]: Sleeping for 2 seconds, before attempting to refresh the cache again
[WARNING]: Failed to update cache after 3 retries due to , retrying
[WARNING]: Sleeping for 4 seconds, before attempting to refresh the cache again
[WARNING]: Failed to update cache after 4 retries due to , retrying
[WARNING]: Sleeping for 8 seconds, before attempting to refresh the cache again
[WARNING]: Failed to update cache after 5 retries due to , retrying
[WARNING]: Sleeping for 12 seconds, before attempting to refresh the cache again
[ERROR]: Task failed: Module failed: Failed to update apt cache after 5 retries: 
Origin: /autobase/automation/playbooks/deploy_pgcluster.yml:87:7
85       when: ansible_os_family == "RedHat"
86
87     - name: Update apt cache
         ^ column 7
fatal: [172.31.36.131]: FAILED! => {"attempts": 3, "changed": false, "msg": "Failed to update apt cache after 5 retries: "}
```

```
TASK [vitabaks.autobase.cloud_resources : Wait for host to be available via SSH] ***
[ERROR]: Task failed: Module failed: Timeout when waiting for 3.94.250.122:22
Origin: /root/.ansible/collections/ansible_collections/vitabaks/autobase/roles/cloud_resources/tasks/aws.yml:587:3
585
586 # Check SSH access
587 - name: Wait for host to be available via SSH
      ^ column 3
failed: [localhost] (item=vitabaks-pgcluster-pgnode01) => {"ansible_index_var": "idx", "ansible_loop_var": "item", "changed": false, "elapsed": 301, "idx": 0, "item": {"ansible_index_var": "idx", "ansible_loop_var": "item", "attempts": 1, "changed": true, "changes": [], "failed": false, "idx": 0, "instance_ids": ["i-08ff6e992c87c7588"], "instances": [{"ami_launch_index": 0, "architecture": "x86_64", "block_device_mappings": [{"device_name": "/dev/sda1", "ebs": {"attach_time": "2026-06-11T20:24:30+00:00", "delete_on_termination": true, "ebs_card_index": 0, "status": "attached", "volume_id": "vol-01d722840abec8f54"}}, {"device_name": "/dev/sdb", "ebs": {"attach_time": "2026-06-11T20:24:29.057000+00:00", "delete_on_termination": true, "ebs_card_index": 0, "status": "attached", "volume_id": "vol-0ceaef7963d278778"}}], "boot_mode": "uefi-preferred", "capacity_reservation_specification": {"capacity_reservation_preference": "open"}, "client_token": "eca8f54edeb029e8f16e2ba74e2868d86d4fe80a52a760c365f86e0c146c", "cpu_options": {"core_count": 1, "threads_per_core": 2}, "current_instance_boot_mode": "uefi", "ebs_optimized": false, "ena_support": true, "enclave_options": {"enabled": false}, "hibernation_options": {"configured": false}, "hypervisor": "xen", "image_id": "ami-04eaa218f1349d88b", "instance_id": "i-08ff6e992c87c7588", "instance_lifecycle": "spot", "instance_type": "t3.small", "key_name": "ssh_key_tmp_veepujf", "launch_time": "2026-06-11T20:24:29+00:00", "maintenance_options": {"auto_recovery": "default", "reboot_migration": "default"}, "metadata_options": {"http_endpoint": "enabled", "http_protocol_ipv6": "disabled", "http_put_response_hop_limit": 2, "http_tokens": "required", "instance_metadata_tags": "disabled", "state": "applied"}, "monitoring": {"state": "disabled"}, "network_interfaces": [{"association": {"ip_owner_id": "amazon", "public_dns_name": "ec2-3-94-250-122.compute-1.amazonaws.com", "public_ip": "3.94.250.122"}, "attachment": {"attach_time": "2026-06-11T20:24:29+00:00", "attachment_id": "eni-attach-0263681b6d9d9d10e", "delete_on_termination": true, "device_index": 0, "network_card_index": 0, "status": "attached"}, "description": "", "groups": [{"group_id": "sg-08fde8a19dd89e9bc", "group_name": "vitabaks-pgcluster-security-group"}], "interface_type": "interface", "ipv6_addresses": [], "mac_address": "0e:b5:d1:74:1e:11", "network_interface_id": "eni-05d73dcb7f52d5868", "operator": {"managed": false}, "owner_id": "554482772640", "private_dns_name": "ip-172-31-33-249.ec2.internal", "private_ip_address": "172.31.33.249", "private_ip_addresses": [{"association": {"ip_owner_id": "amazon", "public_dns_name": "ec2-3-94-250-122.compute-1.amazonaws.com", "public_ip": "3.94.250.122"}, "primary": true, "private_dns_name": "ip-172-31-33-249.ec2.internal", "private_ip_address": "172.31.33.249"}], "source_dest_check": true, "status": "in-use", "subnet_id": "subnet-6a811435", "vpc_id": "vpc-6a01a417"}], "network_performance_options": {"bandwidth_weighting": "default"}, "operator": {"hidden_by_default": false, "managed": false}, "placement": {"availability_zone": "us-east-1d", "availability_zone_id": "use1-az6", "group_name": "", "tenancy": "default"}, "platform_details": "Linux/UNIX", "private_dns_name": "ip-172-31-33-249.ec2.internal", "private_dns_name_options": {"enable_resource_name_dns_a_record": false, "enable_resource_name_dns_aaaa_record": false, "hostname_type": "ip-name"}, "private_ip_address": "172.31.33.249", "product_codes": [], "public_dns_name": "ec2-3-94-250-122.compute-1.amazonaws.com", "public_ip_address": "3.94.250.122", "root_device_name": "/dev/sda1", "root_device_type": "ebs", "secondary_interfaces": [], "security_groups": [{"group_id": "sg-08fde8a19dd89e9bc", "group_name": "vitabaks-pgcluster-security-group"}], "source_dest_check": true, "spot_instance_request_id": "sir-d7dqkfgg", "state": {"code": 16, "name": "running"}, "state_transition_reason": "", "subnet_id": "subnet-6a811435", "tags": {"Name": "vitabaks-pgcluster-pgnode01"}, "usage_operation": "RunInstances", "usage_operation_update_time": "2026-06-11T20:24:29+00:00", "virtualization_type": "hvm", "vpc_id": "vpc-6a01a417"}], "invocation": {"module_args": {"aap_callback": null, "access_key": "AKIAYCGN7VKQO7ZATY7X", "additional_info": null, "availability_zone": null, "aws_ca_bundle": null, "aws_config": null, "count": null, "cpu_credit_specification": null, "cpu_options": null, "debug_botocore_endpoint_logs": false, "detailed_monitoring": null, "ebs_optimized": null, "endpoint_url": null, "exact_count": null, "filters": {"spot-instance-request-id": "sir-d7dqkfgg"}, "hibernation_options": false, "iam_instance_profile": null, "image": null, "image_id": null, "instance_ids": [], "instance_initiated_shutdown_behavior": null, "instance_type": null, "key_name": null, "launch_template": null, "license_specifications": null, "metadata_options": null, "name": "vitabaks-pgcluster-pgnode01", "network": null, "network_interfaces": null, "network_interfaces_ids": null, "placement": null, "placement_group": null, "profile": null, "purge_tags": true, "region": "us-east-1", "secret_key": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER", "security_group": null, "security_groups": [], "session_token": null, "source_dest_check": null, "state": "present", "tags": null, "tenancy": null, "termination_protection": null, "user_data": null, "validate_certs": true, "volumes": null, "vpc_subnet_id": null, "wait": true, "wait_timeout": 600}}, "item": {"ansible_index_var": "idx", "ansible_loop_var": "item", "changed": true, "failed": false, "idx": 0, "invocation": {"module_args": {"access_key": "AKIAYCGN7VKQO7ZATY7X", "aws_ca_bundle": null, "aws_config": null, "client_token": null, "count": 1, "debug_botocore_endpoint_logs": false, "endpoint_url": null, "interruption": "terminate", "launch_group": null, "launch_specification": {"block_device_mappings": [{"device_name": "/dev/sda1", "ebs": {"delete_on_termination": true, "iops": 3000, "throughput": 125, "volume_size": 100, "volume_type": "gp3"}, "no_device": null, "virtual_name": null}, {"device_name": "/dev/sdb", "ebs": {"delete_on_termination": true, "iops": 3000, "throughput": 125, "volume_size": 100, "volume_type": "gp3"}, "no_device": null, "virtual_name": null}], "ebs_optimized": false, "iam_instance_profile": null, "image_id": "ami-04eaa218f1349d88b", "instance_type": "t3.small", "kernel_id": null, "key_name": "ssh_key_tmp_veepujf", "monitoring": null, "network_interfaces": [{"associate_carrier_ip_address": null, "associate_public_ip_address": true, "delete_on_termination": true, "description": null, "device_index": 0, "groups": ["sg-08fde8a19dd89e9bc"], "interface_type": null, "ipv4_prefix_count": null, "ipv4_prefixes": null, "ipv6_address_count": null, "ipv6_addresses": null, "ipv6_prefix_count": null, "ipv6_prefixes": null, "network_card_index": null, "network_interface_id": null, "private_ip_address": null, "private_ip_addresses": null, "secondary_private_ip_address_count": null, "subnet_id": "subnet-6a811435"}], "placement": null, "ramdisk_id": null, "security_group_ids": null, "security_groups": null, "subnet_id": null, "user_data": null}, "profile": null, "region": "us-east-1", "secret_key": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER", "session_token": null, "spot_instance_request_ids": null, "spot_price": null, "spot_type": "one-time", "state": "present", "tags": {"Cluster": "vitabaks-pgcluster", "Name": "vitabaks-pgcluster-pgnode01"}, "terminate_instances": false, "validate_certs": true, "zone_group": null}}, "item": {"ansible_index_var": "idx", "ansible_loop_var": "item", "changed": false, "failed": false, "idx": 0, "instances": [], "invocation": {"module_args": {"access_key": "AKIAYCGN7VKQO7ZATY7X", "aws_ca_bundle": null, "aws_config": null, "debug_botocore_endpoint_logs": false, "endpoint_url": null, "filters": {"instance-lifecycle": "spot", "instance-state-name": ["pending", "running", "shutting-down", "stopping", "stopped"], "instance-type": "t3.small", "tag:Name": "vitabaks-pgcluster-pgnode01"}, "include_attributes": null, "instance_ids": [], "minimum_uptime": null, "profile": null, "region": "us-east-1", "secret_key": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER", "session_token": null, "validate_certs": true}}, "item": 0}, "spot_request": {"create_time": "2026-06-11T20:24:26+00:00", "instance_interruption_behavior": "terminate", "launch_specification": {"block_device_mappings": [{"device_name": "/dev/sda1", "ebs": {"delete_on_termination": true, "iops": 3000, "throughput": 125, "volume_size": 100, "volume_type": "gp3"}}, {"device_name": "/dev/sdb", "ebs": {"delete_on_termination": true, "iops": 3000, "throughput": 125, "volume_size": 100, "volume_type": "gp3"}}], "ebs_optimized": false, "image_id": "ami-04eaa218f1349d88b", "instance_type": "t3.small", "key_name": "ssh_key_tmp_veepujf", "monitoring": {"enabled": false}, "network_interfaces": [{"associate_public_ip_address": true, "delete_on_termination": true, "device_index": 0, "subnet_id": "subnet-6a811435"}], "placement": {"availability_zone": "us-east-1d", "availability_zone_id": "use1-az6"}, "security_groups": [{"group_name": "default"}]}, "product_description": "Linux/UNIX", "spot_instance_request_id": "sir-d7dqkfgg", "spot_price": "0.020800", "state": "open", "status": {"code": "pending-evaluation", "message": "Your Spot request has been submitted for review, and is pending evaluation.", "update_time": "2026-06-11T20:24:26+00:00"}, "tags": {"Cluster": "vitabaks-pgcluster", "Name": "vitabaks-pgcluster-pgnode01"}, "type": "one-time"}}}, "msg": "Timeout when waiting for 3.94.250.122:22"}
```