### PR TITLE
Console: Add SSH public key validation

### DIFF
--- a/console/ui/src/shared/i18n/locales/en/validation.json
+++ b/console/ui/src/shared/i18n/locales/en/validation.json
@@ -4,5 +4,6 @@
   "sshPortRange": "SSH port must be between 1 and 65535",
   "clusterShouldHaveProperNaming": "Cluster name should have only letters, numbers, hyphens and have length equal or less than 24",
   "shouldBeACorrectV4Ip": "The value should be a valid IPv4 address",
+  "invalidSshPublicKey": "Enter a valid SSH public key (one per line)",
   "configFormat": "Value should have \"key:value\" or \"key=value\" format"
 }

--- a/console/ui/src/shared/lib/sshPublicKeyValidation.test.ts
+++ b/console/ui/src/shared/lib/sshPublicKeyValidation.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { isValidSshPublicKeyList } from './sshPublicKeyValidation';
+
+const ED25519_KEY =
+  'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKLrH3fWU5tqdyCqADmTz7Auq3rggkI46hTbya3JWWdR developer@example.com';
+const RSA_KEY =
+  'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDud746JrldE09b1DUcG7rJCV6+1/BWn5Fk5QrzxVxEDug2f4PJn+mtjwnrrXNLhyckIf93MBjsBGRpXWBYFY0OY+V5a17LM4ZOXmA5qFIknOqrpizKnQXM2SvbiumFcVcmtV20K5QdQVGEKzCsVGM9OxTQmgF5Ttp0Ht+h7Wz45CU8eX5mClbBO9b0XLmr4WBFCz3W8z43dtOrsHVbX/i8CsQi2S5ZaPn3nhNdhPZXVc94vtkNxI2TPB+RHYxgm1CC6WNJFoSYUb78aK/fnPOqnIQAB1yW+tblH3kkNnoSID3Zc4HTAHguogMT1WlVswEv3a7GnWe4+aXTxLvE1N6z';
+
+const createOpenSshBlob = (keyType: string): string => {
+  const bytes = new TextEncoder().encode(keyType);
+  const blob = new Uint8Array(4 + bytes.length + 1);
+  new DataView(blob.buffer).setUint32(0, bytes.length);
+  blob.set(bytes, 4);
+  blob[blob.length - 1] = 1;
+
+  return btoa(String.fromCharCode(...blob));
+};
+
+describe('isValidSshPublicKeyList', () => {
+  it('accepts valid OpenSSH public keys, including a comment and multiple lines', () => {
+    expect(isValidSshPublicKeyList(`${ED25519_KEY}\n${RSA_KEY}\n`)).toBe(true);
+  });
+
+  it('rejects arbitrary text and a malformed key blob', () => {
+    expect(isValidSshPublicKeyList('hjvkhjvkgvkjv')).toBe(false);
+    expect(isValidSshPublicKeyList('ssh-ed25519 AAAA developer@example.com')).toBe(false);
+  });
+
+  it('rejects a key whose declared type differs from the encoded key type', () => {
+    expect(isValidSshPublicKeyList(ED25519_KEY.replace('ssh-ed25519', 'ssh-rsa'))).toBe(false);
+  });
+
+  it('accepts the certificate and extended key types supported by ansible.posix.authorized_key', () => {
+    for (const keyType of [
+      'ssh-ed25519-cert-v01@openssh.com',
+      'ssh-xmss@openssh.com',
+      'webauthn-sk-ecdsa-sha2-nistp256@openssh.com',
+    ]) {
+      expect(isValidSshPublicKeyList(`${keyType} ${createOpenSshBlob(keyType)}`)).toBe(true);
+    }
+  });
+});

--- a/console/ui/src/shared/lib/sshPublicKeyValidation.ts
+++ b/console/ui/src/shared/lib/sshPublicKeyValidation.ts
@@ -1,0 +1,164 @@
+// Keep this list aligned with ansible.posix.authorized_key's VALID_SSH2_KEY_TYPES.
+const SSH_KEY_TYPES = new Set([
+  'sk-ecdsa-sha2-nistp256@openssh.com',
+  'sk-ecdsa-sha2-nistp256-cert-v01@openssh.com',
+  'webauthn-sk-ecdsa-sha2-nistp256@openssh.com',
+  'ecdsa-sha2-nistp256',
+  'ecdsa-sha2-nistp256-cert-v01@openssh.com',
+  'ecdsa-sha2-nistp384',
+  'ecdsa-sha2-nistp384-cert-v01@openssh.com',
+  'ecdsa-sha2-nistp521',
+  'ecdsa-sha2-nistp521-cert-v01@openssh.com',
+  'sk-ssh-ed25519@openssh.com',
+  'sk-ssh-ed25519-cert-v01@openssh.com',
+  'ssh-ed25519',
+  'ssh-ed25519-cert-v01@openssh.com',
+  'ssh-dss',
+  'ssh-rsa',
+  'ssh-xmss@openssh.com',
+  'ssh-xmss-cert-v01@openssh.com',
+  'rsa-sha2-256',
+  'rsa-sha2-512',
+  'ssh-rsa-cert-v01@openssh.com',
+  'rsa-sha2-256-cert-v01@openssh.com',
+  'rsa-sha2-512-cert-v01@openssh.com',
+  'ssh-dss-cert-v01@openssh.com',
+]);
+
+const ECDSA_CURVES: Record<string, { name: string; pointLength: number }> = {
+  'ecdsa-sha2-nistp256': { name: 'nistp256', pointLength: 65 },
+  'ecdsa-sha2-nistp384': { name: 'nistp384', pointLength: 97 },
+  'ecdsa-sha2-nistp521': { name: 'nistp521', pointLength: 133 },
+};
+
+const SK_ECDSA_CURVE = { name: 'nistp256', pointLength: 65 };
+const RSA_SHA2_KEY_TYPES = new Set(['rsa-sha2-256', 'rsa-sha2-512']);
+
+const textDecoder = new TextDecoder();
+
+const decodeBase64 = (value: string): Uint8Array | null => {
+  if (!/^[A-Za-z0-9+/]+={0,2}$/.test(value) || value.length % 4 === 1) {
+    return null;
+  }
+
+  try {
+    const paddedValue = value.padEnd(Math.ceil(value.length / 4) * 4, '=');
+    const decoded = atob(paddedValue);
+
+    return Uint8Array.from(decoded, (character) => character.charCodeAt(0));
+  } catch {
+    return null;
+  }
+};
+
+const readUint32 = (value: Uint8Array, offset: number): number | null => {
+  if (offset + 4 > value.length) {
+    return null;
+  }
+
+  return (value[offset] * 2 ** 24 + value[offset + 1] * 2 ** 16 + value[offset + 2] * 2 ** 8 + value[offset + 3]) >>> 0;
+};
+
+const readString = (value: Uint8Array, offset: number): { value: Uint8Array; nextOffset: number } | null => {
+  const length = readUint32(value, offset);
+
+  if (length === null || offset + 4 + length > value.length) {
+    return null;
+  }
+
+  return { value: value.slice(offset + 4, offset + 4 + length), nextOffset: offset + 4 + length };
+};
+
+const readPositiveMpint = (value: Uint8Array, offset: number): number | null => {
+  const mpint = readString(value, offset);
+
+  if (!mpint?.value.length || mpint.value.every((byte) => byte === 0)) {
+    return null;
+  }
+
+  return mpint.nextOffset;
+};
+
+const isValidPublicKeyBlob = (keyType: string, encodedKey: string): boolean => {
+  const blob = decodeBase64(encodedKey);
+
+  if (!blob) {
+    return false;
+  }
+
+  const type = readString(blob, 0);
+
+  const blobKeyType = type && textDecoder.decode(type.value);
+
+  if (!type || (blobKeyType !== keyType && (!RSA_SHA2_KEY_TYPES.has(keyType) || blobKeyType !== 'ssh-rsa'))) {
+    return false;
+  }
+
+  if (keyType === 'ssh-ed25519') {
+    const publicKey = readString(blob, type.nextOffset);
+
+    return Boolean(publicKey && publicKey.value.length === 32 && publicKey.nextOffset === blob.length);
+  }
+
+  if (keyType === 'sk-ssh-ed25519@openssh.com') {
+    const publicKey = readString(blob, type.nextOffset);
+    const application = publicKey && readString(blob, publicKey.nextOffset);
+
+    return Boolean(
+      publicKey && publicKey.value.length === 32 && application?.value.length && application.nextOffset === blob.length,
+    );
+  }
+
+  if (keyType === 'ssh-rsa' || RSA_SHA2_KEY_TYPES.has(keyType)) {
+    const exponentOffset = readPositiveMpint(blob, type.nextOffset);
+    const modulusOffset = exponentOffset === null ? null : readPositiveMpint(blob, exponentOffset);
+
+    return modulusOffset === blob.length;
+  }
+
+  if (keyType === 'ssh-dss') {
+    let offset: number | null = type.nextOffset;
+
+    for (let index = 0; index < 4 && offset !== null; index += 1) {
+      offset = readPositiveMpint(blob, offset);
+    }
+
+    return offset === blob.length;
+  }
+
+  if (!ECDSA_CURVES[keyType] && keyType !== 'sk-ecdsa-sha2-nistp256@openssh.com') {
+    // Certificates, XMSS and WebAuthn key formats are accepted by Ansible. Their
+    // binary payloads vary, but all begin with the algorithm name parsed above.
+    return type.nextOffset < blob.length;
+  }
+
+  const isSecurityKey = keyType === 'sk-ecdsa-sha2-nistp256@openssh.com';
+  const curve = isSecurityKey ? SK_ECDSA_CURVE : ECDSA_CURVES[keyType];
+  const curveName = readString(blob, type.nextOffset);
+  const publicKey = curveName && readString(blob, curveName.nextOffset);
+  const application = isSecurityKey && publicKey && readString(blob, publicKey.nextOffset);
+
+  return Boolean(
+    curve &&
+    curveName &&
+    textDecoder.decode(curveName.value) === curve.name &&
+    publicKey &&
+    publicKey.value.length === curve.pointLength &&
+    publicKey.value[0] === 4 &&
+    (isSecurityKey
+      ? application && application.value.length && application.nextOffset === blob.length
+      : publicKey.nextOffset === blob.length),
+  );
+};
+
+const isValidSshPublicKeyLine = (line: string): boolean => {
+  const [keyType, encodedKey] = line.trim().split(/\s+/, 3);
+
+  return Boolean(keyType && encodedKey && SSH_KEY_TYPES.has(keyType) && isValidPublicKeyBlob(keyType, encodedKey));
+};
+
+export const isValidSshPublicKeyList = (value: string): boolean => {
+  const keys = value.split(/\r?\n/).filter((line) => line.trim());
+
+  return keys.length > 0 && keys.every(isValidSshPublicKeyLine);
+};

--- a/console/ui/src/widgets/cluster-form/model/validation.ts
+++ b/console/ui/src/widgets/cluster-form/model/validation.ts
@@ -17,6 +17,7 @@ import { DatabaseServersBlockSchema } from '@entities/cluster/database-servers-b
 import { SSH_KEY_BLOCK_FIELD_NAMES } from '@entities/cluster/ssh-key-block/model/const.ts';
 import { LoadBalancerBlockSchema } from '@entities/cluster/load-balancers-block/model/validation.ts';
 import { DcsBlockSchema } from '@entities/cluster/expert-mode/dcs-block/model/validation.ts';
+import { isValidSshPublicKeyList } from '@shared/lib/sshPublicKeyValidation.ts';
 
 const CloudFormSchema = (t: TFunction) =>
   yup.object({
@@ -73,7 +74,14 @@ const CloudFormSchema = (t: TFunction) =>
       .mixed()
       .when(CLUSTER_FORM_FIELD_NAMES.PROVIDER, ([provider], schema) =>
         provider?.code !== PROVIDERS.LOCAL
-          ? yup.string().required(t('requiredField', { ns: 'validation' }))
+          ? yup
+              .string()
+              .required(t('requiredField', { ns: 'validation' }))
+              .test(
+                'is valid SSH public key',
+                t('invalidSshPublicKey', { ns: 'validation' }),
+                (value) => !value || isValidSshPublicKeyList(value),
+              )
           : schema.notRequired(),
       ),
   });


### PR DESCRIPTION
Implement SSH public key validation with comprehensive binary parsing of OpenSSH key formats. Supports multiple key types including ed25519, RSA, ECDSA, and certificate variants. Integrates validation into cluster form with appropriate error messaging.

Not correct:
<img width="2192" height="372" alt="image" src="https://github.com/user-attachments/assets/b62fb098-8c45-461a-9d9b-de7935c565c8" />

Correct:
<img width="2176" height="318" alt="image" src="https://github.com/user-attachments/assets/fcbb2642-81bb-49fc-a4ce-a711f38a2011" />
