### PR TITLE
Bump WAL-G version to 3.0.8

### DIFF
--- a/automation/roles/common/defaults/main.yml
+++ b/automation/roles/common/defaults/main.yml
@@ -651,14 +651,14 @@ patroni_watchdog_device: /dev/watchdog
 # If false, ensure that /dev/watchdog is available and can be used by the postgres user.
 patroni_watchdog_configure_softdog: true
 
-patroni_postgresql_use_pg_rewind: true # or 'false'
+patroni_postgresql_use_pg_rewind: true
 # try to use pg_rewind on the former leader when it joins cluster as a replica.
 
-patroni_remove_data_directory_on_rewind_failure: false # or 'true' (if use_pg_rewind: 'true')
+patroni_remove_data_directory_on_rewind_failure: false
 # avoid removing the data directory on an unsuccessful rewind
 # if 'true', Patroni will remove the PostgreSQL data directory and recreate the replica.
 
-patroni_remove_data_directory_on_diverged_timelines: false # or 'true'
+patroni_remove_data_directory_on_diverged_timelines: false
 # if 'true', Patroni will remove the PostgreSQL data directory and recreate the replica
 # if it notices that timelines are diverging and the former master can not start streaming from the new master.
 
@@ -707,8 +707,8 @@ postgresql_archive_command: >-
      else '/bin/true' }}
 
 # pg_probackup
-pg_probackup_install: false # or 'true'
-pg_probackup_install_from_postgrespro_repo: true # or 'false'
+pg_probackup_install: false
+pg_probackup_install_from_postgrespro_repo: true
 pg_probackup_version: "{{ postgresql_version }}"
 pg_probackup_instance: "pg_probackup_instance_name"
 pg_probackup_dir: "/mnt/backup_dir"
@@ -725,9 +725,9 @@ pg_probackup_restore_command: "{{ pg_probackup_command_parts | join('') }}"
 pg_probackup_patroni_cluster_bootstrap_command: "{{ pg_probackup_command_parts | join('') }}"
 
 # WAL-G
-wal_g_install: false # or 'true'
+wal_g_install: true
 # renovate: datasource=github-releases depName=wal-g/wal-g extractVersion=^v(?<version>.*)$
-wal_g_version: 3.0.7
+wal_g_version: 3.0.8
 wal_g_installation_method: "binary" # or "src" to build from source code
 wal_g_path: "/usr/local/bin/wal-g --config {{ postgresql_home_dir }}/.walg.json"
 wal_g_json: # config https://github.com/wal-g/wal-g#configuration
@@ -751,7 +751,7 @@ wal_g_patroni_cluster_bootstrap_recovery_conf:
   - recovery_target_action: "promote"
   - recovery_target_timeline: "latest"
 #  - recovery_target_time: "2020-06-01 11:00:00+03"  # Point-in-Time Recovery (example)
-wal_g_prefetch_dir_create: true # or 'false'
+wal_g_prefetch_dir_create: true
 wal_g_prefetch_dir_path: "{{ postgresql_home_dir }}/wal-g-prefetch"
 
 # Define job_parts outside of wal_g_cron_jobs
@@ -791,7 +791,7 @@ wal_g_cron_jobs:
 
 # pgBackRest
 pgbackrest_install: false # or 'true' to install and configure backups using pgBackRest
-pgbackrest_install_from_pgdg_repo: true # or 'false'
+pgbackrest_install_from_pgdg_repo: true
 pgbackrest_stanza: "{{ patroni_cluster_name }}" # specify your --stanza
 pgbackrest_repo_type: "posix" # or "s3", "gcs", "azure"
 pgbackrest_repo_host: "" # dedicated repository host (optional)
@@ -979,12 +979,12 @@ locale_gen:
 locale: "en_US.UTF-8"
 
 # Configure swap space
-swap_file_create: true # or 'false'
+swap_file_create: true
 swap_file_path: /swapfile
 swap_file_size_mb: "4096" # change this value for your system
 
 # Kernel parameters
-sysctl_set: true # or 'false'
+sysctl_set: true
 sysctl_file: /etc/sysctl.d/autobase.sysctl.conf
 sysctl_conf:
   etcd_cluster: []
@@ -1031,16 +1031,16 @@ sysctl_conf:
 huge_pages_auto_conf: true
 
 # Transparent Huge Pages
-disable_thp: true # or 'false'
+disable_thp: true
 
 # Max open file limit
-set_limits: true # or 'false'
+set_limits: true
 limits_user: "postgres"
 soft_nofile: 65536
 hard_nofile: 200000
 
 # I/O Scheduler (optional)
-set_scheduler: false # or 'true'
+set_scheduler: false
 scheduler:
   - { sched: "deadline", nr_requests: "1024", device: "sda" }
 #  - { sched: "noop" , nr_requests: "1024", device: "sdb" }

--- a/automation/roles/common/defaults/main.yml
+++ b/automation/roles/common/defaults/main.yml
@@ -725,7 +725,7 @@ pg_probackup_restore_command: "{{ pg_probackup_command_parts | join('') }}"
 pg_probackup_patroni_cluster_bootstrap_command: "{{ pg_probackup_command_parts | join('') }}"
 
 # WAL-G
-wal_g_install: true
+wal_g_install: false
 # renovate: datasource=github-releases depName=wal-g/wal-g extractVersion=^v(?<version>.*)$
 wal_g_version: 3.0.8
 wal_g_installation_method: "binary" # or "src" to build from source code

--- a/automation/roles/wal_g/tasks/main.yml
+++ b/automation/roles/wal_g/tasks/main.yml
@@ -81,7 +81,7 @@
       check_mode: false
       vars:
         wal_g_repo: "https://github.com/wal-g/wal-g/releases/download/v{{ wal_g_version | string | replace('v', '') }}"
-        wal_g_archive: "wal-g-pg-ubuntu-20.04-{{ wal_g_architecture_map[ansible_architecture] }}.tar.gz"
+        wal_g_archive: "wal-g-pg-20.04-{{ wal_g_architecture_map[ansible_architecture] }}.tar.gz"
       environment: "{{ proxy_env | default({}) }}"
 
     # Note: We are using a precompiled binary on Ubuntu 20.04,
@@ -89,7 +89,7 @@
 
     - name: Extract WAL-G into /tmp
       ansible.builtin.unarchive:
-        src: "/tmp/wal-g-pg-ubuntu-20.04-{{ wal_g_architecture_map[ansible_architecture] }}.tar.gz"
+        src: "/tmp/wal-g-pg-20.04-{{ wal_g_architecture_map[ansible_architecture] }}.tar.gz"
         dest: /tmp/
         extra_opts:
           - --no-same-owner
@@ -98,7 +98,7 @@
 
     - name: Copy WAL-G binary file to "{{ (wal_g_path | default('/usr/local/bin/wal-g')) | split(' ') | first }}"
       ansible.builtin.copy:
-        src: "/tmp/wal-g-pg-ubuntu-20.04-{{ wal_g_architecture_map[ansible_architecture] }}"
+        src: "/tmp/wal-g-pg-20.04-{{ wal_g_architecture_map[ansible_architecture] }}"
         dest: "{{ (wal_g_path | default('/usr/local/bin/wal-g')) | split(' ') | first }}"
         mode: u+x,g+x,o+x
         remote_src: true
@@ -236,39 +236,6 @@
     - wal_g_version is version('1.0', '>=')
     - (wal_g_installed_version.stderr is search("command not found") or wal_g_installed_version.stdout != wal_g_version)
     - not ansible_check_mode
-  tags: wal-g, wal_g, wal_g_install
-
-# older versions of WAL-G (for compatibility)
-- block:
-    - name: "Download WAL-G v{{ wal_g_version | default('') | string | replace('v', '') }} binary"
-      ansible.builtin.get_url:
-        url: "https://github.com/wal-g/wal-g/releases/download/v{{ wal_g_version | string | replace('v', '') }}/wal-g.linux-amd64.tar.gz"
-        dest: /tmp/
-        timeout: 60
-        validate_certs: false
-      environment: "{{ proxy_env | default({}) }}"
-      check_mode: false
-
-    - name: Extract WAL-G into /tmp
-      ansible.builtin.unarchive:
-        src: "/tmp/wal-g.linux-amd64.tar.gz"
-        dest: /tmp/
-        extra_opts:
-          - --no-same-owner
-        remote_src: true
-      check_mode: false
-
-    - name: Copy WAL-G binary file to "{{ (wal_g_path | default('/usr/local/bin/wal-g')) | split(' ') | first }}"
-      ansible.builtin.copy:
-        src: "/tmp/wal-g"
-        dest: "{{ (wal_g_path | default('/usr/local/bin/wal-g')) | split(' ') | first }}"
-        mode: u+x,g+x,o+x
-        remote_src: true
-  when:
-    - installation_method == "packages"
-    - wal_g_installation_method == "binary"
-    - wal_g_version is version('0.2.19', '<=')
-    - (wal_g_installed_version.stderr is search("command not found") or wal_g_installed_version.stdout != wal_g_version)
   tags: wal-g, wal_g, wal_g_install
 
 # Ensure the WAL_G_PREFETCH directory is created if configured


### PR DESCRIPTION
Bump WAL-G version from 3.0.7 to 3.0.8 in the common role defaults.

https://github.com/wal-g/wal-g/releases