### PR TITLE
Ensure /etc/apt/sources.list.d exists before deb822_repository

### DIFF
--- a/automation/roles/add_repository/tasks/extensions.yml
+++ b/automation/roles/add_repository/tasks/extensions.yml
@@ -1,16 +1,19 @@
 ---
 # Extension Auto-Setup: repository
 
+# The deb822_repository module does not create /etc/apt/sources.list.d/;
+# ensure it exists once before adding any extension repository.
+- name: Ensure /etc/apt/sources.list.d directory exists
+  ansible.builtin.file:
+    path: /etc/apt/sources.list.d
+    state: directory
+    mode: "0755"
+  when: ansible_os_family == "Debian"
+  tags: add_repo, timescaledb, timescale, citus
+
 # TimescaleDB (if 'enable_timescale' is 'true')
 - block:
     # Debian based
-    - name: Ensure /etc/apt/sources.list.d directory exists
-      ansible.builtin.file:
-        path: /etc/apt/sources.list.d
-        state: directory
-        mode: "0755"
-      when: ansible_os_family == "Debian"
-
     - name: Add TimescaleDB repository
       ansible.builtin.deb822_repository:
         name: "timescaledb"
@@ -39,13 +42,6 @@
 # Citus (if 'enable_citus' is 'true')
 - block:
     # Debian based
-    - name: Ensure /etc/apt/sources.list.d directory exists
-      ansible.builtin.file:
-        path: /etc/apt/sources.list.d
-        state: directory
-        mode: "0755"
-      when: ansible_os_family == "Debian" and ansible_architecture in ["x86_64", "amd64"]
-
     - name: Add Citus repository
       ansible.builtin.deb822_repository:
         name: "citusdata"

--- a/automation/roles/add_repository/tasks/extensions.yml
+++ b/automation/roles/add_repository/tasks/extensions.yml
@@ -4,6 +4,13 @@
 # TimescaleDB (if 'enable_timescale' is 'true')
 - block:
     # Debian based
+    - name: Ensure /etc/apt/sources.list.d directory exists
+      ansible.builtin.file:
+        path: /etc/apt/sources.list.d
+        state: directory
+        mode: "0755"
+      when: ansible_os_family == "Debian"
+
     - name: Add TimescaleDB repository
       ansible.builtin.deb822_repository:
         name: "timescaledb"
@@ -32,6 +39,13 @@
 # Citus (if 'enable_citus' is 'true')
 - block:
     # Debian based
+    - name: Ensure /etc/apt/sources.list.d directory exists
+      ansible.builtin.file:
+        path: /etc/apt/sources.list.d
+        state: directory
+        mode: "0755"
+      when: ansible_os_family == "Debian" and ansible_architecture in ["x86_64", "amd64"]
+
     - name: Add Citus repository
       ansible.builtin.deb822_repository:
         name: "citusdata"

--- a/automation/roles/add_repository/tasks/main.yml
+++ b/automation/roles/add_repository/tasks/main.yml
@@ -17,6 +17,13 @@
       retries: 3
       when: "'python3-debian' not in ansible_facts.packages"
 
+    - name: Ensure /etc/apt/sources.list.d directory exists
+      ansible.builtin.file:
+        path: /etc/apt/sources.list.d
+        state: directory
+        mode: "0755"
+      when: apt_repository | length > 0
+
     - name: Add repository
       ansible.builtin.deb822_repository:
         name: "{{ item.name | default(item.repo.split('//')[1].split('/')[0] | replace('.', '-')) }}"

--- a/automation/roles/consul/tasks/install_linux_repo.yml
+++ b/automation/roles/consul/tasks/install_linux_repo.yml
@@ -77,6 +77,13 @@
         - ansible_os_family == "Debian"
         - "'python3-debian' not in ansible_facts.packages"
 
+    - name: Ensure /etc/apt/sources.list.d directory exists
+      ansible.builtin.file:
+        path: /etc/apt/sources.list.d
+        state: directory
+        mode: "0755"
+      when: "ansible_os_family|lower == 'debian'"
+
     - name: Add hashicorp repository
       ansible.builtin.deb822_repository:
         name: "{{ consul_repo_url.split('//')[1] | replace('.', '-') }}"

--- a/automation/roles/consul/tasks/install_linux_repo.yml
+++ b/automation/roles/consul/tasks/install_linux_repo.yml
@@ -82,7 +82,7 @@
         path: /etc/apt/sources.list.d
         state: directory
         mode: "0755"
-      when: "ansible_os_family|lower == 'debian'"
+      when: ansible_os_family == "Debian"
 
     - name: Add hashicorp repository
       ansible.builtin.deb822_repository:

--- a/automation/roles/pg_probackup/tasks/main.yml
+++ b/automation/roles/pg_probackup/tasks/main.yml
@@ -12,6 +12,13 @@
       delay: 5
       retries: 3
 
+    - name: Ensure /etc/apt/sources.list.d directory exists
+      ansible.builtin.file:
+        path: /etc/apt/sources.list.d
+        state: directory
+        mode: "0755"
+      when: ansible_os_family == "Debian"
+
     - name: Add pgdg repository and signing key
       ansible.builtin.deb822_repository:
         name: "{{ pg_probackup_repo_name | default('pg_probackup') }}"


### PR DESCRIPTION
## Issue
Fixes #1584

## Summary
On minimal Debian/Ubuntu hosts, repository setup fails with `FileNotFoundError` because `ansible.builtin.deb822_repository` writes `<name>.sources` files into `/etc/apt/sources.list.d/` but does not create that directory itself. The directory is normally provided by the `apt` package, so the failure only shows up on stripped-down images/containers where it is absent. This adds an idempotent directory-ensure task immediately before every `deb822_repository` call so provisioning succeeds on those systems.

## What changes
- New `ansible.builtin.file: { state: directory, mode: "0755" }` task that ensures `/etc/apt/sources.list.d` exists, inserted **before** each of the 5 `deb822_repository` invocations.
- Each new task is placed **inside the same block** as the repo task it guards, so it inherits the block's `become`, `tags`, and `when`; its task-level `when` is set to exactly match the adjacent `deb822_repository` task. This guarantees the directory is created in **every** code path that adds a repo — including tag-filtered runs (e.g. `--tags timescaledb`) and the arch-gated Citus path — and never runs when no repo is added.
- Wired into all 4 affected role files / 5 call sites:
  - `add_repository/tasks/main.yml` — `apt_repository` loop
  - `add_repository/tasks/extensions.yml` — TimescaleDB and Citus
  - `pg_probackup/tasks/main.yml` — pgdg/PostgresPro repo
  - `consul/tasks/install_linux_repo.yml` — HashiCorp repo (runs under `become: true`)

## Caveats
- Debian/Ubuntu only — `deb822_repository` is a Debian-family module; the RedHat/`yum_repository` paths are untouched.
- Idempotent and zero-churn on normal systems: the directory almost always already exists, in which case the task reports `ok` and changes nothing.
- No `owner`/`group` is set, so an existing directory's ownership is never altered; `mode: "0755"` is the conventional permission for that path.

## Tests
Validated end-to-end in a Debian 12 container (`geerlingguy/docker-debian12-ansible`, ansible-core 2.19.11) by reproducing the exact bug condition — base OS repos in legacy `/etc/apt/sources.list` and `/etc/apt/sources.list.d/` removed — and running the real `add_repository` tasks with the default pgdg `apt_repository`:

| Scenario | Code | `.d` dir | Result |
| --- | --- | --- | --- |
| Reproduce | pre-fix (`main`) | absent | **FAIL** — `FileNotFoundError ... -> /etc/apt/sources.list.d/apt-postgresql-org.sources` (matches the issue) |
| Fix | this PR | absent | **PASS** — dir created (`0755`), `.sources` written, `apt update` succeeds |
| No-regression | this PR | present | **PASS** — dir task reports `ok` (no churn), full run green |
| Idempotency | this PR | present (re-run) | **PASS** — `changed=0`, fully idempotent |

Also: `yamllint -c .config/.yamllint` passes on all four changed files; `mode: "0755"` quoting matches the repo convention.

## How to reproduce / verify
1. On a Debian 12 / Ubuntu 24.04+ host (or container) without `/etc/apt/sources.list.d/`, define an `apt_repository` entry and run the `deploy_pgcluster` playbook.
2. **Before:** the *Add repository* task fails with `FileNotFoundError: [Errno 2] No such file or directory: '.../local-repo.sources'`.
3. **After:** the directory is created first and the repository is added successfully.
