### PR TITLE
Fix: Use filters when removing EC2 instances

### DIFF
--- a/automation/roles/cloud_resources/tasks/aws.yml
+++ b/automation/roles/cloud_resources/tasks/aws.yml
@@ -653,9 +653,13 @@
       amazon.aws.ec2_instance:
         access_key: "{{ lookup('ansible.builtin.env', 'AWS_ACCESS_KEY_ID') }}"
         secret_key: "{{ lookup('ansible.builtin.env', 'AWS_SECRET_ACCESS_KEY') }}"
-        name: "{{ server_name | lower }}{{ '%02d' % (idx + 1) }}"
         region: "{{ server_location }}"
+        filters:
+          instance-type: "{{ server_type }}"
+          instance-state-name: ["pending", "running", "shutting-down", "stopping", "stopped"]
+          "tag:Name": "{{ server_name | lower }}{{ '%02d' % (idx + 1) }}"
         state: absent
+        wait: true
       loop: "{{ range(0, server_count | int) | list }}"
       loop_control:
         index_var: idx

--- a/automation/roles/cloud_resources/tasks/aws.yml
+++ b/automation/roles/cloud_resources/tasks/aws.yml
@@ -397,6 +397,9 @@
             secret_key: "{{ lookup('ansible.builtin.env', 'AWS_SECRET_ACCESS_KEY') }}"
             region: "{{ server_location }}"
             name: "{{ server_name | lower }}{{ '%02d' % (idx + 1) }}"
+            tags:
+              Name: "{{ server_name | lower }}{{ '%02d' % (idx + 1) }}"
+              Cluster: "{{ patroni_cluster_name }}"
             filters:
               spot-instance-request-id: "{{ item.spot_request.spot_instance_request_id }}"
           loop: "{{ ec2_spot_request_result.results }}"

--- a/automation/roles/cloud_resources/tasks/aws.yml
+++ b/automation/roles/cloud_resources/tasks/aws.yml
@@ -658,6 +658,7 @@
           instance-type: "{{ server_type }}"
           instance-state-name: ["pending", "running", "shutting-down", "stopping", "stopped"]
           "tag:Name": "{{ server_name | lower }}{{ '%02d' % (idx + 1) }}"
+          "tag:Cluster": "{{ patroni_cluster_name }}"
         state: absent
         wait: true
       loop: "{{ range(0, server_count | int) | list }}"


### PR DESCRIPTION
Replace the direct name parameter with filters (instance-type, instance-state-name, and tag:Name matching the previous name pattern) to more precisely select EC2 instances across various states.

The instance has not been deleted before.

Fixed:

```
PLAY [vitabaks.autobase.cloud_resources | Provision or configure cloud resources for a PostgreSQL Cluster] **********************************************************************************************************************************

TASK [Gathering Facts] **********************************************************************************************************************************************************************************************************************
ok: [localhost]

TASK [Set variable: 'pgbackrest_install' to configure Postgres backups] *********************************************************************************************************************************************************************
ok: [localhost]

TASK [vitabaks.autobase.cloud_resources : Ensure that 'python3-pip' package is present on control host] *************************************************************************************************************************************
ok: [localhost -> 127.0.0.1]

TASK [vitabaks.autobase.cloud_resources : Ensure that 'boto3' dependency is present on control host] ****************************************************************************************************************************************
ok: [localhost -> 127.0.0.1]

TASK [vitabaks.autobase.cloud_resources : AWS: Delete EC2 instance] *************************************************************************************************************************************************************************
ok: [localhost] => (item=vitabaks-pgcluster-pgnode01)

TASK [vitabaks.autobase.cloud_resources : AWS: Delete Network Load Balancer (NLB)] **********************************************************************************************************************************************************
changed: [localhost] => (item=vitabaks-pgcluster-primary)

TASK [vitabaks.autobase.cloud_resources : AWS: Delete NLB Target Group] *********************************************************************************************************************************************************************
changed: [localhost] => (item=vitabaks-pgcluster-tg-primary)
FAILED - RETRYING: [localhost]: AWS: Delete Security Group (3 retries left).
FAILED - RETRYING: [localhost]: AWS: Delete Security Group (2 retries left).
FAILED - RETRYING: [localhost]: AWS: Delete Security Group (1 retries left).

TASK [vitabaks.autobase.cloud_resources : AWS: Delete Security Group] ***********************************************************************************************************************************************************************
[ERROR]: Task failed: Module failed: Failed to delete security group: An error occurred (DependencyViolation) when calling the DeleteSecurityGroup operation: resource sg-08fde8a19dd89e9bc has a dependent object
Origin: /home/ubuntu/.ansible/collections/ansible_collections/vitabaks/autobase/roles/cloud_resources/tasks/aws.yml:718:7

716         (item in ['sync', 'async'] and server_count | int > 1 and synchronous_mode | bool))
717
718     - name: "AWS: Delete Security Group"
          ^ column 7

fatal: [localhost]: FAILED! => {"attempts": 3, "boto3_version": "1.43.6", "botocore_version": "1.43.9", "changed": false, "error": {"code": "DependencyViolation", "message": "resource sg-08fde8a19dd89e9bc has a dependent object"}, "msg": "Failed to delete security group: An error occurred (DependencyViolation) when calling the DeleteSecurityGroup operation: resource sg-08fde8a19dd89e9bc has a dependent object", "response_metadata": {"http_headers": {"cache-control": "no-cache, no-store", "connection": "close", "content-type": "text/xml;charset=UTF-8", "date": "Mon, 22 Jun 2026 20:33:30 GMT", "server": "AmazonEC2", "strict-transport-security": "max-age=31536000; includeSubDomains", "transfer-encoding": "chunked", "vary": "accept-encoding", "x-amzn-requestid": "197f372c-42fc-4642-a8c1-7143551abb5d"}, "http_status_code": 400, "request_id": "197f372c-42fc-4642-a8c1-7143551abb5d", "retry_attempts": 0}}

PLAY RECAP **********************************************************************************************************************************************************************************************************************************
localhost                  : ok=7    changed=2    unreachable=0    failed=1    skipped=47   rescued=0    ignored=0  
```