### PR TITLE
Add tag propagation to pg_auto_reindexer role

### DIFF
--- a/automation/playbooks/add_node.yml
+++ b/automation/playbooks/add_node.yml
@@ -341,7 +341,6 @@
         (cluster_vip is defined and cluster_vip | length > 0)
 
     - role: vitabaks.autobase.postgresql_index_maintenance
-      when: postgresql_index_maintenance_enabled | default(postgresql_index_maintenance.enabled | default(false)) | bool
 
     - role: vitabaks.autobase.netdata
 

--- a/automation/playbooks/config_pgcluster.yml
+++ b/automation/playbooks/config_pgcluster.yml
@@ -195,7 +195,6 @@
       when: inventory_hostname in groups['primary']
 
     - role: vitabaks.autobase.postgresql_index_maintenance
-      when: postgresql_index_maintenance_enabled | default(postgresql_index_maintenance.enabled | default(false)) | bool
 
     - role: vitabaks.autobase.wal_g
       when: wal_g_install | default(false) | bool

--- a/automation/playbooks/deploy_pgcluster.yml
+++ b/automation/playbooks/deploy_pgcluster.yml
@@ -341,7 +341,6 @@
       when: inventory_hostname == groups['master'][0]
 
     - role: vitabaks.autobase.postgresql_index_maintenance
-      when: postgresql_index_maintenance_enabled | default(postgresql_index_maintenance.enabled | default(false)) | bool
 
     - role: vitabaks.autobase.netdata
 

--- a/automation/roles/postgresql_index_maintenance/tasks/main.yml
+++ b/automation/roles/postgresql_index_maintenance/tasks/main.yml
@@ -12,6 +12,7 @@
     timeout: 60
     validate_certs: false
   environment: "{{ proxy_env | default({}) }}"
+  when: postgresql_index_maintenance_enabled | default(postgresql_index_maintenance.enabled | default(false)) | bool
   tags: pg_auto_reindexer, pg_auto_reindexer_install
 
 # For PostgreSQL 11 and below, pg_repack is used for index maintenance
@@ -34,6 +35,7 @@
   when:
     - installation_method == "packages"
     - postgresql_version | int <= 11
+    - postgresql_index_maintenance_enabled | default(postgresql_index_maintenance.enabled | default(false)) | bool
   tags: pg_auto_reindexer, pg_auto_reindexer_install
 
 - name: Configure pg_auto_reindexer cron jobs

--- a/automation/roles/postgresql_index_maintenance/tasks/main.yml
+++ b/automation/roles/postgresql_index_maintenance/tasks/main.yml
@@ -39,6 +39,8 @@
 - name: Configure pg_auto_reindexer cron jobs
   ansible.builtin.include_role:
     name: vitabaks.autobase.cron
+    apply:
+      tags: pg_auto_reindexer, pg_auto_reindexer_cron
   vars:
     cron_jobs: "{{ postgresql_index_maintenance.cron_jobs | default(postgresql_index_maintenance_cron_jobs) }}"
   tags: pg_auto_reindexer, pg_auto_reindexer_cron


### PR DESCRIPTION
1. Add `apply` directive to the `include_role` task for pg_auto_reindexer cron configuration.
    - This ensures that tags specified on the include_role task are properly propagated to tasks within the included role, allowing for more granular control when running playbooks with tag filters.
2. Allow to disable cron jobs for pg_auto_reindexer.