### PR TITLE
Fix/unlock postgres user for ssh (issue #1587)

### DIFF
--- a/automation/roles/ssh_keys/tasks/main.yml
+++ b/automation/roles/ssh_keys/tasks/main.yml
@@ -35,6 +35,21 @@
         state: present
         system: true
 
+    - name: Check password lock state for "{{ ssh_key_user | default('') }}" user
+      ansible.builtin.command: "getent shadow {{ ssh_key_user | default('') }}"
+      register: ssh_key_user_shadow
+      changed_when: false
+      no_log: true
+
+    - name: Unlock the locked password for "{{ ssh_key_user | default('') }}" user (required for SSH key auth)
+      ansible.builtin.user:
+        name: "{{ ssh_key_user | default('') }}"
+        password: '*'
+        password_lock: false
+      when:
+        - ssh_key_user | default('') == 'postgres'
+        - ssh_key_user_shadow.stdout is match('^postgres:!+')
+
     - name: Create a 2048-bit SSH key for user "{{ ssh_key_user | default('') }}" in ~/.ssh/id_rsa (if not already exist)
       ansible.builtin.user:
         name: "{{ ssh_key_user }}"

--- a/automation/roles/ssh_keys/tasks/main.yml
+++ b/automation/roles/ssh_keys/tasks/main.yml
@@ -35,20 +35,20 @@
         state: present
         system: true
 
-    - name: Check password lock state for "{{ ssh_key_user | default('') }}" user
-      ansible.builtin.command: "getent shadow {{ ssh_key_user | default('') }}"
-      register: ssh_key_user_shadow
-      changed_when: false
-      no_log: true
+    - block:
+        - name: Check password lock state for "{{ ssh_key_user }}" user
+          ansible.builtin.command: "getent shadow {{ ssh_key_user }}"
+          register: ssh_key_user_shadow
+          changed_when: false
+          no_log: true
 
-    - name: Unlock the locked password for "{{ ssh_key_user | default('') }}" user (required for SSH key auth)
-      ansible.builtin.user:
-        name: "{{ ssh_key_user | default('') }}"
-        password: '*'
-        password_lock: false
-      when:
-        - ssh_key_user | default('') == 'postgres'
-        - ssh_key_user_shadow.stdout is match('^postgres:!+')
+        - name: Unlock the locked password for "{{ ssh_key_user }}" user (required for SSH key auth)
+          ansible.builtin.user:
+            name: "{{ ssh_key_user }}"
+            password: '*'
+            password_lock: false
+          when: ssh_key_user_shadow.stdout is match('^postgres:!+')
+      when: ssh_key_user | default('') == 'postgres'
 
     - name: Create a 2048-bit SSH key for user "{{ ssh_key_user | default('') }}" in ~/.ssh/id_rsa (if not already exist)
       ansible.builtin.user:


### PR DESCRIPTION
### Summary

Fix: unlock postgres OS user account in ssh_keys role to enable SSH key-based authentication (closes issue #1587)

### Description

On Debian (and RHEL), the `postgres` system user is created by the PostgreSQL package with a locked password (`!` in `/etc/shadow`). While this prevents password-based login, PAM's `pam_unix.so` account module also blocks locked accounts before SSH public key verification is attempted.

This means that even though the `ssh_keys` role correctly generates SSH keys and populates `authorized_keys`, all SSH connections as `postgres` fail with `Permission denied` when `enable_ssh_key_based_authentication` is enabled.

#### Changes

Added two tasks to `roles/ssh_keys/tasks/main.yml`, after user creation and before SSH key generation:

1. **Check password lock state** — runs `getent shadow` to detect if the account is locked
2. **Unlock the locked password** — sets `password: '*'` (invalid hash, prevents password login) and `password_lock: false` (removes `!` from shadow)

Both tasks are guarded by:
- `ssh_key_user == 'postgres'` — only affects the postgres user
- `ssh_key_user_shadow.stdout is match('^postgres:!+')` — only runs when the account is actually locked

#### Why this approach

- Idempotent: only triggers if the account is locked
- Secure: `password: '*'` is an invalid hash, so password-based login is still impossible
- Consistent with existing fix in `cron` role (PR #1360), but scoped to OS-agnostic SSH setup
- Minimal: 10 lines of code, no new dependencies

#### Related

- PR #1360 — similar fix for cron role (RHEL-only)