### PR TITLE
Hide Patroni config contents from ansible logs

### DIFF
--- a/automation/roles/patroni/tasks/patroni.yml
+++ b/automation/roles/patroni/tasks/patroni.yml
@@ -10,6 +10,7 @@
   vars:
     etcd_hosts: "{{ groups['etcd_cluster'] | default([]) }}"
   notify: "reload patroni"
+  no_log: "{{ patroni_conf_no_log | default(true) }}" # hide config contents from ansible logs
 
 - name: Flush handlers
   ansible.builtin.meta: flush_handlers


### PR DESCRIPTION
Hide Patroni configuration contents in Ansible logs by default to prevent accidental disclosure of superuser and replication passwords in CI/CD pipelines.