### PR TITLE
Set ssh_public_access default to true

### DIFF
--- a/automation/roles/cloud_resources/defaults/main.yml
+++ b/automation/roles/cloud_resources/defaults/main.yml
@@ -26,7 +26,7 @@ ssh_key_content: "" # (optional) If provided, the public key content will be add
 
 # Firewall / Security Group
 cloud_firewall: true # Specify 'false' if you don't want to configure Firewall rules, or want to manage them yourself.
-ssh_public_access: false # Allow public ssh access (required for deployment from the public network). Applicable if server_public_ip is set to true.
+ssh_public_access: true # Allow public ssh access (required for deployment from the public network). Applicable if server_public_ip is set to true.
 ssh_public_allowed_ips: "" # (comma-separated list of IP addresses in CIDR format) If empty, then public access is allowed for any IP address.
 netdata_public_access: false # Allow access to the Netdata monitoring from the public network (if 'netdata_install' is 'true').
 netdata_public_allowed_ips: "" # (comma-separated list of IP addresses in CIDR format) If empty, then public access is allowed for any IP address.


### PR DESCRIPTION
Enable public SSH access by default by changing `ssh_public_access` from `false` to `true` in `automation/roles/cloud_resources/defaults/main.yml`.

This improves the first-time Autobase experience, since the Console is often not running in the same network as the future PostgreSQL cluster. For production use, public SSH access should be disabled after the initial setup via the cluster settings.