### PR TITLE
Add resizefs role for automatic filesystem growth

### DIFF
--- a/automation/playbooks/cloud_resources.yml
+++ b/automation/playbooks/cloud_resources.yml
@@ -20,9 +20,16 @@
     - role: vitabaks.autobase.cloud_resources
       when: cloud_provider | default('') | length > 0
       vars:
-        generate_inventory: false
+        generate_inventory: "{{ true if resizefs_enabled | default(false) else false }}"
       tags: always
 
+- name: vitabaks.autobase.cloud_resources | Resize filesystem
+  hosts: postgres_cluster
+  become: true
+  become_method: sudo
+  gather_facts: true
+  any_errors_fatal: true
+  roles:
     - role: vitabaks.autobase.resizefs
       when: resizefs_enabled | default(false) | bool
       tags: always

--- a/automation/playbooks/cloud_resources.yml
+++ b/automation/playbooks/cloud_resources.yml
@@ -22,3 +22,7 @@
       vars:
         generate_inventory: false
       tags: always
+
+    - role: vitabaks.autobase.resizefs
+      when: resizefs_enabled | default(false) | bool
+      tags: always

--- a/automation/playbooks/config_pgcluster.yml
+++ b/automation/playbooks/config_pgcluster.yml
@@ -159,6 +159,9 @@
       when: firewall_enabled_at_boot | default(false) | bool
       tags: firewall
 
+    - role: vitabaks.autobase.resizefs
+      when: resizefs_enabled | default(false) | bool
+
     - role: vitabaks.autobase.hostname
     - role: vitabaks.autobase.resolv_conf
     - role: vitabaks.autobase.etc_hosts

--- a/automation/roles/common/defaults/main.yml
+++ b/automation/roles/common/defaults/main.yml
@@ -1165,6 +1165,11 @@ mount:
 #    opts: defaults,noatime
 #    state: mounted
 
+# Automatically grow the block device and filesystem
+# when the underlying disk has available space.
+resizefs_enabled: false
+resizefs_target_path: "{{ postgresql_data_dir }}"
+
 ############################################################
 # Repository and packages
 ############################################################

--- a/automation/roles/mount/README.md
+++ b/automation/roles/mount/README.md
@@ -23,6 +23,7 @@ Notes:
 - If multiple candidate disks are detected, the role fails and asks you to set `mount[].src` explicitly.
 - If `mount[].src` is given as `UUID=...`, the role assumes the filesystem already exists and only mounts it.
 - ZFS packages are installed per OS family (Ubuntu/Debian/RedHat) and the zfs module is loaded automatically.
+- New ZFS pools are created with `autoexpand=on`, allowing the pool to use additional device capacity after the underlying disk is expanded.
 
 ## Example:
 

--- a/automation/roles/mount/tasks/main.yml
+++ b/automation/roles/mount/tasks/main.yml
@@ -179,6 +179,7 @@
         - name: "Create zpool (use {{ (mount | first | default({})).src | default('/dev/' ~ (lsblk_disk_device | default('')), true) }})"
           ansible.builtin.command: >-
             zpool create -f
+            -o autoexpand=on
             -O compression=on
             -O atime=off
             -O recordsize=128k

--- a/automation/roles/resizefs/README.md
+++ b/automation/roles/resizefs/README.md
@@ -13,5 +13,4 @@ It resolves the filesystem device and type with `findmnt` and `lsblk`, grows the
 
 ## Notes
 
-- ZFS pools created by the `mount` role use `autoexpand=on`; this role skips ZFS.
 - LVM is not supported yet; this role skips LVM.

--- a/automation/roles/resizefs/README.md
+++ b/automation/roles/resizefs/README.md
@@ -1,0 +1,17 @@
+# Ansible Role: resizefs
+
+This role grows the block device and filesystem when the underlying disk or volume has available space.
+
+It resolves the filesystem device and type with `findmnt` and `lsblk`, grows the partition with `community.general.parted` and grows filesystems with `community.general.filesystem`.
+
+## Role Variables
+
+| Variable | Default | Description |
+|---|---|---|
+| resizefs_enabled | false | Enable automatic resize checks. |
+| resizefs_target_path | `{{ postgresql_data_dir }}` | Path used to find the mounted filesystem to resize. If the exact path does not exist yet, the nearest existing parent path is used. |
+
+## Notes
+
+- ZFS pools created by the `mount` role use `autoexpand=on`; this role skips ZFS.
+- LVM is not supported yet; this role skips LVM.

--- a/automation/roles/resizefs/defaults/main.yml
+++ b/automation/roles/resizefs/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+# resizefs_enabled: true
+# resizefs_target_path: "{{ postgresql_data_dir }}"

--- a/automation/roles/resizefs/meta/main.yml
+++ b/automation/roles/resizefs/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - role: vitabaks.autobase.common

--- a/automation/roles/resizefs/tasks/main.yml
+++ b/automation/roles/resizefs/tasks/main.yml
@@ -1,11 +1,16 @@
 ---
 # This role is used to automatically grow the block device and filesystem
 # when the underlying disk has available space.
-# Note: LVM is not supported yet (TODO).
-
-# /dev/nvme1n1      TYPE=disk -> resize filesystem only
-# /dev/nvme1n1p1    TYPE=part -> resize partition + resize filesystem
-# /dev/mapper/...   TYPE zfs/lvm/dm/crypt -> skip
+#
+# Supported:
+# - ext4/xfs on whole disk: resize filesystem only
+# - ext4/xfs on partition: resize partition + resize filesystem
+# - zfs on single whole disk vdev: zpool online -e
+# - zfs on single partition vdev: resize partition up to the ZFS reserved slice + zpool online -e
+#
+# Not supported yet:
+# - LVM
+# - ZFS mirror/raidz/multi-vdev pools
 
 - name: "Get filesystem source and type for {{ resizefs_target_path }}"
   ansible.builtin.command:
@@ -21,17 +26,21 @@
   when: resizefs_enabled | bool
   tags: resizefs
 
+#
+# ext4/xfs
+#
+
 - name: "Get block device type for {{ resizefs_mount.stdout.split()[0] | default('') }}"
   ansible.builtin.command:
     argv:
       - lsblk
+      - --nodeps
       - --noheadings
       - --output
       - TYPE
       - "{{ resizefs_mount.stdout.split()[0] }}"
   register: resizefs_device_type
   changed_when: false
-  failed_when: false
   when:
     - resizefs_enabled | bool
     - resizefs_mount.stdout is defined
@@ -40,17 +49,34 @@
     - resizefs_mount.stdout.split()[1] in ['ext4', 'xfs']
   tags: resizefs
 
+- name: "Get block device kernel name for {{ resizefs_mount.stdout.split()[0] | default('') }}"
+  ansible.builtin.command:
+    argv:
+      - lsblk
+      - --nodeps
+      - --noheadings
+      - --output
+      - NAME
+      - "{{ resizefs_mount.stdout.split()[0] }}"
+  register: resizefs_device_name
+  changed_when: false
+  when:
+    - resizefs_enabled | bool
+    - resizefs_device_type.stdout is defined
+    - resizefs_device_type.stdout | trim in ['part', 'disk']
+  tags: resizefs
+
 - name: "Get parent disk for {{ resizefs_mount.stdout.split()[0] | default('') }}"
   ansible.builtin.command:
     argv:
       - lsblk
+      - --nodeps
       - --noheadings
       - --output
       - PKNAME
       - "{{ resizefs_mount.stdout.split()[0] }}"
   register: resizefs_parent_disk
   changed_when: false
-  failed_when: false
   when:
     - resizefs_enabled | bool
     - resizefs_device_type.stdout is defined
@@ -61,14 +87,15 @@
   ansible.builtin.command:
     argv:
       - cat
-      - "/sys/class/block/{{ resizefs_mount.stdout.split()[0] | basename }}/partition"
+      - "/sys/class/block/{{ resizefs_device_name.stdout | trim }}/partition"
   register: resizefs_partition_number
   changed_when: false
-  failed_when: false
   when:
     - resizefs_enabled | bool
     - resizefs_device_type.stdout is defined
     - resizefs_device_type.stdout | trim == 'part'
+    - resizefs_device_name.stdout is defined
+    - resizefs_device_name.stdout | trim | length > 0
   tags: resizefs
 
 - name: "Grow partition for /dev/{{ resizefs_parent_disk.stdout | default('') | trim }}"
@@ -105,7 +132,7 @@
     - resizefs_parent_disk.stdout | trim | length > 0
   tags: resizefs
 
-- name: "Wait for udev to settle"
+- name: "Wait for udev to settle after partition resize"
   ansible.builtin.command:
     argv:
       - udevadm
@@ -132,4 +159,159 @@
     - resizefs_mount.stdout.split()[1] in ['ext4', 'xfs']
     - resizefs_device_type.stdout is defined
     - resizefs_device_type.stdout | trim in ['part', 'disk']
+  tags: resizefs
+
+#
+# zfs
+#
+
+- name: "Get ZFS vdev path for {{ resizefs_mount.stdout.split()[0] | default('') }}"
+  ansible.builtin.shell: |
+    set -o pipefail
+    zpool status -P {{ resizefs_mount.stdout.split()[0].split('/')[0] | quote }} \
+      | awk '/^[[:space:]]+\/dev\// { print $1 }'
+  args:
+    executable: /bin/bash
+  register: resizefs_zfs_vdev
+  changed_when: false
+  when:
+    - resizefs_enabled | bool
+    - resizefs_mount.stdout is defined
+    - resizefs_mount.stdout.split() | length >= 2
+    - resizefs_mount.stdout.split()[1] == 'zfs'
+  tags: resizefs
+
+- name: "Get ZFS vdev device type for {{ resizefs_zfs_vdev.stdout_lines[0] | default('') }}"
+  ansible.builtin.command:
+    argv:
+      - lsblk
+      - --nodeps
+      - --noheadings
+      - --output
+      - TYPE
+      - "{{ resizefs_zfs_vdev.stdout_lines[0] }}"
+  register: resizefs_zfs_device_type
+  changed_when: false
+  when:
+    - resizefs_enabled | bool
+    - resizefs_zfs_vdev.stdout_lines is defined
+    - resizefs_zfs_vdev.stdout_lines | length == 1
+    - resizefs_zfs_vdev.stdout_lines[0] is match('^/dev/')
+  tags: resizefs
+
+- name: "Get ZFS vdev kernel name for {{ resizefs_zfs_vdev.stdout_lines[0] | default('') }}"
+  ansible.builtin.command:
+    argv:
+      - lsblk
+      - --nodeps
+      - --noheadings
+      - --output
+      - NAME
+      - "{{ resizefs_zfs_vdev.stdout_lines[0] }}"
+  register: resizefs_zfs_device_name
+  changed_when: false
+  when:
+    - resizefs_enabled | bool
+    - resizefs_zfs_device_type.stdout is defined
+    - resizefs_zfs_device_type.stdout | trim in ['part', 'disk']
+  tags: resizefs
+
+- name: "Get ZFS vdev parent disk for {{ resizefs_zfs_vdev.stdout_lines[0] | default('') }}"
+  ansible.builtin.command:
+    argv:
+      - lsblk
+      - --nodeps
+      - --noheadings
+      - --output
+      - PKNAME
+      - "{{ resizefs_zfs_vdev.stdout_lines[0] }}"
+  register: resizefs_zfs_parent_disk
+  changed_when: false
+  when:
+    - resizefs_enabled | bool
+    - resizefs_zfs_device_type.stdout is defined
+    - resizefs_zfs_device_type.stdout | trim == 'part'
+  tags: resizefs
+
+- name: "Get ZFS vdev partition number for {{ resizefs_zfs_vdev.stdout_lines[0] | default('') }}"
+  ansible.builtin.command:
+    argv:
+      - cat
+      - "/sys/class/block/{{ resizefs_zfs_device_name.stdout | trim }}/partition"
+  register: resizefs_zfs_partition_number
+  changed_when: false
+  when:
+    - resizefs_enabled | bool
+    - resizefs_zfs_device_type.stdout is defined
+    - resizefs_zfs_device_type.stdout | trim == 'part'
+    - resizefs_zfs_device_name.stdout is defined
+    - resizefs_zfs_device_name.stdout | trim | length > 0
+  tags: resizefs
+
+- name: "Grow ZFS vdev partition for /dev/{{ resizefs_zfs_parent_disk.stdout | default('') | trim }}"
+  community.general.parted:
+    device: "/dev/{{ resizefs_zfs_parent_disk.stdout | trim }}"
+    number: "{{ resizefs_zfs_partition_number.stdout | trim | int }}"
+    part_end: "-9MiB" # Leave space for the ZFS reserved partition
+    resize: true
+    state: present
+  register: resizefs_zfs_partition_grow
+  when:
+    - resizefs_enabled | bool
+    - resizefs_zfs_device_type.stdout is defined
+    - resizefs_zfs_device_type.stdout | trim == 'part'
+    - resizefs_zfs_parent_disk.stdout is defined
+    - resizefs_zfs_parent_disk.stdout | trim | length > 0
+    - resizefs_zfs_partition_number.stdout is defined
+    - resizefs_zfs_partition_number.stdout | trim | length > 0
+  tags: resizefs
+
+- name: "Refresh ZFS vdev partition table for /dev/{{ resizefs_zfs_parent_disk.stdout | default('') | trim }}"
+  ansible.builtin.command:
+    argv:
+      - partprobe
+      - "/dev/{{ resizefs_zfs_parent_disk.stdout | trim }}"
+  changed_when: false
+  when:
+    - resizefs_enabled | bool
+    - resizefs_zfs_device_type.stdout is defined
+    - resizefs_zfs_device_type.stdout | trim == 'part'
+    - resizefs_zfs_partition_grow is defined
+    - resizefs_zfs_partition_grow.changed | default(false)
+    - resizefs_zfs_parent_disk.stdout is defined
+    - resizefs_zfs_parent_disk.stdout | trim | length > 0
+  tags: resizefs
+
+- name: "Wait for udev to settle after ZFS partition resize"
+  ansible.builtin.command:
+    argv:
+      - udevadm
+      - settle
+  changed_when: false
+  when:
+    - resizefs_enabled | bool
+    - resizefs_zfs_device_type.stdout is defined
+    - resizefs_zfs_device_type.stdout | trim == 'part'
+    - resizefs_zfs_partition_grow is defined
+    - resizefs_zfs_partition_grow.changed | default(false)
+  tags: resizefs
+
+- name: "Expand ZFS pool {{ resizefs_mount.stdout.split()[0].split('/')[0] | default('') }}"
+  ansible.builtin.command:
+    argv:
+      - zpool
+      - online
+      - -e
+      - "{{ resizefs_mount.stdout.split()[0].split('/')[0] }}"
+      - "{{ resizefs_zfs_vdev.stdout_lines[0] }}"
+  changed_when: false
+  when:
+    - resizefs_enabled | bool
+    - resizefs_mount.stdout is defined
+    - resizefs_mount.stdout.split() | length >= 2
+    - resizefs_mount.stdout.split()[1] == 'zfs'
+    - resizefs_zfs_vdev.stdout_lines is defined
+    - resizefs_zfs_vdev.stdout_lines | length == 1
+    - resizefs_zfs_device_type.stdout is defined
+    - resizefs_zfs_device_type.stdout | trim in ['part', 'disk']
   tags: resizefs

--- a/automation/roles/resizefs/tasks/main.yml
+++ b/automation/roles/resizefs/tasks/main.yml
@@ -166,14 +166,16 @@
 # zfs
 #
 
-- name: "Get ZFS vdev path for {{ resizefs_mount.stdout.split()[0] | default('') }}"
+- name: "Get ZFS vdev name for {{ resizefs_mount.stdout.split()[0] | default('') }}"
   ansible.builtin.shell: |
     set -o pipefail
     pool={{ resizefs_mount.stdout.split()[0].split('/')[0] | quote }}
 
-    zpool status -P "$pool" \
-      | awk '
-          /^[[:space:]]+\/dev\/[A-Za-z0-9_\/.-]+[[:space:]]+ONLINE/ {
+    zpool status "$pool" \
+      | awk -v pool="$pool" '
+          /^[[:space:]]+[A-Za-z0-9_\/.-]+[[:space:]]+ONLINE/ &&
+          $1 != pool &&
+          $1 !~ /^(mirror|raidz|logs|cache|spares|special|dedup)/ {
             print $1
           }
         '
@@ -196,7 +198,6 @@
       - -e
       - "{{ resizefs_mount.stdout.split()[0].split('/')[0] }}"
       - "{{ resizefs_zfs_vdev.stdout_lines[0] }}"
-  changed_when: false
   when:
     - resizefs_enabled | bool
     - resizefs_mount.stdout is defined
@@ -204,4 +205,5 @@
     - resizefs_mount.stdout.split()[1] == 'zfs'
     - resizefs_zfs_vdev.stdout_lines is defined
     - resizefs_zfs_vdev.stdout_lines | length == 1
+    - resizefs_zfs_vdev.stdout_lines[0] is not match('^/')
   tags: resizefs

--- a/automation/roles/resizefs/tasks/main.yml
+++ b/automation/roles/resizefs/tasks/main.yml
@@ -5,12 +5,13 @@
 # Supported:
 # - ext4/xfs on whole disk: resize filesystem only
 # - ext4/xfs on partition: resize partition + resize filesystem
-# - zfs on single whole disk vdev: zpool online -e
-# - zfs on single partition vdev: resize partition up to the ZFS reserved slice + zpool online -e
+# - zfs on single whole disk vdev / ZFS-managed disk layout: zpool online -e
 #
 # Not supported yet:
 # - LVM
+# - dm-crypt
 # - ZFS mirror/raidz/multi-vdev pools
+# - ZFS pools created directly on user-managed partitions
 
 - name: "Get filesystem source and type for {{ resizefs_target_path }}"
   ansible.builtin.command:
@@ -165,11 +166,19 @@
 # zfs
 #
 
-- name: "Get ZFS vdev path for {{ resizefs_mount.stdout.split()[0] | default('') }}"
+- name: "Get ZFS vdev name for {{ resizefs_mount.stdout.split()[0] | default('') }}"
   ansible.builtin.shell: |
     set -o pipefail
-    zpool status -P {{ resizefs_mount.stdout.split()[0].split('/')[0] | quote }} \
-      | awk '/^[[:space:]]+\/dev\// { print $1 }'
+    pool={{ resizefs_mount.stdout.split()[0].split('/')[0] | quote }}
+
+    zpool status "$pool" \
+      | awk -v pool="$pool" '
+          /^[[:space:]]+[A-Za-z0-9_\/.-]+[[:space:]]+ONLINE/ &&
+          $1 != pool &&
+          $1 !~ /^(mirror|raidz|logs|cache|spares|special|dedup)/ {
+            print $1
+          }
+        '
   args:
     executable: /bin/bash
   register: resizefs_zfs_vdev
@@ -179,121 +188,6 @@
     - resizefs_mount.stdout is defined
     - resizefs_mount.stdout.split() | length >= 2
     - resizefs_mount.stdout.split()[1] == 'zfs'
-  tags: resizefs
-
-- name: "Get ZFS vdev device type for {{ resizefs_zfs_vdev.stdout_lines[0] | default('') }}"
-  ansible.builtin.command:
-    argv:
-      - lsblk
-      - --nodeps
-      - --noheadings
-      - --output
-      - TYPE
-      - "{{ resizefs_zfs_vdev.stdout_lines[0] }}"
-  register: resizefs_zfs_device_type
-  changed_when: false
-  when:
-    - resizefs_enabled | bool
-    - resizefs_zfs_vdev.stdout_lines is defined
-    - resizefs_zfs_vdev.stdout_lines | length == 1
-    - resizefs_zfs_vdev.stdout_lines[0] is match('^/dev/')
-  tags: resizefs
-
-- name: "Get ZFS vdev kernel name for {{ resizefs_zfs_vdev.stdout_lines[0] | default('') }}"
-  ansible.builtin.command:
-    argv:
-      - lsblk
-      - --nodeps
-      - --noheadings
-      - --output
-      - NAME
-      - "{{ resizefs_zfs_vdev.stdout_lines[0] }}"
-  register: resizefs_zfs_device_name
-  changed_when: false
-  when:
-    - resizefs_enabled | bool
-    - resizefs_zfs_device_type.stdout is defined
-    - resizefs_zfs_device_type.stdout | trim in ['part', 'disk']
-  tags: resizefs
-
-- name: "Get ZFS vdev parent disk for {{ resizefs_zfs_vdev.stdout_lines[0] | default('') }}"
-  ansible.builtin.command:
-    argv:
-      - lsblk
-      - --nodeps
-      - --noheadings
-      - --output
-      - PKNAME
-      - "{{ resizefs_zfs_vdev.stdout_lines[0] }}"
-  register: resizefs_zfs_parent_disk
-  changed_when: false
-  when:
-    - resizefs_enabled | bool
-    - resizefs_zfs_device_type.stdout is defined
-    - resizefs_zfs_device_type.stdout | trim == 'part'
-  tags: resizefs
-
-- name: "Get ZFS vdev partition number for {{ resizefs_zfs_vdev.stdout_lines[0] | default('') }}"
-  ansible.builtin.command:
-    argv:
-      - cat
-      - "/sys/class/block/{{ resizefs_zfs_device_name.stdout | trim }}/partition"
-  register: resizefs_zfs_partition_number
-  changed_when: false
-  when:
-    - resizefs_enabled | bool
-    - resizefs_zfs_device_type.stdout is defined
-    - resizefs_zfs_device_type.stdout | trim == 'part'
-    - resizefs_zfs_device_name.stdout is defined
-    - resizefs_zfs_device_name.stdout | trim | length > 0
-  tags: resizefs
-
-- name: "Grow ZFS vdev partition for /dev/{{ resizefs_zfs_parent_disk.stdout | default('') | trim }}"
-  community.general.parted:
-    device: "/dev/{{ resizefs_zfs_parent_disk.stdout | trim }}"
-    number: "{{ resizefs_zfs_partition_number.stdout | trim | int }}"
-    part_end: "-9MiB" # Leave space for the ZFS reserved partition
-    resize: true
-    state: present
-  register: resizefs_zfs_partition_grow
-  when:
-    - resizefs_enabled | bool
-    - resizefs_zfs_device_type.stdout is defined
-    - resizefs_zfs_device_type.stdout | trim == 'part'
-    - resizefs_zfs_parent_disk.stdout is defined
-    - resizefs_zfs_parent_disk.stdout | trim | length > 0
-    - resizefs_zfs_partition_number.stdout is defined
-    - resizefs_zfs_partition_number.stdout | trim | length > 0
-  tags: resizefs
-
-- name: "Refresh ZFS vdev partition table for /dev/{{ resizefs_zfs_parent_disk.stdout | default('') | trim }}"
-  ansible.builtin.command:
-    argv:
-      - partprobe
-      - "/dev/{{ resizefs_zfs_parent_disk.stdout | trim }}"
-  changed_when: false
-  when:
-    - resizefs_enabled | bool
-    - resizefs_zfs_device_type.stdout is defined
-    - resizefs_zfs_device_type.stdout | trim == 'part'
-    - resizefs_zfs_partition_grow is defined
-    - resizefs_zfs_partition_grow.changed | default(false)
-    - resizefs_zfs_parent_disk.stdout is defined
-    - resizefs_zfs_parent_disk.stdout | trim | length > 0
-  tags: resizefs
-
-- name: "Wait for udev to settle after ZFS partition resize"
-  ansible.builtin.command:
-    argv:
-      - udevadm
-      - settle
-  changed_when: false
-  when:
-    - resizefs_enabled | bool
-    - resizefs_zfs_device_type.stdout is defined
-    - resizefs_zfs_device_type.stdout | trim == 'part'
-    - resizefs_zfs_partition_grow is defined
-    - resizefs_zfs_partition_grow.changed | default(false)
   tags: resizefs
 
 - name: "Expand ZFS pool {{ resizefs_mount.stdout.split()[0].split('/')[0] | default('') }}"
@@ -312,6 +206,4 @@
     - resizefs_mount.stdout.split()[1] == 'zfs'
     - resizefs_zfs_vdev.stdout_lines is defined
     - resizefs_zfs_vdev.stdout_lines | length == 1
-    - resizefs_zfs_device_type.stdout is defined
-    - resizefs_zfs_device_type.stdout | trim in ['part', 'disk']
   tags: resizefs

--- a/automation/roles/resizefs/tasks/main.yml
+++ b/automation/roles/resizefs/tasks/main.yml
@@ -1,0 +1,135 @@
+---
+# This role is used to automatically grow the block device and filesystem
+# when the underlying disk has available space.
+# Note: LVM is not supported yet (TODO).
+
+# /dev/nvme1n1      TYPE=disk -> resize filesystem only
+# /dev/nvme1n1p1    TYPE=part -> resize partition + resize filesystem
+# /dev/mapper/...   TYPE zfs/lvm/dm/crypt -> skip
+
+- name: "Get filesystem source and type for {{ resizefs_target_path }}"
+  ansible.builtin.command:
+    argv:
+      - findmnt
+      - -n
+      - -T
+      - "{{ resizefs_target_path }}"
+      - -o
+      - SOURCE,FSTYPE
+  register: resizefs_mount
+  changed_when: false
+  when: resizefs_enabled | bool
+  tags: resizefs
+
+- name: "Get block device type for {{ resizefs_mount.stdout.split()[0] | default('') }}"
+  ansible.builtin.command:
+    argv:
+      - lsblk
+      - --noheadings
+      - --output
+      - TYPE
+      - "{{ resizefs_mount.stdout.split()[0] }}"
+  register: resizefs_device_type
+  changed_when: false
+  failed_when: false
+  when:
+    - resizefs_enabled | bool
+    - resizefs_mount.stdout is defined
+    - resizefs_mount.stdout.split() | length >= 2
+    - resizefs_mount.stdout.split()[0] is match('^/dev/')
+    - resizefs_mount.stdout.split()[1] in ['ext4', 'xfs']
+  tags: resizefs
+
+- name: "Get parent disk for {{ resizefs_mount.stdout.split()[0] | default('') }}"
+  ansible.builtin.command:
+    argv:
+      - lsblk
+      - --noheadings
+      - --output
+      - PKNAME
+      - "{{ resizefs_mount.stdout.split()[0] }}"
+  register: resizefs_parent_disk
+  changed_when: false
+  failed_when: false
+  when:
+    - resizefs_enabled | bool
+    - resizefs_device_type.stdout is defined
+    - resizefs_device_type.stdout | trim == 'part'
+  tags: resizefs
+
+- name: "Get partition number for {{ resizefs_mount.stdout.split()[0] | default('') }}"
+  ansible.builtin.command:
+    argv:
+      - cat
+      - "/sys/class/block/{{ resizefs_mount.stdout.split()[0] | basename }}/partition"
+  register: resizefs_partition_number
+  changed_when: false
+  failed_when: false
+  when:
+    - resizefs_enabled | bool
+    - resizefs_device_type.stdout is defined
+    - resizefs_device_type.stdout | trim == 'part'
+  tags: resizefs
+
+- name: "Grow partition for /dev/{{ resizefs_parent_disk.stdout | default('') | trim }}"
+  community.general.parted:
+    device: "/dev/{{ resizefs_parent_disk.stdout | trim }}"
+    number: "{{ resizefs_partition_number.stdout | trim | int }}"
+    part_end: "100%"
+    resize: true
+    state: present
+  register: resizefs_partition_grow
+  when:
+    - resizefs_enabled | bool
+    - resizefs_device_type.stdout is defined
+    - resizefs_device_type.stdout | trim == 'part'
+    - resizefs_parent_disk.stdout is defined
+    - resizefs_parent_disk.stdout | trim | length > 0
+    - resizefs_partition_number.stdout is defined
+    - resizefs_partition_number.stdout | trim | length > 0
+  tags: resizefs
+
+- name: "Refresh partition table for /dev/{{ resizefs_parent_disk.stdout | default('') | trim }}"
+  ansible.builtin.command:
+    argv:
+      - partprobe
+      - "/dev/{{ resizefs_parent_disk.stdout | trim }}"
+  changed_when: false
+  when:
+    - resizefs_enabled | bool
+    - resizefs_device_type.stdout is defined
+    - resizefs_device_type.stdout | trim == 'part'
+    - resizefs_partition_grow is defined
+    - resizefs_partition_grow.changed | default(false)
+    - resizefs_parent_disk.stdout is defined
+    - resizefs_parent_disk.stdout | trim | length > 0
+  tags: resizefs
+
+- name: "Wait for udev to settle"
+  ansible.builtin.command:
+    argv:
+      - udevadm
+      - settle
+  changed_when: false
+  when:
+    - resizefs_enabled | bool
+    - resizefs_device_type.stdout is defined
+    - resizefs_device_type.stdout | trim == 'part'
+    - resizefs_partition_grow is defined
+    - resizefs_partition_grow.changed | default(false)
+  tags: resizefs
+
+- name: "Grow filesystem for {{ resizefs_mount.stdout.split()[0] | default('') }}"
+  community.general.filesystem:
+    dev: "{{ resizefs_mount.stdout.split()[0] }}"
+    fstype: "{{ resizefs_mount.stdout.split()[1] }}"
+    resizefs: true
+  when:
+    - resizefs_enabled | bool
+    - resizefs_mount.stdout is defined
+    - resizefs_mount.stdout.split() | length >= 2
+    - resizefs_mount.stdout.split()[0] is match('^/dev/')
+    - resizefs_mount.stdout.split()[1] in ['ext4', 'xfs']
+    - resizefs_device_type.stdout is defined
+    - resizefs_device_type.stdout | trim in ['part', 'disk']
+  tags: resizefs

--- a/automation/roles/resizefs/tasks/main.yml
+++ b/automation/roles/resizefs/tasks/main.yml
@@ -166,16 +166,14 @@
 # zfs
 #
 
-- name: "Get ZFS vdev name for {{ resizefs_mount.stdout.split()[0] | default('') }}"
+- name: "Get ZFS vdev path for {{ resizefs_mount.stdout.split()[0] | default('') }}"
   ansible.builtin.shell: |
     set -o pipefail
     pool={{ resizefs_mount.stdout.split()[0].split('/')[0] | quote }}
 
-    zpool status "$pool" \
-      | awk -v pool="$pool" '
-          /^[[:space:]]+[A-Za-z0-9_\/.-]+[[:space:]]+ONLINE/ &&
-          $1 != pool &&
-          $1 !~ /^(mirror|raidz|logs|cache|spares|special|dedup)/ {
+    zpool status -P "$pool" \
+      | awk '
+          /^[[:space:]]+\/dev\/[A-Za-z0-9_\/.-]+[[:space:]]+ONLINE/ {
             print $1
           }
         '

--- a/automation/tags.md
+++ b/automation/tags.md
@@ -111,6 +111,7 @@
 - netdata
 - ssh_public_keys
 - mount, zpool
+- resizefs
 - perf, flamegraph
 - tls
   - tls_cert_generate


### PR DESCRIPTION
Add a new **resizefs** role that automatically grows block devices and filesystems when the underlying disk has available space. The role supports ext4, xfs and zfs, skips LVM (it will be added to the future).

Variables:
- `resizefs_enabled`, default `false`
- `resizefs_target_path`, default `{{ postgresql_data_dir }}`

Closes: https://github.com/autobase-tech/autobase/issues/1284