### PR TITLE
Console: Add failure log link to failed cluster status

### DIFF
--- a/console/ui/src/shared/i18n/locales/en/clusters.json
+++ b/console/ui/src/shared/i18n/locales/en/clusters.json
@@ -4,6 +4,7 @@
   "createCluster": "Create cluster",
   "createPostgresCluster": "Create Postgres Cluster",
   "clusterName": "Cluster name",
+  "showFailureLog": "Show failure log",
   "creationTime": "Creation time",
   "servers": "Servers",
   "server": "Server",

--- a/console/ui/src/widgets/clusters-table/lib/hooks.tsx
+++ b/console/ui/src/widgets/clusters-table/lib/hooks.tsx
@@ -8,6 +8,51 @@ import { CircularProgress, Link, Stack, Typography } from '@mui/material';
 import { generateAbsoluteRouterPath } from '@shared/lib/functions.ts';
 import RouterPaths from '@app/router/routerPathsConfig';
 import { ClusterInfo } from '@shared/api/api/clusters.ts';
+import { useLazyGetOperationsQuery } from '@shared/api/api/operations.ts';
+import { selectCurrentProject } from '@app/redux/slices/projectSlice/projectSelectors.ts';
+import { useAppSelector } from '@app/redux/store/hooks.ts';
+import { handleRequestErrorCatch } from '@shared/lib/functions.ts';
+import { useNavigate } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+
+const OPERATIONS_START_DATE = new Date(0).toISOString();
+
+const FailedClusterStatusLink = ({ clusterName }: { clusterName: string }) => {
+  const { t } = useTranslation('clusters');
+  const navigate = useNavigate();
+  const currentProject = useAppSelector(selectCurrentProject);
+  const [getOperations, { isFetching }] = useLazyGetOperationsQuery();
+
+  const handleClick = async () => {
+    try {
+      const response = await getOperations({
+        projectId: Number(currentProject),
+        clusterName,
+        status: CLUSTER_STATUSES.FAILED,
+        startDate: OPERATIONS_START_DATE,
+        endDate: new Date().toISOString(),
+        sortBy: '-id',
+        limit: 1,
+        offset: 0,
+      }).unwrap();
+      const operationId = response.data?.[0]?.id;
+
+      if (operationId != null) {
+        navigate(
+          generateAbsoluteRouterPath(RouterPaths.operations.log.absolutePath, { operationId: String(operationId) }),
+        );
+      }
+    } catch (error) {
+      handleRequestErrorCatch(error);
+    }
+  };
+
+  return (
+    <Link component="button" type="button" onClick={handleClick} disabled={isFetching} title={t('showFailureLog')}>
+      {CLUSTER_STATUSES.FAILED}
+    </Link>
+  );
+};
 
 export const useGetClustersTableData = (data: ClusterInfo[]) =>
   useMemo(
@@ -34,7 +79,11 @@ export const useGetClustersTableData = (data: ClusterInfo[]) =>
             ) : clusterStatusColorNamesMap[cluster.status] ? (
               <img src={clusterStatusColorNamesMap[cluster.status]} alt={cluster.status} width="16px" />
             ) : null}
-            <Typography>{cluster.status}</Typography>
+            {cluster.status === CLUSTER_STATUSES.FAILED ? (
+              <FailedClusterStatusLink clusterName={cluster.name ?? ''} />
+            ) : (
+              <Typography>{cluster.status}</Typography>
+            )}
           </Stack>
         ),
         [CLUSTER_TABLE_COLUMN_NAMES.CREATION_TIME]: cluster.creation_time,


### PR DESCRIPTION
When a cluster has a FAILED status, users can now click on it to navigate to the operation failure log.

<img width="3584" height="2108" alt="image" src="https://github.com/user-attachments/assets/d4786a6a-4e73-4db3-8434-74aa79f9efd4" />
<img width="3584" height="2108" alt="image" src="https://github.com/user-attachments/assets/e4c95437-3f6c-4859-9fe2-a1cbcd93e260" />
