### PR TITLE
Add cloud_resources playbook

### DIFF
--- a/automation/README.md
+++ b/automation/README.md
@@ -85,6 +85,10 @@ Autobase adheres to a modular design separating atomic logic (roles) and orchest
 
 ## List of Playbooks
 
+#### Infrastructure
+
+- `cloud_resources` – Provision and configure cloud resources on AWS, GCP, Azure, DigitalOcean, and Hetzner Cloud. Note: also called by `deploy_pgcluster` when `cloud_provider` is defined.
+
 #### Deployment
 
 - `deploy_pgcluster` – Deploy a new highly available PostgreSQL cluster. This playbook also includes:

--- a/automation/playbooks/cloud_resources.yml
+++ b/automation/playbooks/cloud_resources.yml
@@ -19,4 +19,6 @@
   roles:
     - role: vitabaks.autobase.cloud_resources
       when: cloud_provider | default('') | length > 0
+      vars:
+        generate_inventory: false
       tags: always

--- a/automation/playbooks/cloud_resources.yml
+++ b/automation/playbooks/cloud_resources.yml
@@ -1,0 +1,22 @@
+---
+- name: vitabaks.autobase.cloud_resources | Provision or configure cloud resources for a PostgreSQL Cluster
+  hosts: localhost
+  gather_facts: true
+  any_errors_fatal: true
+  pre_tasks:
+    # set_fact: 'pgbackrest_install' to configure Postgres backups if not disabled explicitly.
+    # Note: Applicable only for "aws", "gcp", "azure", because:
+    # "digitalocean" - requires the Spaces access keys ("digital_ocean_spaces_access_key" and "digital_ocean_spaces_secret_key" variables)
+    # "hetzner" - requires the S3 credentials ("hetzner_object_storage_access_key" and "hetzner_object_storage_secret_key" variables).
+    - name: "Set variable: 'pgbackrest_install' to configure Postgres backups"
+      ansible.builtin.set_fact:
+        pgbackrest_install: true
+      when:
+        - not (pgbackrest_install | default(false) | bool or wal_g_install | default(false) | bool)
+        - cloud_provider | default('') | lower in ['aws', 'gcp', 'azure']
+        - pgbackrest_auto_conf | default(true) | bool # to be able to disable auto backup settings
+      tags: always
+  roles:
+    - role: vitabaks.autobase.cloud_resources
+      when: cloud_provider | default('') | length > 0
+      tags: always

--- a/automation/roles/cloud_resources/tasks/aws.yml
+++ b/automation/roles/cloud_resources/tasks/aws.yml
@@ -631,6 +631,7 @@
   when:
     - server_result.results is defined
     - (server_result.results | selectattr('instances','defined') | list | length) > 0
+    - generate_inventory | default(true) | bool
 
 # Delete the temporary ssh key from the cloud after creating the EC2 instance
 - name: "AWS: Remove temporary SSH key '{{ ssh_key_name | default('') }}' from cloud"

--- a/automation/roles/cloud_resources/tasks/azure.yml
+++ b/automation/roles/cloud_resources/tasks/azure.yml
@@ -543,6 +543,7 @@
   when:
     - server_result.results is defined
     - (server_result.results | selectattr('ansible_facts.azure_vm', 'defined') | list | length) > 0
+    - generate_inventory | default(true) | bool
 
 # Delete (if state is absent)
 - block:

--- a/automation/roles/cloud_resources/tasks/digitalocean.yml
+++ b/automation/roles/cloud_resources/tasks/digitalocean.yml
@@ -710,6 +710,7 @@
   when:
     - droplet_result.results is defined
     - (droplet_result.results | selectattr('data','defined') | list | length) > 0
+    - generate_inventory | default(true) | bool
 
 # Delete the temporary SSH key from the cloud after creating the droplet
 - name: "DigitalOcean: Remove temporary SSH key '{{ ssh_key_name | default('') }}' from cloud"

--- a/automation/roles/cloud_resources/tasks/gcp.yml
+++ b/automation/roles/cloud_resources/tasks/gcp.yml
@@ -587,6 +587,7 @@
   when:
     - server_result.results is defined
     - (server_result.results | selectattr('networkInterfaces', 'defined') | list | length) > 0
+    - generate_inventory | default(true) | bool
 
 # Delete (if state is absent)
 - block:

--- a/automation/roles/cloud_resources/tasks/hetzner.yml
+++ b/automation/roles/cloud_resources/tasks/hetzner.yml
@@ -735,6 +735,7 @@
   when:
     - server_result.results is defined
     - (server_result.results | selectattr('hcloud_server','defined') | list | length) > 0
+    - generate_inventory | default(true) | bool
 
 # Delete the temporary ssh key from the cloud after creating the server
 - name: "Hetzner Cloud: Remove temporary SSH key {{ ssh_key_name | default('') }} from cloud"


### PR DESCRIPTION
Added a new `cloud_resources` playbook to provision or configure cloud resources for a PostgreSQL Cluster.

It allows us to manage the infrastructure after deployment, for example, to increase the volume size.