### PR TITLE
Extract GCP project ID from service account credentials

### DIFF
--- a/automation/roles/cloud_resources/README.md
+++ b/automation/roles/cloud_resources/README.md
@@ -90,7 +90,7 @@ Provision the PostgreSQL cluster infrastructure in public clouds (AWS, GCP, Azur
 | Variable | Provider | Default/Notes |
 |----------|----------|---------------|
 | aws_ec2_spot_instance | AWS | Fallback for server_spot |
-| gcp_project | GCP | Fallbacks to projectNumber from credentials |
+| gcp_project | GCP | Fallbacks to project_id from service account credentials |
 | gcp_compute_instance_preemptible | GCP | Fallback for server_spot |
 | gcp_compute_health_check_interval_sec, gcp_compute_health_check_check_timeout_sec, gcp_compute_health_check_unhealthy_threshold, gcp_compute_health_check_healthy_threshold | GCP | Interval/timeout/threshold tuning |
 | gcp_compute_backend_service_timeout_sec, gcp_compute_backend_service_log_enable | GCP | LB Backend timeouts/logging |

--- a/automation/roles/cloud_resources/tasks/gcp.yml
+++ b/automation/roles/cloud_resources/tasks/gcp.yml
@@ -88,7 +88,8 @@
   ansible.builtin.fail:
     msg: >-
       Unable to determine the GCP project.
-      Try to explicitly set the project ID in the gcp_project variable.
+      Make sure that a valid GCP service account JSON key is provided
+      or explicitly set the project ID in the gcp_project variable.
   when: gcp_project | default('') | length < 1
 
 # Create (if state is present)

--- a/automation/roles/cloud_resources/tasks/gcp.yml
+++ b/automation/roles/cloud_resources/tasks/gcp.yml
@@ -78,12 +78,18 @@
   when: gcp_service_account_contents is not defined
 
 # Project info
-- name: "GCP: Gather information about project"
-  google.cloud.gcp_resourcemanager_project_info:
-    auth_kind: "serviceaccount"
-    service_account_contents: "{{ gcp_service_account_contents }}"
-  register: project_info
-  when: gcp_project is not defined or gcp_project | length < 1
+- name: "Set variable: gcp_project"
+  ansible.builtin.set_fact:
+    gcp_project: "{{ (gcp_service_account_contents | from_json).get('project_id', '') }}"
+  no_log: true
+  when: gcp_project | default('') | length < 1
+
+- name: "Fail if GCP project was not found"
+  ansible.builtin.fail:
+    msg: >-
+      Unable to determine the GCP project.
+      Try to explicitly set the project ID in the gcp_project variable.
+  when: gcp_project | default('') | length < 1
 
 # Create (if state is present)
 - block:
@@ -108,7 +114,7 @@
       google.cloud.gcp_compute_network_info:
         auth_kind: "serviceaccount"
         service_account_contents: "{{ gcp_service_account_contents }}"
-        project: "{{ gcp_project | default(project_info.resources[0].projectNumber) }}"
+        project: "{{ gcp_project | default('') }}"
         filters:
           - name = "{{ gcp_network_name }}"
       register: gcp_network_info
@@ -117,7 +123,7 @@
       google.cloud.gcp_compute_subnetwork_info:
         auth_kind: "serviceaccount"
         service_account_contents: "{{ gcp_service_account_contents }}"
-        project: "{{ gcp_project | default(project_info.resources[0].projectNumber) }}"
+        project: "{{ gcp_project | default('') }}"
         region: "{{ (item | split('/regions/'))[1] | split('/subnetworks/') | first }}"
         filters:
           - name = "{{ item | split('/subnetworks/') | last }}"
@@ -140,7 +146,7 @@
       google.cloud.gcp_compute_firewall:
         auth_kind: "serviceaccount"
         service_account_contents: "{{ gcp_service_account_contents }}"
-        project: "{{ gcp_project | default(project_info.resources[0].projectNumber) }}"
+        project: "{{ gcp_project | default('') }}"
         name: "{{ patroni_cluster_name }}-ssh-public"
         description: "Firewall rule for public SSH access to Postgres cluster servers"
         allowed:
@@ -162,7 +168,7 @@
       google.cloud.gcp_compute_firewall:
         auth_kind: "serviceaccount"
         service_account_contents: "{{ gcp_service_account_contents }}"
-        project: "{{ gcp_project | default(project_info.resources[0].projectNumber) }}"
+        project: "{{ gcp_project | default('') }}"
         name: "{{ patroni_cluster_name }}-netdata-public"
         description: "Firewall rule for public Netdata monitoring access"
         allowed:
@@ -184,7 +190,7 @@
       google.cloud.gcp_compute_firewall:
         auth_kind: "serviceaccount"
         service_account_contents: "{{ gcp_service_account_contents }}"
-        project: "{{ gcp_project | default(project_info.resources[0].projectNumber) }}"
+        project: "{{ gcp_project | default('') }}"
         name: "{{ patroni_cluster_name }}-database-public"
         description: "Firewall rule for public database access"
         allowed:
@@ -214,7 +220,7 @@
       google.cloud.gcp_compute_firewall:
         auth_kind: "serviceaccount"
         service_account_contents: "{{ gcp_service_account_contents }}"
-        project: "{{ gcp_project | default(project_info.resources[0].projectNumber) }}"
+        project: "{{ gcp_project | default('') }}"
         name: "{{ patroni_cluster_name }}-firewall-rule"
         description: "Firewall rule for Postgres cluster"
         allowed:
@@ -255,7 +261,7 @@
       google.cloud.gcp_compute_firewall:
         auth_kind: "serviceaccount"
         service_account_contents: "{{ gcp_service_account_contents }}"
-        project: "{{ gcp_project | default(project_info.resources[0].projectNumber) }}"
+        project: "{{ gcp_project | default('') }}"
         name: "{{ patroni_cluster_name }}-lb-firewall-rule"
         description: "Firewall rule for Health Checks and Load Balancer access to the database"
         priority: 900
@@ -279,7 +285,7 @@
       google.cloud.gcp_compute_instance_info:
         auth_kind: "serviceaccount"
         service_account_contents: "{{ gcp_service_account_contents }}"
-        project: "{{ gcp_project | default(project_info.resources[0].projectNumber) }}"
+        project: "{{ gcp_project | default('') }}"
         zone: "{{ server_location + '-b' if not server_location is match('.*-[a-z]$') else server_location }}" # add "-b" if the zone is not defined
         filters:
           - "name = {{ server_name | lower }}{{ '%02d' % (idx + 1) }}"
@@ -293,7 +299,7 @@
       google.cloud.gcp_compute_instance:
         auth_kind: "serviceaccount"
         service_account_contents: "{{ gcp_service_account_contents }}"
-        project: "{{ gcp_project | default(project_info.resources[0].projectNumber) }}"
+        project: "{{ gcp_project | default('') }}"
         zone: "{{ server_location + '-b' if not server_location is match('.*-[a-z]$') else server_location }}" # add "-b" if the zone is not defined
         name: "{{ server_name | lower }}{{ '%02d' % (idx + 1) }}"
         machine_type: "{{ server_type }}"
@@ -342,7 +348,7 @@
       google.cloud.gcp_compute_disk:
         auth_kind: "serviceaccount"
         service_account_contents: "{{ gcp_service_account_contents }}"
-        project: "{{ gcp_project | default(project_info.resources[0].projectNumber) }}"
+        project: "{{ gcp_project | default('') }}"
         zone: "{{ server_location + '-b' if not server_location is match('.*-[a-z]$') else server_location }}"
         name: "{{ server_name | lower }}{{ '%02d' % (idx + 1) }}-storage"
         size_gb: "{{ volume_size | int }}"
@@ -363,7 +369,7 @@
           google.cloud.gcp_compute_instance_group:
             auth_kind: "serviceaccount"
             service_account_contents: "{{ gcp_service_account_contents }}"
-            project: "{{ gcp_project | default(project_info.resources[0].projectNumber) }}"
+            project: "{{ gcp_project | default('') }}"
             name: "{{ patroni_cluster_name }}"
             description: "{{ patroni_cluster_name }} instance group"
             region: "{{ region }}"
@@ -395,7 +401,7 @@
           google.cloud.gcp_compute_health_check:
             auth_kind: "serviceaccount"
             service_account_contents: "{{ gcp_service_account_contents }}"
-            project: "{{ gcp_project | default(project_info.resources[0].projectNumber) }}"
+            project: "{{ gcp_project | default('') }}"
             name: "{{ patroni_cluster_name }}-{{ item }}-hc"
             description: "{{ patroni_cluster_name }} {{ item }} health check"
             type: "{{ patroni_restapi_protocol | upper }}"
@@ -423,7 +429,7 @@
           google.cloud.gcp_compute_backend_service:
             auth_kind: "serviceaccount"
             service_account_contents: "{{ gcp_service_account_contents }}"
-            project: "{{ gcp_project | default(project_info.resources[0].projectNumber) }}"
+            project: "{{ gcp_project | default('') }}"
             name: "{{ patroni_cluster_name }}-{{ item }}"
             description: "{{ patroni_cluster_name }} {{ item }} backend"
             protocol: "TCP"
@@ -458,7 +464,7 @@
           google.cloud.gcp_compute_target_tcp_proxy:
             auth_kind: "serviceaccount"
             service_account_contents: "{{ gcp_service_account_contents }}"
-            project: "{{ gcp_project | default(project_info.resources[0].projectNumber) }}"
+            project: "{{ gcp_project | default('') }}"
             name: "{{ patroni_cluster_name }}-{{ item }}-proxy"
             description: "{{ patroni_cluster_name }} {{ item }} TCP Proxy"
             service:
@@ -480,7 +486,7 @@
           google.cloud.gcp_compute_global_address:
             auth_kind: "serviceaccount"
             service_account_contents: "{{ gcp_service_account_contents }}"
-            project: "{{ gcp_project | default(project_info.resources[0].projectNumber) }}"
+            project: "{{ gcp_project | default('') }}"
             name: "{{ patroni_cluster_name }}-{{ item }}-ip"
             description: "{{ patroni_cluster_name }} {{ item }} load balancer IP address"
             address_type: "EXTERNAL"
@@ -501,7 +507,7 @@
           google.cloud.gcp_compute_global_forwarding_rule:
             auth_kind: "serviceaccount"
             service_account_contents: "{{ gcp_service_account_contents }}"
-            project: "{{ gcp_project | default(project_info.resources[0].projectNumber) }}"
+            project: "{{ gcp_project | default('') }}"
             name: "{{ patroni_cluster_name }}-{{ item }}-fr"
             description: "{{ patroni_cluster_name }} {{ item }} forwarding rule"
             load_balancing_scheme: "EXTERNAL"
@@ -527,7 +533,7 @@
       google.cloud.gcp_storage_bucket:
         auth_kind: "serviceaccount"
         service_account_contents: "{{ gcp_service_account_contents }}"
-        project: "{{ gcp_project | default(project_info.resources[0].projectNumber) }}"
+        project: "{{ gcp_project | default('') }}"
         name: "{{ gcp_bucket_name }}"
         storage_class: "{{ gcp_bucket_storage_class }}"
         predefined_default_object_acl: "{{ gcp_bucket_default_object_acl }}"
@@ -611,7 +617,7 @@
       google.cloud.gcp_compute_instance:
         auth_kind: "serviceaccount"
         service_account_contents: "{{ gcp_service_account_contents }}"
-        project: "{{ gcp_project | default(project_info.resources[0].projectNumber) }}"
+        project: "{{ gcp_project | default('') }}"
         zone: "{{ server_location + '-b' if not server_location is match('.*-[a-z]$') else server_location }}" # add "-b" if the zone is not defined
         name: "{{ server_name | lower }}{{ '%02d' % (idx + 1) }}"
         state: absent
@@ -624,7 +630,7 @@
       google.cloud.gcp_compute_global_forwarding_rule:
         auth_kind: "serviceaccount"
         service_account_contents: "{{ gcp_service_account_contents }}"
-        project: "{{ gcp_project | default(project_info.resources[0].projectNumber) }}"
+        project: "{{ gcp_project | default('') }}"
         name: "{{ patroni_cluster_name }}-{{ item }}-fr"
         target: "/global/targetTcpProxies/{{ patroni_cluster_name }}-{{ item }}-proxy"
         state: absent
@@ -642,7 +648,7 @@
       google.cloud.gcp_compute_global_address:
         auth_kind: "serviceaccount"
         service_account_contents: "{{ gcp_service_account_contents }}"
-        project: "{{ gcp_project | default(project_info.resources[0].projectNumber) }}"
+        project: "{{ gcp_project | default('') }}"
         name: "{{ patroni_cluster_name }}-{{ item }}-ip"
         address_type: "EXTERNAL"
         ip_version: "IPV4"
@@ -661,7 +667,7 @@
       google.cloud.gcp_compute_target_tcp_proxy:
         auth_kind: "serviceaccount"
         service_account_contents: "{{ gcp_service_account_contents }}"
-        project: "{{ gcp_project | default(project_info.resources[0].projectNumber) }}"
+        project: "{{ gcp_project | default('') }}"
         name: "{{ patroni_cluster_name }}-{{ item }}-proxy"
         service:
           selfLink: "/global/backendServices/{{ patroni_cluster_name }}-{{ item }}"
@@ -680,7 +686,7 @@
       google.cloud.gcp_compute_backend_service:
         auth_kind: "serviceaccount"
         service_account_contents: "{{ gcp_service_account_contents }}"
-        project: "{{ gcp_project | default(project_info.resources[0].projectNumber) }}"
+        project: "{{ gcp_project | default('') }}"
         name: "{{ patroni_cluster_name }}-{{ item }}"
         state: absent
       loop:
@@ -697,7 +703,7 @@
       google.cloud.gcp_compute_health_check:
         auth_kind: "serviceaccount"
         service_account_contents: "{{ gcp_service_account_contents }}"
-        project: "{{ gcp_project | default(project_info.resources[0].projectNumber) }}"
+        project: "{{ gcp_project | default('') }}"
         name: "{{ patroni_cluster_name }}-{{ item }}-hc"
         state: absent
       loop:
@@ -714,7 +720,7 @@
       google.cloud.gcp_compute_instance_group:
         auth_kind: "serviceaccount"
         service_account_contents: "{{ gcp_service_account_contents }}"
-        project: "{{ gcp_project | default(project_info.resources[0].projectNumber) }}"
+        project: "{{ gcp_project | default('') }}"
         name: "{{ patroni_cluster_name }}"
         region: "{{ server_location[:-2] if server_location[-2:] | regex_search('-[a-z]$') else server_location }}"
         zone: "{{ server_location + '-b' if not server_location is match('.*-[a-z]$') else server_location }}"
@@ -724,7 +730,7 @@
       google.cloud.gcp_compute_firewall:
         auth_kind: "serviceaccount"
         service_account_contents: "{{ gcp_service_account_contents }}"
-        project: "{{ gcp_project | default(project_info.resources[0].projectNumber) }}"
+        project: "{{ gcp_project | default('') }}"
         name: "{{ patroni_cluster_name }}-ssh-public"
         state: absent
 
@@ -732,7 +738,7 @@
       google.cloud.gcp_compute_firewall:
         auth_kind: "serviceaccount"
         service_account_contents: "{{ gcp_service_account_contents }}"
-        project: "{{ gcp_project | default(project_info.resources[0].projectNumber) }}"
+        project: "{{ gcp_project | default('') }}"
         name: "{{ patroni_cluster_name }}-netdata-public"
         state: absent
 
@@ -740,7 +746,7 @@
       google.cloud.gcp_compute_firewall:
         auth_kind: "serviceaccount"
         service_account_contents: "{{ gcp_service_account_contents }}"
-        project: "{{ gcp_project | default(project_info.resources[0].projectNumber) }}"
+        project: "{{ gcp_project | default('') }}"
         name: "{{ patroni_cluster_name }}-database-public"
         state: absent
 
@@ -748,7 +754,7 @@
       google.cloud.gcp_compute_firewall:
         auth_kind: "serviceaccount"
         service_account_contents: "{{ gcp_service_account_contents }}"
-        project: "{{ gcp_project | default(project_info.resources[0].projectNumber) }}"
+        project: "{{ gcp_project | default('') }}"
         name: "{{ patroni_cluster_name }}-firewall-rule"
         state: absent
 
@@ -756,7 +762,7 @@
       google.cloud.gcp_compute_firewall:
         auth_kind: "serviceaccount"
         service_account_contents: "{{ gcp_service_account_contents }}"
-        project: "{{ gcp_project | default(project_info.resources[0].projectNumber) }}"
+        project: "{{ gcp_project | default('') }}"
         name: "{{ patroni_cluster_name }}-lb-firewall-rule"
         state: absent
 
@@ -764,7 +770,7 @@
       google.cloud.gcp_storage_bucket:
         auth_kind: "serviceaccount"
         service_account_contents: "{{ gcp_service_account_contents }}"
-        project: "{{ gcp_project | default(project_info.resources[0].projectNumber) }}"
+        project: "{{ gcp_project | default('') }}"
         name: "{{ gcp_bucket_name }}"
         state: absent
       when:

--- a/automation/roles/cloud_resources/tasks/gcp.yml
+++ b/automation/roles/cloud_resources/tasks/gcp.yml
@@ -82,6 +82,7 @@
   ansible.builtin.set_fact:
     gcp_project: "{{ (gcp_service_account_contents | from_json).get('project_id', '') }}"
   no_log: true
+  changed_when: false
   when: gcp_project | default('') | length < 1
 
 - name: "Fail if GCP project was not found"


### PR DESCRIPTION
Replace the GCP API call to retrieve project information with direct extraction from the service account JSON contents.

This eliminates an unnecessary API dependency and simplifies project ID retrieval. Updated all task project references to use the extracted project ID with an empty string fallback instead of the previous API response.