### PR TITLE
Move shared_buffers to postgresql_parameters

### DIFF
--- a/automation/roles/common/defaults/main.yml
+++ b/automation/roles/common/defaults/main.yml
@@ -363,6 +363,8 @@ postgresql_parameters:
   - { option: "max_locks_per_transaction", value: "512" }
   - { option: "max_prepared_transactions", value: "0" }
   - { option: "huge_pages", value: "try" } # "vm.nr_hugepages" is auto-configured for shared_buffers >= 8GB (if huge_pages_auto_conf is true)
+  - { option: "shared_buffers", value: "{{ (ansible_memtotal_mb * 0.25) | int }}MB" } # by default, 25% of RAM
+  - { option: "effective_cache_size", value: "{{ (ansible_memtotal_mb * 0.75) | int }}MB" } # by default, 75% of RAM
   - { option: "work_mem", value: "64MB" } # increase it if possible
   - { option: "maintenance_work_mem", value: "512MB" } # or 2GB/4GB
   - { option: "checkpoint_timeout", value: "15min" } # or 30min
@@ -449,9 +451,9 @@ postgresql_parameters_overrides: []
 #  - { option: "", value: "" }
 
 # Host-level PostgreSQL parameters are defined locally in patroni.yml and override the common ones stored in DCS.
-local_postgresql_parameters:
- - { option: "shared_buffers", value: "{{ (ansible_memtotal_mb * 0.25) | int }}MB" } # by default, 25% of RAM
- - { option: "effective_cache_size", value: "{{ (ansible_memtotal_mb * 0.75) | int }}MB" } # by default, 75% of RAM
+local_postgresql_parameters: []
+# - { option: "shared_buffers", value: "{{ (ansible_memtotal_mb * 0.25) | int }}MB" }
+# - { option: "effective_cache_size", value: "{{ (ansible_memtotal_mb * 0.75) | int }}MB" }
 
 # Final PostgreSQL parameters (cluster-wide, stored in DCS).
 postgresql_parameters_dcs: >-


### PR DESCRIPTION
Add cluster-wide PostgreSQL memory settings to the common defaults. Remove the corresponding host-level entries from local_postgresql_parameters (replace them with an empty list while keeping commented examples) to avoid duplicate or conflicting overrides.

By default, PostgreSQL parameters stored in DCS should be the single source of truth for cluster-wide configuration. Necessary for integration with the  UI platform.

If needed, you can still override settings for a specific host by defining the local_postgresql_parameters variable.