### PR TITLE
Bump default etcd_version to 3.6.13

### DIFF
--- a/automation/roles/common/defaults/main.yml
+++ b/automation/roles/common/defaults/main.yml
@@ -133,7 +133,7 @@ dcs_exists: false # or 'true' if you do not want Autobase to deploy and manage e
 
 # if dcs_type: "etcd" and dcs_exists: false
 # renovate: datasource=github-releases depName=etcd-io/etcd extractVersion=^v(?<version>.*)$
-etcd_version: 3.5.27
+etcd_version: 3.6.13
 # Note: when etcd_installation_method: "rpm", the etcd package is installed from pgdg-rhel-extras,
 # unless install_postgresql_repo or install_postgresql_repo_extras are set to false.
 etcd_installation_method: "binary" # binary -> install from repo such as https://github.com, "{{ pkg_type }}" -> install from apt or yum repository

--- a/automation/roles/etcd/README.md
+++ b/automation/roles/etcd/README.md
@@ -6,7 +6,7 @@ This role installs and configures [etcd](https://etcd.io/), a distributed, relia
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `etcd_version` | `3.5.23` | etcd version. |
+| `etcd_version` | `3.6.13` | etcd version. |
 | `etcd_cluster_name` | `"etcd-{{ patroni_cluster_name }}"` | etcd cluster name (token). |
 | `etcd_bind_address` | `""` | IP address to bind etcd services (tasks fall back to `bind_address` when unset). |
 | `etcd_conf_dir` | `/etc/etcd` | etcd configuration directory. |


### PR DESCRIPTION
Update automation/roles/common/defaults/main.yml to change the default etcd_version from 3.5.27 to 3.6.13.

Closes: https://github.com/autobase-tech/autobase/issues/1602