### PR TITLE
Console: Add support for local disk storage

### DIFF
--- a/automation/roles/cloud_resources/README.md
+++ b/automation/roles/cloud_resources/README.md
@@ -35,8 +35,8 @@ Provision the PostgreSQL cluster infrastructure in public clouds (AWS, GCP, Azur
 | server_network | string | "" | Existing network/subnet/VPC. If provided, the server will be added to this network (needs to be created beforehand) |
 | server_spot | bool | false | Spot/preemptible where supported. Applicable for AWS, GCP, Azure |
 | server_public_ip | bool | true | Assign public IPs to servers |
-| volume_type | string | "" | Data disk type. Defaults: 'gp3' for AWS, 'pd-ssd' for GCP, 'StandardSSD_LRS' for Azure |
-| volume_size | int | 100 | Data disk size (GB) |
+| volume_type | string | "" | Data disk type. Set to `local` to use the system disk and skip creating an external data disk. Defaults: 'gp3' for AWS, 'pd-ssd' for GCP, 'StandardSSD_LRS' for Azure |
+| volume_size | int | 100 | Data disk size (GB). Set to `0` to use the system disk; this is equivalent to `volume_type: local` |
 | system_volume_type | string | "" | System disk type. Defaults: 'gp3' for AWS, 'pd-ssd' for GCP, 'StandardSSD_LRS' for Azure |
 | system_volume_size | int | 100 | System disk size (GB) |
 | ssh_key_name | string | "" | Name of the SSH key to be added to the server. Note: If not provided, all cloud available SSH keys will be added (applicable to DigitalOcean, Hetzner) |

--- a/automation/roles/cloud_resources/defaults/main.yml
+++ b/automation/roles/cloud_resources/defaults/main.yml
@@ -12,14 +12,16 @@ server_network: "" # (optional) If provided, the server will be added to this ne
 server_spot: false # Spot instance. Applicable for AWS, GCP, Azure.
 server_public_ip: true # Assign public IPs; set false only when the control host can reach private IPs and outbound egress is provided separately (for example, NAT).
 
-volume_type: "" # Volume type. Defaults: 'gp3' for AWS, 'pd-ssd' for GCP, 'StandardSSD_LRS' for Azure.
-volume_size: 100 # Storage size for the data directory (in gigabytes).
+volume_type: "" # Data disk type. Set to 'local' to use the system disk and skip creating an external data disk.
+volume_size: 100 # Storage size for the data directory (GB). Set to 0 to use the system disk.
 volume_iops: 3000 # Volume IOPS. Applicable for AWS if volume_type is 'io1', 'io2' or 'gp3'.
 volume_throughput: 125 # Volume throughput (in MiB/s). Applicable for AWS if volume_type is 'gp3'.
 system_volume_type: "" # System volume type. Defaults: 'gp3' for AWS, 'pd-ssd' for GCP, 'StandardSSD_LRS' for Azure.
 system_volume_size: 100 # System volume size (in gigabytes). Applicable for AWS, GCP, Azure.
 system_volume_iops: 3000 # System volume IOPS. Applicable for AWS if system_volume_type is 'io1', 'io2' or 'gp3'.
 system_volume_throughput: 125 # System volume throughput (in MiB/s). Applicable for AWS if system_volume_type is 'gp3'.
+
+use_local_disk: "{{ volume_type | default('') | lower == 'local' or volume_size | default(100) | int == 0 }}" # Use local disk if volume_type is 'local' or volume_size is 0.
 
 ssh_key_name: "" # Name of the SSH key to be added to the server. Note: If not provided, all cloud available SSH keys will be added (applicable to DigitalOcean, Hetzner).
 ssh_key_content: "" # (optional) If provided, the public key content will be added to the cloud (directly to the server for GCP).

--- a/automation/roles/cloud_resources/tasks/aws.yml
+++ b/automation/roles/cloud_resources/tasks/aws.yml
@@ -284,21 +284,7 @@
                 groups: "{{ ([] if not cloud_firewall | bool else [ec2_security_group_result.group_id]) }}"
                 assign_public_ip: "{{ server_public_ip | bool }}"
                 delete_on_termination: true
-            volumes:
-              - device_name: /dev/sda1
-                ebs:
-                  volume_type: "{{ system_volume_type | default('gp3', true) }}"
-                  volume_size: "{{ system_volume_size | default(80) | int }}"
-                  iops: "{{ system_volume_iops | default(3000) | int if system_volume_type | default('gp3', true) in ['gp3', 'io1', 'io2'] else omit }}"
-                  throughput: "{{ (system_volume_throughput | default(125) | int) if (system_volume_type | default('gp3', true)) == 'gp3' else omit }}"
-                  delete_on_termination: true
-              - device_name: /dev/sdb
-                ebs:
-                  volume_type: "{{ volume_type | default('gp3', true) }}"
-                  volume_size: "{{ volume_size | int }}"
-                  iops: "{{ volume_iops | default(3000) | int if volume_type | default('gp3', true) in ['gp3', 'io1', 'io2'] else omit }}"
-                  throughput: "{{ (volume_throughput | default(125) | int) if (volume_type | default('gp3', true)) == 'gp3' else omit }}"
-                  delete_on_termination: true
+            volumes: "{{ [system_volume] + ([] if use_local_disk | bool else [data_volume]) }}"
             tags:
               Name: "{{ server_name | lower }}{{ '%02d' % (idx + 1) }}"
               Cluster: "{{ patroni_cluster_name }}"
@@ -310,6 +296,23 @@
           retries: 3
           delay: 10
           when: ec2_instance_info.results[idx].instances | length == 0 # only if instance does not exist
+          vars:
+            system_volume:
+              device_name: /dev/sda1
+              ebs:
+                volume_type: "{{ system_volume_type | default('gp3', true) }}"
+                volume_size: "{{ system_volume_size | default(80) | int }}"
+                iops: "{{ system_volume_iops | default(3000) | int if system_volume_type | default('gp3', true) in ['gp3', 'io1', 'io2'] else omit }}"
+                throughput: "{{ (system_volume_throughput | default(125) | int) if (system_volume_type | default('gp3', true)) == 'gp3' else omit }}"
+                delete_on_termination: true
+            data_volume:
+              device_name: /dev/sdb
+              ebs:
+                volume_type: "{{ volume_type | default('gp3', true) }}"
+                volume_size: "{{ volume_size | int }}"
+                iops: "{{ volume_iops | default(3000) | int if volume_type | default('gp3', true) in ['gp3', 'io1', 'io2'] else omit }}"
+                throughput: "{{ (volume_throughput | default(125) | int) if (volume_type | default('gp3', true)) == 'gp3' else omit }}"
+                delete_on_termination: true
       when: not server_spot | default(aws_ec2_spot_instance | default(false)) | bool
 
     # Spot instance (if 'server_spot' is 'true')
@@ -347,21 +350,7 @@
                   associate_public_ip_address: "{{ server_public_ip | bool }}"
                   delete_on_termination: true
                   device_index: 0
-              block_device_mappings:
-                - device_name: /dev/sda1
-                  ebs:
-                    volume_type: "{{ volume_type | default('gp3', true) }}"
-                    volume_size: 100 # TODO: use 'system_volume_size' variable (https://github.com/ansible-collections/amazon.aws/issues/1949)
-                    iops: "{{ system_volume_iops | default(3000) | int if system_volume_type | default('gp3', true) in ['gp3', 'io1', 'io2'] else omit }}"
-                    throughput: "{{ (system_volume_throughput | default(125) | int) if (system_volume_type | default('gp3', true)) == 'gp3' else omit }}"
-                    delete_on_termination: true
-                - device_name: /dev/sdb
-                  ebs:
-                    volume_type: "{{ volume_type | default('gp3', true) }}"
-                    volume_size: 10 # will be redefined via the ec2_vol module
-                    iops: "{{ volume_iops | default(3000) | int if volume_type | default('gp3', true) in ['gp3', 'io1', 'io2'] else omit }}"
-                    throughput: "{{ (volume_throughput | default(125) | int) if (volume_type | default('gp3', true)) == 'gp3' else omit }}"
-                    delete_on_termination: true
+              block_device_mappings: "{{ [system_volume] + ([] if use_local_disk | bool else [data_volume]) }}"
             tags:
               Name: "{{ server_name | lower }}{{ '%02d' % (idx + 1) }}"
               Cluster: "{{ patroni_cluster_name }}"
@@ -371,6 +360,23 @@
             label: "{{ server_name | lower }}{{ '%02d' % (idx + 1) }}"
           register: ec2_spot_request_result
           when: item.instances[0] | default('') | length < 1
+          vars:
+            system_volume:
+              device_name: /dev/sda1
+              ebs:
+                volume_type: "{{ system_volume_type | default('gp3', true) }}"
+                volume_size: 100 # TODO: use 'system_volume_size' variable (https://github.com/ansible-collections/amazon.aws/issues/1949)
+                iops: "{{ system_volume_iops | default(3000) | int if system_volume_type | default('gp3', true) in ['gp3', 'io1', 'io2'] else omit }}"
+                throughput: "{{ (system_volume_throughput | default(125) | int) if (system_volume_type | default('gp3', true)) == 'gp3' else omit }}"
+                delete_on_termination: true
+            data_volume:
+              device_name: /dev/sdb
+              ebs:
+                volume_type: "{{ volume_type | default('gp3', true) }}"
+                volume_size: 10 # will be redefined via the ec2_vol module
+                iops: "{{ volume_iops | default(3000) | int if volume_type | default('gp3', true) in ['gp3', 'io1', 'io2'] else omit }}"
+                throughput: "{{ (volume_throughput | default(125) | int) if (volume_type | default('gp3', true)) == 'gp3' else omit }}"
+                delete_on_termination: true
 
         - name: "AWS: Wait for EC2 Spot instance to be created"
           amazon.aws.ec2_instance:
@@ -458,6 +464,7 @@
           }}
       register: ec2_volume_resize_result
       when:
+        - not use_local_disk | bool
         - server_result.results is defined
         - item.instances is defined
         - data_volume.ebs.volume_id | default('') | length > 0

--- a/automation/roles/cloud_resources/tasks/azure.yml
+++ b/automation/roles/cloud_resources/tasks/azure.yml
@@ -304,10 +304,7 @@
         os_type: Linux
         os_disk_size_gb: "{{ system_volume_size | default('80') }}" # system disk size
         managed_disk_type: "{{ system_volume_type | default('StandardSSD_LRS', true) }}"
-        data_disks:
-          - lun: 0
-            disk_size_gb: "{{ volume_size | int }}"
-            managed_disk_type: "{{ volume_type | default('StandardSSD_LRS', true) }}"
+        data_disks: "{{ [] if use_local_disk | bool else [data_disk] }}"
         network_interface_names:
           - "{{ server_name | lower }}{{ '%02d' % (idx + 1) }}-network-interface"
         tags:
@@ -317,6 +314,11 @@
         index_var: idx
         label: "{{ server_name | lower }}{{ '%02d' % (idx + 1) }}"
       register: server_result
+      vars:
+        data_disk:
+          lun: 0
+          disk_size_gb: "{{ volume_size | int }}"
+          managed_disk_type: "{{ volume_type | default('StandardSSD_LRS', true) }}"
 
     # Required to allow data disk size to be changed after deployment without deallocating the VM.
     - name: "Azure: Ensure data disk size"
@@ -330,6 +332,7 @@
       loop_control:
         label: "{{ item.ansible_facts.azure_vm.storage_profile.data_disks[0].name | default('data-disk') }}"
       when:
+        - not use_local_disk | bool
         - item.ansible_facts.azure_vm.storage_profile.data_disks is defined
         - item.ansible_facts.azure_vm.storage_profile.data_disks | length > 0
         - item.ansible_facts.azure_vm.storage_profile.data_disks[0].managed_disk is defined

--- a/automation/roles/cloud_resources/tasks/digitalocean.yml
+++ b/automation/roles/cloud_resources/tasks/digitalocean.yml
@@ -534,6 +534,7 @@
         index_var: idx
         label: "{{ server_name | lower }}{{ '%02d' % (idx + 1) }}-storage"
       register: block_storage_result
+      when: not use_local_disk | bool
 
     - name: "DigitalOcean: Attach Block Storage to Droplet"
       community.digitalocean.digital_ocean_block_storage:
@@ -547,7 +548,9 @@
       loop_control:
         index_var: idx
         label: "{{ server_name | lower }}{{ '%02d' % (idx + 1) }}-storage"
-      when: droplet_result.results is defined
+      when:
+        - not use_local_disk | bool
+        - droplet_result.results is defined
 
     # Load Balancer
     - name: "Set variable: digital_ocean_load_balancer_port"

--- a/automation/roles/cloud_resources/tasks/gcp.yml
+++ b/automation/roles/cloud_resources/tasks/gcp.yml
@@ -305,21 +305,7 @@
         zone: "{{ server_location + '-b' if not server_location is match('.*-[a-z]$') else server_location }}" # add "-b" if the zone is not defined
         name: "{{ server_name | lower }}{{ '%02d' % (idx + 1) }}"
         machine_type: "{{ server_type }}"
-        disks:
-          - device_name: "{{ server_name | lower }}{{ '%02d' % (idx + 1) }}-system"
-            auto_delete: true
-            boot: true
-            initialize_params:
-              disk_name: "{{ server_name | lower }}{{ '%02d' % (idx + 1) }}-system"
-              source_image: "{{ server_image }}"
-              disk_size_gb: "{{ system_volume_size | default('80') }}" # system disk size
-              disk_type: "{{ system_volume_type | default('pd-ssd', true) }}"
-          - device_name: "{{ server_name | lower }}{{ '%02d' % (idx + 1) }}-storage"
-            auto_delete: true
-            initialize_params:
-              disk_name: "{{ server_name | lower }}{{ '%02d' % (idx + 1) }}-storage"
-              disk_size_gb: "{{ volume_size | int }}"
-              disk_type: "{{ volume_type | default('pd-ssd', true) }}"
+        disks: "{{ [system_disk] + ([] if use_local_disk | bool else [data_disk]) }}"
         network_interfaces:
           - network:
               selfLink: "global/networks/{{ gcp_network_name }}"
@@ -344,6 +330,23 @@
       until: server_result is success
       delay: 10
       retries: 3
+      vars:
+        system_disk:
+          device_name: "{{ server_name | lower }}{{ '%02d' % (idx + 1) }}-system"
+          auto_delete: true
+          boot: true
+          initialize_params:
+            disk_name: "{{ server_name | lower }}{{ '%02d' % (idx + 1) }}-system"
+            source_image: "{{ server_image }}"
+            disk_size_gb: "{{ system_volume_size | default('80') }}"
+            disk_type: "{{ system_volume_type | default('pd-ssd', true) }}"
+        data_disk:
+          device_name: "{{ server_name | lower }}{{ '%02d' % (idx + 1) }}-storage"
+          auto_delete: true
+          initialize_params:
+            disk_name: "{{ server_name | lower }}{{ '%02d' % (idx + 1) }}-storage"
+            disk_size_gb: "{{ volume_size | int }}"
+            disk_type: "{{ volume_type | default('pd-ssd', true) }}"
 
     # Required to allow data disk size to be changed after deployment.
     - name: "GCP: Ensure data disk size"
@@ -360,6 +363,7 @@
       loop_control:
         index_var: idx
         label: "{{ server_name | lower }}{{ '%02d' % (idx + 1) }}-storage"
+      when: not use_local_disk | bool
 
     # Load Balancer
     # This block creates Global External classic proxy Network Load Balancer.

--- a/automation/roles/cloud_resources/tasks/hetzner.yml
+++ b/automation/roles/cloud_resources/tasks/hetzner.yml
@@ -528,6 +528,7 @@
       loop_control:
         index_var: idx
         label: "{{ server_name | lower }}{{ '%02d' % (idx + 1) }}-storage"
+      when: not use_local_disk | bool
 
     # Load Balancer
     - name: "Hetzner Cloud: Create or modify Load Balancer"

--- a/automation/roles/common/defaults/main.yml
+++ b/automation/roles/common/defaults/main.yml
@@ -279,7 +279,7 @@ postgresql_cluster_name: "{{ 'main' if ansible_os_family == 'Debian' else 'data'
 postgresql_home_dir: "{{ '/var/lib/postgresql' if ansible_os_family == 'Debian' else '/var/lib/pgsql' }}"
 # You can specify custom data dir path. Example: "/pgdata/{{ postgresql_version }}/main"
 postgresql_data_dir: "\
-  {% if cloud_provider | default('') | length > 0 %}\
+  {% if cloud_provider | default('') | length > 0 and volume_type | default('') | lower != 'local' %}\
   {{ postgresql_data_dir_mount_path | default('/pgdata') }}/{{ postgresql_version }}/{{ postgresql_cluster_name }}\
   {% else %}\
   {{ postgresql_home_dir }}/{{ postgresql_version }}/{{ postgresql_cluster_name }}\

--- a/automation/roles/common/defaults/main.yml
+++ b/automation/roles/common/defaults/main.yml
@@ -279,7 +279,7 @@ postgresql_cluster_name: "{{ 'main' if ansible_os_family == 'Debian' else 'data'
 postgresql_home_dir: "{{ '/var/lib/postgresql' if ansible_os_family == 'Debian' else '/var/lib/pgsql' }}"
 # You can specify custom data dir path. Example: "/pgdata/{{ postgresql_version }}/main"
 postgresql_data_dir: "\
-  {% if cloud_provider | default('') | length > 0 and volume_type | default('') | lower != 'local' %}\
+  {% if cloud_provider | default('') | length > 0 %}\
   {{ postgresql_data_dir_mount_path | default('/pgdata') }}/{{ postgresql_version }}/{{ postgresql_cluster_name }}\
   {% else %}\
   {{ postgresql_home_dir }}/{{ postgresql_version }}/{{ postgresql_cluster_name }}\

--- a/automation/roles/mount/tasks/main.yml
+++ b/automation/roles/mount/tasks/main.yml
@@ -25,7 +25,10 @@
         executable: /bin/bash
       register: lsblk_disk
       changed_when: false
-      when: (cloud_provider | default('') | length > 0) and (mount | first | default({})).src | default('') | length < 1
+      when:
+        - volume_type | default('') | lower != 'local'
+        - volume_size | default(100) | int != 0
+        - (cloud_provider | default('') | length > 0) and (mount | first | default({})).src | default('') | length < 1
 
     # Stop if empty volume is not detected
     - name: Empty volume is not detected

--- a/console/ui/src/entities/cluster/expert-mode/data-directory-block/ui/index.tsx
+++ b/console/ui/src/entities/cluster/expert-mode/data-directory-block/ui/index.tsx
@@ -1,4 +1,4 @@
-import { FC, useEffect, useRef } from 'react';
+import { FC, useEffect } from 'react';
 import { Box, TextField, Typography } from '@mui/material';
 import { Controller, useFormContext, useWatch } from 'react-hook-form';
 import { DATA_DIRECTORY_FIELD_NAMES } from '@entities/cluster/expert-mode/data-directory-block/model/const.ts';
@@ -15,18 +15,10 @@ const DataDirectoryBlock: FC = () => {
   } = useFormContext();
 
   const watchPostgresVersion = useWatch({ name: CLUSTER_FORM_FIELD_NAMES.POSTGRES_VERSION });
-  const watchDataDirectory = useWatch({ name: DATA_DIRECTORY_FIELD_NAMES.DATA_DIRECTORY });
-  const previousPostgresVersion = useRef(watchPostgresVersion);
 
   useEffect(() => {
-    const dataDirectory = `/pgdata/${watchPostgresVersion ?? 18}/main`;
-    const previousDefaultDirectory = `/pgdata/${previousPostgresVersion.current ?? 18}/main`;
-
-    if (!watchDataDirectory || (watchDataDirectory === previousDefaultDirectory && watchDataDirectory !== dataDirectory)) {
-      setValue(DATA_DIRECTORY_FIELD_NAMES.DATA_DIRECTORY, dataDirectory);
-    }
-    previousPostgresVersion.current = watchPostgresVersion;
-  }, [setValue, watchDataDirectory, watchPostgresVersion]);
+    setValue(DATA_DIRECTORY_FIELD_NAMES.DATA_DIRECTORY, `/pgdata/${watchPostgresVersion ?? 18}/main`);
+  }, [setValue, watchPostgresVersion]);
 
   return (
     <Box>

--- a/console/ui/src/entities/cluster/expert-mode/data-directory-block/ui/index.tsx
+++ b/console/ui/src/entities/cluster/expert-mode/data-directory-block/ui/index.tsx
@@ -1,4 +1,4 @@
-import { FC, useEffect } from 'react';
+import { FC, useEffect, useRef } from 'react';
 import { Box, TextField, Typography } from '@mui/material';
 import { Controller, useFormContext, useWatch } from 'react-hook-form';
 import { DATA_DIRECTORY_FIELD_NAMES } from '@entities/cluster/expert-mode/data-directory-block/model/const.ts';
@@ -15,10 +15,18 @@ const DataDirectoryBlock: FC = () => {
   } = useFormContext();
 
   const watchPostgresVersion = useWatch({ name: CLUSTER_FORM_FIELD_NAMES.POSTGRES_VERSION });
+  const watchDataDirectory = useWatch({ name: DATA_DIRECTORY_FIELD_NAMES.DATA_DIRECTORY });
+  const previousPostgresVersion = useRef(watchPostgresVersion);
 
   useEffect(() => {
-    setValue(DATA_DIRECTORY_FIELD_NAMES.DATA_DIRECTORY, `/pgdata/${watchPostgresVersion ?? 18}/main`);
-  }, [watchPostgresVersion]);
+    const dataDirectory = `/pgdata/${watchPostgresVersion ?? 18}/main`;
+    const previousDefaultDirectory = `/pgdata/${previousPostgresVersion.current ?? 18}/main`;
+
+    if (!watchDataDirectory || (watchDataDirectory === previousDefaultDirectory && watchDataDirectory !== dataDirectory)) {
+      setValue(DATA_DIRECTORY_FIELD_NAMES.DATA_DIRECTORY, dataDirectory);
+    }
+    previousPostgresVersion.current = watchPostgresVersion;
+  }, [setValue, watchDataDirectory, watchPostgresVersion]);
 
   return (
     <Box>

--- a/console/ui/src/entities/cluster/storage-block/ui/index.tsx
+++ b/console/ui/src/entities/cluster/storage-block/ui/index.tsx
@@ -105,15 +105,20 @@ const StorageBlock: FC = () => {
                       label: t('volumeType'),
                       options: volumeTypes,
                     },
-                  ]
-                    .filter(({ fieldName }) => !isSystemDisk || fieldName !== STORAGE_BLOCK_FIELDS.FILE_SYSTEM_TYPE)
-                    .map(({ fieldName, label, options }) => (
+                  ].map(({ fieldName, label, options }) => (
                     <Controller
                       key={fieldName}
                       control={control}
                       name={fieldName}
                       render={({ field }) => (
-                        <FormControl fullWidth size="small">
+                        <FormControl
+                          fullWidth
+                          size="small"
+                          sx={
+                            isSystemDisk && fieldName === STORAGE_BLOCK_FIELDS.FILE_SYSTEM_TYPE
+                              ? { visibility: 'hidden' }
+                              : undefined
+                          }>
                           <InputLabel>{label}</InputLabel>
                           <Select
                             {...field}
@@ -145,7 +150,7 @@ const StorageBlock: FC = () => {
                         </FormControl>
                       )}
                     />
-                    ))}
+                  ))}
                 </Stack>
               ) : null
             }

--- a/console/ui/src/entities/cluster/storage-block/ui/index.tsx
+++ b/console/ui/src/entities/cluster/storage-block/ui/index.tsx
@@ -23,6 +23,7 @@ const StorageBlock: FC = () => {
 
   const watchProvider = useWatch({ name: CLUSTER_FORM_FIELD_NAMES.PROVIDER });
   const watchVolume = useWatch({ name: STORAGE_BLOCK_FIELDS.VOLUME_TYPE });
+  const isSystemDisk = watchVolume === LOCAL_VOLUME_TYPE;
 
   useEffect(() => {
     const volumes = watchProvider?.volumes;
@@ -104,7 +105,9 @@ const StorageBlock: FC = () => {
                       label: t('volumeType'),
                       options: volumeTypes,
                     },
-                  ].map(({ fieldName, label, options }) => (
+                  ]
+                    .filter(({ fieldName }) => !isSystemDisk || fieldName !== STORAGE_BLOCK_FIELDS.FILE_SYSTEM_TYPE)
+                    .map(({ fieldName, label, options }) => (
                     <Controller
                       key={fieldName}
                       control={control}
@@ -142,7 +145,7 @@ const StorageBlock: FC = () => {
                         </FormControl>
                       )}
                     />
-                  ))}
+                    ))}
                 </Stack>
               ) : null
             }

--- a/console/ui/src/entities/cluster/storage-block/ui/index.tsx
+++ b/console/ui/src/entities/cluster/storage-block/ui/index.tsx
@@ -23,11 +23,12 @@ const StorageBlock: FC = () => {
 
   const watchProvider = useWatch({ name: CLUSTER_FORM_FIELD_NAMES.PROVIDER });
   const watchVolume = useWatch({ name: STORAGE_BLOCK_FIELDS.VOLUME_TYPE });
-  const watchStorageAmount = useWatch({ name: STORAGE_BLOCK_FIELDS.STORAGE_AMOUNT });
 
   useEffect(() => {
     const volumes = watchProvider?.volumes;
-    setStorage(volumes?.find((volume) => volume?.is_default) ?? {});
+    const defaultVolume = volumes?.find((volume) => volume?.is_default) ?? volumes?.[0];
+    setStorage(defaultVolume ?? {});
+    setValue(STORAGE_BLOCK_FIELDS.STORAGE_AMOUNT, defaultVolume?.min_size ?? 1);
 
     setVolumeTypes(
       [
@@ -39,29 +40,22 @@ const StorageBlock: FC = () => {
     setValue(
       // imperatively set a volume type when user changes provider
       STORAGE_BLOCK_FIELDS.VOLUME_TYPE,
-      volumes?.find((volume) => volume?.is_default)?.volume_type ?? volumes?.[0]?.volume_type,
+      defaultVolume?.volume_type,
     );
   }, [setValue, t, watchProvider?.volumes]);
 
   useEffect(() => {
     if (watchVolume === LOCAL_VOLUME_TYPE) {
-      setStorage({});
       setValue(STORAGE_BLOCK_FIELDS.STORAGE_AMOUNT, 0);
       return;
     }
 
-    // set selected storage size sa minimum available for selected volume
+    // Update the slider bounds for the selected volume. The size itself is set
+    // by the volume-type control, so manually typed values are not overwritten.
     const volumes = watchProvider?.volumes;
     const storage = volumes?.find((volume) => volume?.volume_type === watchVolume);
     setStorage(storage);
-    setValue(STORAGE_BLOCK_FIELDS.STORAGE_AMOUNT, storage?.min_size ?? 1);
   }, [setValue, watchProvider?.volumes, watchVolume]);
-
-  useEffect(() => {
-    if (watchStorageAmount === 0 && watchVolume !== LOCAL_VOLUME_TYPE) {
-      setValue(STORAGE_BLOCK_FIELDS.VOLUME_TYPE, LOCAL_VOLUME_TYPE);
-    }
-  }, [setValue, watchStorageAmount, watchVolume]);
 
   return (
     <Box>
@@ -71,15 +65,26 @@ const StorageBlock: FC = () => {
       <Controller
         control={control}
         name={STORAGE_BLOCK_FIELDS.STORAGE_AMOUNT}
-        render={({ field: { onChange, value } }) => (
+        render={({ field: { onChange, value } }) => {
+          const handleStorageChange = (amount: number) => {
+            onChange(amount);
+
+            if (amount === 0) {
+              setValue(STORAGE_BLOCK_FIELDS.VOLUME_TYPE, LOCAL_VOLUME_TYPE);
+            } else if (watchVolume === LOCAL_VOLUME_TYPE && amount >= (storage?.min_size ?? 1)) {
+              const defaultVolume = watchProvider?.volumes?.find((volume) => volume?.is_default) ?? watchProvider?.volumes?.[0];
+              setValue(STORAGE_BLOCK_FIELDS.VOLUME_TYPE, defaultVolume?.volume_type);
+            }
+          };
+
+          return (
           <ClusterSliderBox
             min={storage?.min_size ?? 1}
             max={storage?.max_size ?? 100}
             marksAdditionalLabel="GB"
             marksAmount={10}
-            step={100}
             amount={value}
-            changeAmount={onChange}
+            changeAmount={handleStorageChange}
             unit="GB"
             limitMax
             allowZero
@@ -107,7 +112,19 @@ const StorageBlock: FC = () => {
                       render={({ field }) => (
                         <FormControl fullWidth size="small">
                           <InputLabel>{label}</InputLabel>
-                          <Select {...field} size="small" label={label}>
+                          <Select
+                            {...field}
+                            size="small"
+                            label={label}
+                            onChange={(event) => {
+                              field.onChange(event);
+                              if (fieldName === STORAGE_BLOCK_FIELDS.VOLUME_TYPE) {
+                                const selectedVolume = watchProvider?.volumes?.find(
+                                  (volume) => volume?.volume_type === event.target.value,
+                                );
+                                setValue(STORAGE_BLOCK_FIELDS.STORAGE_AMOUNT, selectedVolume?.min_size ?? 0);
+                              }
+                            }}>
                             {options.map(({ value, label }) => (
                               <MenuItem key={value} value={value}>
                                 <Tooltip
@@ -130,7 +147,8 @@ const StorageBlock: FC = () => {
               ) : null
             }
           />
-        )}
+          );
+        }}
       />
     </Box>
   );

--- a/console/ui/src/entities/cluster/storage-block/ui/index.tsx
+++ b/console/ui/src/entities/cluster/storage-block/ui/index.tsx
@@ -9,6 +9,7 @@ import { fileSystemTypeOptions, STORAGE_BLOCK_FIELDS } from '@entities/cluster/s
 import { IS_EXPERT_MODE } from '@shared/model/constants.ts';
 
 const StorageBlock: FC = () => {
+  const LOCAL_VOLUME_TYPE = 'local';
   const { t } = useTranslation(['clusters', 'shared']);
   const theme = useTheme();
   const [storage, setStorage] = useState({}); // full info about selected storage
@@ -22,16 +23,17 @@ const StorageBlock: FC = () => {
 
   const watchProvider = useWatch({ name: CLUSTER_FORM_FIELD_NAMES.PROVIDER });
   const watchVolume = useWatch({ name: STORAGE_BLOCK_FIELDS.VOLUME_TYPE });
+  const watchStorageAmount = useWatch({ name: STORAGE_BLOCK_FIELDS.STORAGE_AMOUNT });
 
   useEffect(() => {
     const volumes = watchProvider?.volumes;
     setStorage(volumes?.find((volume) => volume?.is_default) ?? {});
 
     setVolumeTypes(
-      volumes?.map((volume) => ({
-        label: volume?.volume_type,
-        value: volume?.volume_type,
-      })) ?? [],
+      [
+        ...(volumes?.map((volume) => ({ label: volume?.volume_type, value: volume?.volume_type })) ?? []),
+        { label: t('localDisk'), value: LOCAL_VOLUME_TYPE },
+      ],
     );
 
     setValue(
@@ -39,15 +41,27 @@ const StorageBlock: FC = () => {
       STORAGE_BLOCK_FIELDS.VOLUME_TYPE,
       volumes?.find((volume) => volume?.is_default)?.volume_type ?? volumes?.[0]?.volume_type,
     );
-  }, [watchProvider]);
+  }, [setValue, t, watchProvider?.volumes]);
 
   useEffect(() => {
+    if (watchVolume === LOCAL_VOLUME_TYPE) {
+      setStorage({});
+      setValue(STORAGE_BLOCK_FIELDS.STORAGE_AMOUNT, 0);
+      return;
+    }
+
     // set selected storage size sa minimum available for selected volume
     const volumes = watchProvider?.volumes;
     const storage = volumes?.find((volume) => volume?.volume_type === watchVolume);
     setStorage(storage);
     setValue(STORAGE_BLOCK_FIELDS.STORAGE_AMOUNT, storage?.min_size ?? 1);
-  }, [watchVolume]);
+  }, [setValue, watchProvider?.volumes, watchVolume]);
+
+  useEffect(() => {
+    if (watchStorageAmount === 0 && watchVolume !== LOCAL_VOLUME_TYPE) {
+      setValue(STORAGE_BLOCK_FIELDS.VOLUME_TYPE, LOCAL_VOLUME_TYPE);
+    }
+  }, [setValue, watchStorageAmount, watchVolume]);
 
   return (
     <Box>
@@ -68,6 +82,7 @@ const StorageBlock: FC = () => {
             changeAmount={onChange}
             unit="GB"
             limitMax
+            allowZero
             icon={<StorageIcon width="24px" height="24px" style={{ fill: theme.palette.text.primary }} />}
             error={errors[STORAGE_BLOCK_FIELDS.STORAGE_AMOUNT]}
             topRightElements={
@@ -97,8 +112,10 @@ const StorageBlock: FC = () => {
                               <MenuItem key={value} value={value}>
                                 <Tooltip
                                   title={
-                                    watchProvider?.volumes?.find((volume) => volume?.volume_type === value)
-                                      ?.volume_description ?? ''
+                                    value === LOCAL_VOLUME_TYPE
+                                      ? t('localDiskDescription')
+                                      : watchProvider?.volumes?.find((volume) => volume?.volume_type === value)
+                                          ?.volume_description ?? ''
                                   }>
                                   {label}
                                 </Tooltip>

--- a/console/ui/src/pages/operation-log/ui/index.tsx
+++ b/console/ui/src/pages/operation-log/ui/index.tsx
@@ -4,9 +4,8 @@ import { useGetOperationsByIdLogQuery } from '@shared/api/api/operations.ts';
 import { useParams } from 'react-router-dom';
 import { LazyLog } from 'react-lazylog';
 import { useQueryPolling } from '@shared/lib/hooks.tsx';
-import { OPERATIONS_POLLING_INTERVAL } from '@shared/config/constants.ts';
 
-const OPERATION_LOG_POLLING_INTERVAL = Number(OPERATIONS_POLLING_INTERVAL) || 5_000;
+const OPERATION_LOG_POLLING_INTERVAL = 5_000;
 
 const OperationLog: FC = () => {
   const { operationId } = useParams();

--- a/console/ui/src/pages/operation-log/ui/index.tsx
+++ b/console/ui/src/pages/operation-log/ui/index.tsx
@@ -1,23 +1,18 @@
 import { FC, useEffect, useState } from 'react';
-import { Box, Stack } from '@mui/material';
+import { Box } from '@mui/material';
 import { useGetOperationsByIdLogQuery } from '@shared/api/api/operations.ts';
 import { useParams } from 'react-router-dom';
 import { LazyLog } from 'react-lazylog';
 import { useQueryPolling } from '@shared/lib/hooks.tsx';
-import { useAppSelector } from '@app/redux/store/hooks.ts';
-import { selectPollingInterval } from '@app/redux/slices/pollingIntervalSlice/pollingIntervalSlice.ts';
-import RefreshIntervalSelect from '@features/refresh-interval-select';
+import { OPERATIONS_POLLING_INTERVAL } from '@shared/config/constants.ts';
+
+const OPERATION_LOG_POLLING_INTERVAL = Number(OPERATIONS_POLLING_INTERVAL) || 5_000;
 
 const OperationLog: FC = () => {
   const { operationId } = useParams();
   const [isStopRequest, setIsStopRequest] = useState(false);
-  const pollingInterval = useAppSelector(selectPollingInterval('operationLogs'));
-
-  const log = useQueryPolling(
-    () => useGetOperationsByIdLogQuery({ id: operationId }),
-    pollingInterval,
-    { stop: isStopRequest },
-  );
+  const logRequest = useGetOperationsByIdLogQuery({ id: operationId });
+  const log = useQueryPolling(logRequest, OPERATION_LOG_POLLING_INTERVAL, { stop: isStopRequest });
 
   useEffect(() => {
     setIsStopRequest(!!log.data?.isComplete);
@@ -25,9 +20,6 @@ const OperationLog: FC = () => {
 
   return (
     <Box width="100%" height="85vh">
-      <Stack direction="row" justifyContent="flex-end" alignItems="center" gap="8px" pb={1}>
-        <RefreshIntervalSelect context="operationLogs" />
-      </Stack>
       <LazyLog
         follow
         scrollToAlignment="end"

--- a/console/ui/src/pages/overview-cluster/ui/index.tsx
+++ b/console/ui/src/pages/overview-cluster/ui/index.tsx
@@ -1,5 +1,4 @@
 import { FC } from 'react';
-import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router-dom';
 import { useGetClustersByIdQuery } from '@shared/api/api/clusters.ts';
 import { Grid } from '@mui/material';
@@ -12,11 +11,11 @@ import { selectPollingInterval } from '@app/redux/slices/pollingIntervalSlice/po
 import Spinner from '@shared/ui/spinner';
 
 const OverviewCluster: FC = () => {
-  const { t } = useTranslation('clusters');
   const { clusterId } = useParams();
   const pollingInterval = useAppSelector(selectPollingInterval('clusterOverview'));
 
-  const cluster = useQueryPolling(() => useGetClustersByIdQuery({ id: clusterId }), pollingInterval);
+  const clusterRequest = useGetClustersByIdQuery({ id: clusterId });
+  const cluster = useQueryPolling(clusterRequest, pollingInterval);
 
   const connectionInfo = cluster.data?.connection_info;
 

--- a/console/ui/src/shared/i18n/locales/en/clusters.json
+++ b/console/ui/src/shared/i18n/locales/en/clusters.json
@@ -18,6 +18,8 @@
   "selectInstanceType": "Select instance type",
   "numberOfInstances": "Number of instances",
   "dataDiskStorage": "Data disk storage",
+  "localDisk": "Local disk",
+  "localDiskDescription": "Store PostgreSQL data on the server's system disk; no external data disk is created.",
   "sshPublicKey": "SSH public key",
   "sshKey": "SSH key",
   "sshKeyAuthDescription": "Connect to your services with an SSH key pair",

--- a/console/ui/src/shared/i18n/locales/en/clusters.json
+++ b/console/ui/src/shared/i18n/locales/en/clusters.json
@@ -18,7 +18,7 @@
   "selectInstanceType": "Select instance type",
   "numberOfInstances": "Number of instances",
   "dataDiskStorage": "Data disk storage",
-  "localDisk": "Local disk",
+  "localDisk": "System disk",
   "localDiskDescription": "Store PostgreSQL data on the server's system disk; no external data disk is created.",
   "sshPublicKey": "SSH public key",
   "sshKey": "SSH key",

--- a/console/ui/src/shared/lib/clusterValuesTransformFunctions.ts
+++ b/console/ui/src/shared/lib/clusterValuesTransformFunctions.ts
@@ -83,7 +83,8 @@ export const getCloudProviderExtraVars = (values: ClusterFormValues) => ({
   ...(IS_EXPERT_MODE
     ? {
         postgresql_data_dir_mount_fstype: values[STORAGE_BLOCK_FIELDS.FILE_SYSTEM_TYPE],
-        volume_type: values[STORAGE_BLOCK_FIELDS.VOLUME_TYPE],
+        volume_type:
+          values[STORAGE_BLOCK_FIELDS.STORAGE_AMOUNT] === 0 ? 'local' : values[STORAGE_BLOCK_FIELDS.VOLUME_TYPE],
         database_public_access: !!values?.[ADDITIONAL_SETTINGS_BLOCK_FIELD_NAMES.IS_DB_PUBLIC_ACCESS],
         cloud_load_balancer: !!values?.[ADDITIONAL_SETTINGS_BLOCK_FIELD_NAMES.IS_CLOUD_LOAD_BALANCER],
         ...([PROVIDERS.AWS, PROVIDERS.GCP, PROVIDERS.AZURE].includes(values[CLUSTER_FORM_FIELD_NAMES.PROVIDER]?.code) &&
@@ -96,7 +97,9 @@ export const getCloudProviderExtraVars = (values: ClusterFormValues) => ({
           ? { server_network: values[NETWORK_BLOCK_FIELD_NAMES.SERVER_NETWORK] }
           : {}),
       }
-    : {}),
+    : values[STORAGE_BLOCK_FIELDS.STORAGE_AMOUNT] === 0
+      ? { volume_type: 'local' }
+      : {}),
 });
 
 /**

--- a/console/ui/src/shared/lib/clusterValuesTransformFunctions.ts
+++ b/console/ui/src/shared/lib/clusterValuesTransformFunctions.ts
@@ -100,6 +100,9 @@ export const getCloudProviderExtraVars = (values: ClusterFormValues) => ({
     : values[STORAGE_BLOCK_FIELDS.STORAGE_AMOUNT] === 0
       ? { volume_type: 'local' }
       : {}),
+  ...(values[STORAGE_BLOCK_FIELDS.STORAGE_AMOUNT] === 0 && values[DATA_DIRECTORY_FIELD_NAMES.DATA_DIRECTORY]
+    ? { postgresql_data_dir: values[DATA_DIRECTORY_FIELD_NAMES.DATA_DIRECTORY] }
+    : {}),
 });
 
 /**

--- a/console/ui/src/shared/lib/clusterValuesTransformFunctions.ts
+++ b/console/ui/src/shared/lib/clusterValuesTransformFunctions.ts
@@ -82,7 +82,9 @@ export const getCloudProviderExtraVars = (values: ClusterFormValues) => ({
   ...values[CLUSTER_FORM_FIELD_NAMES.REGION_CONFIG].cloud_image.image,
   ...(IS_EXPERT_MODE
     ? {
-        postgresql_data_dir_mount_fstype: values[STORAGE_BLOCK_FIELDS.FILE_SYSTEM_TYPE],
+        ...(values[STORAGE_BLOCK_FIELDS.STORAGE_AMOUNT] === 0
+          ? {}
+          : { postgresql_data_dir_mount_fstype: values[STORAGE_BLOCK_FIELDS.FILE_SYSTEM_TYPE] }),
         volume_type:
           values[STORAGE_BLOCK_FIELDS.STORAGE_AMOUNT] === 0 ? 'local' : values[STORAGE_BLOCK_FIELDS.VOLUME_TYPE],
         database_public_access: !!values?.[ADDITIONAL_SETTINGS_BLOCK_FIELD_NAMES.IS_DB_PUBLIC_ACCESS],

--- a/console/ui/src/shared/lib/clusterValuesTransformFunctions.ts
+++ b/console/ui/src/shared/lib/clusterValuesTransformFunctions.ts
@@ -100,9 +100,6 @@ export const getCloudProviderExtraVars = (values: ClusterFormValues) => ({
     : values[STORAGE_BLOCK_FIELDS.STORAGE_AMOUNT] === 0
       ? { volume_type: 'local' }
       : {}),
-  ...(values[STORAGE_BLOCK_FIELDS.STORAGE_AMOUNT] === 0 && values[DATA_DIRECTORY_FIELD_NAMES.DATA_DIRECTORY]
-    ? { postgresql_data_dir: values[DATA_DIRECTORY_FIELD_NAMES.DATA_DIRECTORY] }
-    : {}),
 });
 
 /**

--- a/console/ui/src/shared/lib/hooks.tsx
+++ b/console/ui/src/shared/lib/hooks.tsx
@@ -8,8 +8,11 @@ import { toast } from 'react-toastify';
  * @param pollingInterval - Polling interval in ms. Use 0 to disable polling.
  * @param options - Different config options.
  */
-export const useQueryPolling = (request: any, pollingInterval: number, options?: { stop?: boolean }) => {
-  const result = request();
+export const useQueryPolling = <T extends { refetch: () => unknown }>(
+  result: T,
+  pollingInterval: number,
+  options?: { stop?: boolean },
+) => {
   const stop = options?.stop === true;
 
   useEffect(() => {
@@ -18,7 +21,7 @@ export const useQueryPolling = (request: any, pollingInterval: number, options?:
     return () => {
       clearInterval(polling);
     };
-  }, [pollingInterval, stop]);
+  }, [pollingInterval, result, stop]);
 
   return result;
 };

--- a/console/ui/src/shared/ui/slider-box/model/types.ts
+++ b/console/ui/src/shared/ui/slider-box/model/types.ts
@@ -1,18 +1,21 @@
 import { ReactElement } from 'react';
-import { Mark } from '@mui/material/Slider/useSlider.types';
+import { SliderProps } from '@mui/material';
+import { FieldError } from 'react-hook-form';
+
+type SliderMark = Extract<NonNullable<SliderProps['marks']>, readonly unknown[]>[number];
 
 export interface SliderBoxProps {
   amount: number;
-  changeAmount: (...event: any[]) => void;
+  changeAmount: (amount: number) => void;
   icon?: ReactElement;
   unit?: string;
   min: number;
   max: number;
-  marks?: { label: unknown; value: unknown }[];
+  marks?: SliderMark[];
   marksAmount?: number;
   marksAdditionalLabel?: string;
   step?: number | null;
-  error?: object;
+  error?: FieldError;
   limitMin?: boolean;
   limitMax?: boolean;
   allowZero?: boolean;
@@ -26,4 +29,4 @@ export type GenerateSliderMarksType = (
   max: number,
   amount: number,
   marksAdditionalLabel: string,
-) => Mark[];
+) => SliderMark[];

--- a/console/ui/src/shared/ui/slider-box/model/types.ts
+++ b/console/ui/src/shared/ui/slider-box/model/types.ts
@@ -15,6 +15,7 @@ export interface SliderBoxProps {
   error?: object;
   limitMin?: boolean;
   limitMax?: boolean;
+  allowZero?: boolean;
   topRightElements?: ReactElement | null;
 }
 

--- a/console/ui/src/shared/ui/slider-box/ui/index.tsx
+++ b/console/ui/src/shared/ui/slider-box/ui/index.tsx
@@ -23,9 +23,11 @@ const ClusterSliderBox: FC<SliderBoxProps> = ({
 }) => {
   const theme = useTheme();
   const [inputValue, setInputValue] = useState(String(amount));
+  const [sliderValue, setSliderValue] = useState(amount);
 
   useEffect(() => {
     setInputValue(String(amount));
+    setSliderValue(amount);
   }, [amount]);
 
   const onChange = (e: ChangeEvent<HTMLInputElement>) => {
@@ -51,7 +53,15 @@ const ClusterSliderBox: FC<SliderBoxProps> = ({
   };
 
   const handleSliderChange: NonNullable<SliderProps['onChange']> = (_event, value) => {
+    if (allowZero) {
+      setSliderValue(Number(value));
+      return;
+    }
     changeAmount(Number(value));
+  };
+
+  const handleSliderChangeCommitted: NonNullable<SliderProps['onChangeCommitted']> = (_event, value) => {
+    if (allowZero) changeAmount(Number(value) < min ? 0 : Number(value));
   };
 
   const sliderMarks = marks ?? generateSliderMarks(min ?? 1, max ?? 100, marksAmount ?? 0, marksAdditionalLabel);
@@ -95,13 +105,14 @@ const ClusterSliderBox: FC<SliderBoxProps> = ({
         padding="32px">
         {topRightElements ?? null}
         <Slider
-          value={amount}
+          value={allowZero ? sliderValue : amount}
           onChange={handleSliderChange}
-          step={allowZero ? null : step}
+          onChangeCommitted={handleSliderChangeCommitted}
+          step={allowZero ? 1 : step}
           valueLabelDisplay="auto"
           min={allowZero ? 0 : min}
           max={max}
-          marks={allowZero ? [{ value: 0, label: `0 ${marksAdditionalLabel}` }, ...sliderMarks] : sliderMarks}
+          marks={sliderMarks}
         />
       </Box>
     </Box>

--- a/console/ui/src/shared/ui/slider-box/ui/index.tsx
+++ b/console/ui/src/shared/ui/slider-box/ui/index.tsx
@@ -18,6 +18,7 @@ const ClusterSliderBox: FC<SliderBoxProps> = ({
   error,
   limitMin = true,
   limitMax,
+  allowZero = false,
   topRightElements,
 }) => {
   const theme = useTheme();
@@ -26,7 +27,9 @@ const ClusterSliderBox: FC<SliderBoxProps> = ({
     const { value } = e.target;
     if (/^\d*$/.test(value)) {
       const num = Number(value);
-      changeAmount(num < (min ?? 0) && limitMin ? min : num > (max ?? Infinity) && limitMax ? max : num);
+      changeAmount(
+        num === 0 && allowZero ? 0 : num < (min ?? 0) && limitMin ? min : num > (max ?? Infinity) && limitMax ? max : num,
+      );
     }
   };
 
@@ -68,8 +71,9 @@ const ClusterSliderBox: FC<SliderBoxProps> = ({
         padding="32px">
         {topRightElements ?? null}
         <Slider
-          value={amount}
+          value={amount === 0 && allowZero ? min : amount}
           onChange={changeAmount}
+          disabled={amount === 0 && allowZero}
           step={step}
           valueLabelDisplay="auto"
           min={min}

--- a/console/ui/src/shared/ui/slider-box/ui/index.tsx
+++ b/console/ui/src/shared/ui/slider-box/ui/index.tsx
@@ -1,5 +1,5 @@
-import { ChangeEvent, FC } from 'react';
-import { Box, Slider, TextField, Typography, useTheme } from '@mui/material';
+import { ChangeEvent, FC, useEffect, useState } from 'react';
+import { Box, Slider, SliderProps, TextField, Typography, useTheme } from '@mui/material';
 import { SliderBoxProps } from '@shared/ui/slider-box/model/types.ts';
 
 import { generateSliderMarks } from '@shared/ui/slider-box/lib/functions.ts';
@@ -22,16 +22,39 @@ const ClusterSliderBox: FC<SliderBoxProps> = ({
   topRightElements,
 }) => {
   const theme = useTheme();
+  const [inputValue, setInputValue] = useState(String(amount));
+
+  useEffect(() => {
+    setInputValue(String(amount));
+  }, [amount]);
 
   const onChange = (e: ChangeEvent<HTMLInputElement>) => {
     const { value } = e.target;
     if (/^\d*$/.test(value)) {
-      const num = Number(value);
-      changeAmount(
-        num === 0 && allowZero ? 0 : num < (min ?? 0) && limitMin ? min : num > (max ?? Infinity) && limitMax ? max : num,
-      );
+      setInputValue(value);
+      if (value) changeAmount(Number(value));
     }
   };
+
+  const onBlur = () => {
+    const num = Number(inputValue);
+    const nextAmount =
+      num === 0 && allowZero
+        ? 0
+        : !inputValue || (num < (min ?? 0) && limitMin)
+          ? min
+          : num > (max ?? Infinity) && limitMax
+            ? max
+            : num;
+    setInputValue(String(nextAmount));
+    changeAmount(nextAmount);
+  };
+
+  const handleSliderChange: NonNullable<SliderProps['onChange']> = (_event, value) => {
+    changeAmount(Number(value));
+  };
+
+  const sliderMarks = marks ?? generateSliderMarks(min ?? 1, max ?? 100, marksAmount ?? 0, marksAdditionalLabel);
 
   return (
     <Box
@@ -53,10 +76,11 @@ const ClusterSliderBox: FC<SliderBoxProps> = ({
         {icon}
         <TextField
           required
-          value={amount}
+          value={inputValue}
           onChange={onChange}
+          onBlur={onBlur}
           error={!!error}
-          helperText={(error as any)?.message ?? ''}
+          helperText={error?.message ?? ''}
           size="small"
           sx={{ width: '75px' }}
         />
@@ -71,14 +95,13 @@ const ClusterSliderBox: FC<SliderBoxProps> = ({
         padding="32px">
         {topRightElements ?? null}
         <Slider
-          value={amount === 0 && allowZero ? min : amount}
-          onChange={changeAmount}
-          disabled={amount === 0 && allowZero}
-          step={step}
+          value={amount}
+          onChange={handleSliderChange}
+          step={allowZero ? null : step}
           valueLabelDisplay="auto"
-          min={min}
+          min={allowZero ? 0 : min}
           max={max}
-          marks={marks ?? generateSliderMarks(min ?? 1, max ?? 100, marksAmount ?? 0, marksAdditionalLabel)}
+          marks={allowZero ? [{ value: 0, label: `0 ${marksAdditionalLabel}` }, ...sliderMarks] : sliderMarks}
         />
       </Box>
     </Box>

--- a/console/ui/src/widgets/cluster-form/ui/ClusterFormCloudProviderFormPart.tsx
+++ b/console/ui/src/widgets/cluster-form/ui/ClusterFormCloudProviderFormPart.tsx
@@ -5,18 +5,26 @@ import InstancesAmountBlock from '@entities/cluster/instances-amount-block';
 import StorageBlock from '@entities/cluster/storage-block';
 import ClusterFormSshKeyBlock from '@entities/cluster/ssh-key-block';
 import { IS_EXPERT_MODE } from '@shared/model/constants.ts';
+import { useWatch } from 'react-hook-form';
+import { STORAGE_BLOCK_FIELDS } from '@entities/cluster/storage-block/model/const.ts';
 
 const NetworkBlock = lazy(() => import('@entities/cluster/expert-mode/network-block/ui'));
+const DataDirectoryBlock = lazy(() => import('@entities/cluster/expert-mode/data-directory-block/ui'));
 
-const ClusterFormCloudProviderFormPart: FC = () => (
-  <>
-    <ClusterFormRegionBlock />
-    <ClusterFormInstancesBlock />
-    <InstancesAmountBlock />
-    <StorageBlock />
-    {IS_EXPERT_MODE ? <NetworkBlock /> : null}
-    <ClusterFormSshKeyBlock />
-  </>
-);
+const ClusterFormCloudProviderFormPart: FC = () => {
+  const watchStorageAmount = useWatch({ name: STORAGE_BLOCK_FIELDS.STORAGE_AMOUNT });
+
+  return (
+    <>
+      <ClusterFormRegionBlock />
+      <ClusterFormInstancesBlock />
+      <InstancesAmountBlock />
+      <StorageBlock />
+      {watchStorageAmount === 0 ? <DataDirectoryBlock /> : null}
+      {IS_EXPERT_MODE ? <NetworkBlock /> : null}
+      <ClusterFormSshKeyBlock />
+    </>
+  );
+};
 
 export default ClusterFormCloudProviderFormPart;

--- a/console/ui/src/widgets/cluster-form/ui/ClusterFormCloudProviderFormPart.tsx
+++ b/console/ui/src/widgets/cluster-form/ui/ClusterFormCloudProviderFormPart.tsx
@@ -5,26 +5,18 @@ import InstancesAmountBlock from '@entities/cluster/instances-amount-block';
 import StorageBlock from '@entities/cluster/storage-block';
 import ClusterFormSshKeyBlock from '@entities/cluster/ssh-key-block';
 import { IS_EXPERT_MODE } from '@shared/model/constants.ts';
-import { useWatch } from 'react-hook-form';
-import { STORAGE_BLOCK_FIELDS } from '@entities/cluster/storage-block/model/const.ts';
 
 const NetworkBlock = lazy(() => import('@entities/cluster/expert-mode/network-block/ui'));
-const DataDirectoryBlock = lazy(() => import('@entities/cluster/expert-mode/data-directory-block/ui'));
 
-const ClusterFormCloudProviderFormPart: FC = () => {
-  const watchStorageAmount = useWatch({ name: STORAGE_BLOCK_FIELDS.STORAGE_AMOUNT });
-
-  return (
-    <>
-      <ClusterFormRegionBlock />
-      <ClusterFormInstancesBlock />
-      <InstancesAmountBlock />
-      <StorageBlock />
-      {watchStorageAmount === 0 ? <DataDirectoryBlock /> : null}
-      {IS_EXPERT_MODE ? <NetworkBlock /> : null}
-      <ClusterFormSshKeyBlock />
-    </>
-  );
-};
+const ClusterFormCloudProviderFormPart: FC = () => (
+  <>
+    <ClusterFormRegionBlock />
+    <ClusterFormInstancesBlock />
+    <InstancesAmountBlock />
+    <StorageBlock />
+    {IS_EXPERT_MODE ? <NetworkBlock /> : null}
+    <ClusterFormSshKeyBlock />
+  </>
+);
 
 export default ClusterFormCloudProviderFormPart;

--- a/console/ui/src/widgets/cluster-form/ui/index.tsx
+++ b/console/ui/src/widgets/cluster-form/ui/index.tsx
@@ -28,7 +28,6 @@ import { SECRET_MODAL_CONTENT_FORM_FIELD_NAMES } from '@entities/secret-form-blo
 import { ClusterFormProps } from '@widgets/cluster-form/model/types.ts';
 import { DATABASE_SERVERS_FIELD_NAMES } from '@/entities/cluster/database-servers-block/model/const';
 import { mapFormValuesToRequestFields } from '@shared/lib/clusterValuesTransformFunctions.ts';
-import { STORAGE_BLOCK_FIELDS } from '@entities/cluster/storage-block/model/const.ts';
 
 const DatabaseBlock = lazy(() => import('@entities/cluster/expert-mode/databases-block/ui'));
 const ConnectionPoolsBlock = lazy(() => import('@entities/cluster/expert-mode/connection-pools-block/ui'));
@@ -56,8 +55,6 @@ const ClusterForm: React.FC<ClusterFormProps> = ({
   const methods = useFormContext();
 
   const watchProvider = useWatch({ name: CLUSTER_FORM_FIELD_NAMES.PROVIDER });
-  const watchStorageAmount = useWatch({ name: STORAGE_BLOCK_FIELDS.STORAGE_AMOUNT });
-  const isCloudLocalDisk = watchProvider?.code !== PROVIDERS.LOCAL && watchStorageAmount === 0;
 
   const secrets = useGetSecretsQuery({ type: watchProvider?.code, projectId: currentProject });
 
@@ -144,9 +141,7 @@ const ClusterForm: React.FC<ClusterFormProps> = ({
           <ClusterNameBox />
           <ClusterDescriptionBlock />
           <PostgresVersionBox postgresVersions={postgresVersionsData} />
-          {(isCloudLocalDisk || (IS_EXPERT_MODE && watchProvider?.code === PROVIDERS.LOCAL)) ? (
-            <DataDirectoryBlock />
-          ) : null}
+          {IS_EXPERT_MODE && watchProvider?.code === PROVIDERS.LOCAL ? <DataDirectoryBlock /> : null}
           {IS_EXPERT_MODE ? (
             <>
               <DatabaseBlock />

--- a/console/ui/src/widgets/cluster-form/ui/index.tsx
+++ b/console/ui/src/widgets/cluster-form/ui/index.tsx
@@ -28,6 +28,7 @@ import { SECRET_MODAL_CONTENT_FORM_FIELD_NAMES } from '@entities/secret-form-blo
 import { ClusterFormProps } from '@widgets/cluster-form/model/types.ts';
 import { DATABASE_SERVERS_FIELD_NAMES } from '@/entities/cluster/database-servers-block/model/const';
 import { mapFormValuesToRequestFields } from '@shared/lib/clusterValuesTransformFunctions.ts';
+import { STORAGE_BLOCK_FIELDS } from '@entities/cluster/storage-block/model/const.ts';
 
 const DatabaseBlock = lazy(() => import('@entities/cluster/expert-mode/databases-block/ui'));
 const ConnectionPoolsBlock = lazy(() => import('@entities/cluster/expert-mode/connection-pools-block/ui'));
@@ -55,6 +56,8 @@ const ClusterForm: React.FC<ClusterFormProps> = ({
   const methods = useFormContext();
 
   const watchProvider = useWatch({ name: CLUSTER_FORM_FIELD_NAMES.PROVIDER });
+  const watchStorageAmount = useWatch({ name: STORAGE_BLOCK_FIELDS.STORAGE_AMOUNT });
+  const isCloudLocalDisk = watchProvider?.code !== PROVIDERS.LOCAL && watchStorageAmount === 0;
 
   const secrets = useGetSecretsQuery({ type: watchProvider?.code, projectId: currentProject });
 
@@ -141,7 +144,9 @@ const ClusterForm: React.FC<ClusterFormProps> = ({
           <ClusterNameBox />
           <ClusterDescriptionBlock />
           <PostgresVersionBox postgresVersions={postgresVersionsData} />
-          {IS_EXPERT_MODE && watchProvider?.code === PROVIDERS.LOCAL ? <DataDirectoryBlock /> : null}
+          {(isCloudLocalDisk || (IS_EXPERT_MODE && watchProvider?.code === PROVIDERS.LOCAL)) ? (
+            <DataDirectoryBlock />
+          ) : null}
           {IS_EXPERT_MODE ? (
             <>
               <DatabaseBlock />

--- a/console/ui/src/widgets/cluster-summary/lib/hooks.tsx
+++ b/console/ui/src/widgets/cluster-summary/lib/hooks.tsx
@@ -136,12 +136,14 @@ const useGetCloudProviderConfig = () => {
                     {`${data[CLUSTER_FORM_FIELD_NAMES.INSTANCE_CONFIG]?.currency}${data[
                       CLUSTER_FORM_FIELD_NAMES.INSTANCE_CONFIG
                     ]?.price_monthly.toFixed(2)}/${t('perServer', { ns: 'clusters' })}`}
-                    , ~
-                    {isLocalDisk
-                      ? t('localDisk')
-                      : `${defaultVolume?.currency}${(
+                    {!isLocalDisk && (
+                      <>
+                        , ~
+                        {`${defaultVolume?.currency}${(
                           defaultVolume?.price_monthly * data[STORAGE_BLOCK_FIELDS.STORAGE_AMOUNT]
                         )?.toFixed(2)}/${t('perDisk', { ns: 'clusters' })}`}
+                      </>
+                    )}
                   </Typography>
                 </Stack>
               </>

--- a/console/ui/src/widgets/cluster-summary/lib/hooks.tsx
+++ b/console/ui/src/widgets/cluster-summary/lib/hooks.tsx
@@ -31,6 +31,7 @@ const useGetCloudProviderConfig = () => {
 
   return (data: CloudProviderClustersSummary) => {
     const defaultVolume = data[CLUSTER_FORM_FIELD_NAMES.PROVIDER]?.volumes?.find((volume) => volume?.is_default) ?? {};
+    const isLocalDisk = data[STORAGE_BLOCK_FIELDS.STORAGE_AMOUNT] === 0;
 
     return [
       {
@@ -109,7 +110,7 @@ const useGetCloudProviderConfig = () => {
         children: (
           <Stack direction={'row'} spacing={0.5} alignItems="center" minHeight="20px">
             <StorageIcon height="24px" width="24px" style={{ fill: theme.palette.text.primary }} />
-            <Typography>{data[STORAGE_BLOCK_FIELDS.STORAGE_AMOUNT]} GB</Typography>
+            <Typography>{isLocalDisk ? t('localDisk') : `${data[STORAGE_BLOCK_FIELDS.STORAGE_AMOUNT]} GB`}</Typography>
           </Stack>
         ),
       },
@@ -124,7 +125,7 @@ const useGetCloudProviderConfig = () => {
                   {`${data[CLUSTER_FORM_FIELD_NAMES.INSTANCE_CONFIG]?.currency}${(
                     data[CLUSTER_FORM_FIELD_NAMES.INSTANCE_CONFIG]?.price_monthly *
                       data[CLUSTER_FORM_FIELD_NAMES.INSTANCES_AMOUNT] +
-                    defaultVolume?.price_monthly *
+                    (isLocalDisk ? 0 : defaultVolume?.price_monthly) *
                       data[STORAGE_BLOCK_FIELDS.STORAGE_AMOUNT] *
                       data[CLUSTER_FORM_FIELD_NAMES.INSTANCES_AMOUNT]
                   )?.toFixed(2)}/${t('month', { ns: 'shared' })}`}
@@ -136,9 +137,11 @@ const useGetCloudProviderConfig = () => {
                       CLUSTER_FORM_FIELD_NAMES.INSTANCE_CONFIG
                     ]?.price_monthly.toFixed(2)}/${t('perServer', { ns: 'clusters' })}`}
                     , ~
-                    {`${defaultVolume?.currency}${(
-                      defaultVolume?.price_monthly * data[STORAGE_BLOCK_FIELDS.STORAGE_AMOUNT]
-                    )?.toFixed(2)}/${t('perDisk', { ns: 'clusters' })}`}
+                    {isLocalDisk
+                      ? t('localDisk')
+                      : `${defaultVolume?.currency}${(
+                          defaultVolume?.price_monthly * data[STORAGE_BLOCK_FIELDS.STORAGE_AMOUNT]
+                        )?.toFixed(2)}/${t('perDisk', { ns: 'clusters' })}`}
                   </Typography>
                 </Stack>
               </>

--- a/console/ui/src/widgets/clusters-table/ui/index.tsx
+++ b/console/ui/src/widgets/clusters-table/ui/index.tsx
@@ -21,7 +21,7 @@ import DefaultTable from '@shared/ui/default-table';
 import RowActionsMenu from '@features/row-actions-menu/ui';
 
 const ClustersTable: FC = () => {
-  const { t, i18n } = useTranslation('clusters');
+  const { t } = useTranslation('clusters');
 
   const currentProject = useAppSelector(selectCurrentProject);
   const pollingInterval = useAppSelector(selectPollingInterval('clusters'));
@@ -41,16 +41,13 @@ const ClustersTable: FC = () => {
   const environments = useGetEnvironmentsQuery({ offset: 0, limit: 999_999_999 });
   const postgresVersions = useGetPostgresVersionsQuery();
 
-  const clustersList = useQueryPolling(
-    () =>
-      useGetClustersQuery({
-        projectId: Number(currentProject), // TODO: projectId, projectCode
-        offset: pagination.pageIndex * pagination.pageSize,
-        limit: pagination.pageSize,
-        ...(sorting?.[0] ? { sortBy: manageSortingOrder(sorting[0]) } : {}),
-      }),
-    pollingInterval,
-  );
+  const clustersListRequest = useGetClustersQuery({
+    projectId: Number(currentProject), // TODO: projectId, projectCode
+    offset: pagination.pageIndex * pagination.pageSize,
+    limit: pagination.pageSize,
+    ...(sorting?.[0] ? { sortBy: manageSortingOrder(sorting[0]) } : {}),
+  });
+  const clustersList = useQueryPolling(clustersListRequest, pollingInterval);
 
   const columns = useMemo<MRT_ColumnDef<ClustersTableValues>[]>(
     () =>
@@ -59,7 +56,7 @@ const ClustersTable: FC = () => {
         environmentOptions: environments.data?.data?.map((environment) => environment.name) ?? [],
         postgresVersionOptions: postgresVersions.data?.data?.map((version) => version.major_version) ?? [],
       }),
-    [i18n.language, environments.data?.data, postgresVersions.data?.data],
+    [environments.data?.data, postgresVersions.data?.data, t],
   );
 
   const data = useGetClustersTableData(clustersList.data?.data);

--- a/console/ui/src/widgets/operations-table/ui/index.tsx
+++ b/console/ui/src/widgets/operations-table/ui/index.tsx
@@ -22,7 +22,7 @@ import DefaultTable from '@shared/ui/default-table';
 import RowActionsMenu from '@features/row-actions-menu/ui';
 
 const OperationsTable: FC = () => {
-  const { t, i18n } = useTranslation(['operations', 'shared']);
+  const { t } = useTranslation(['operations', 'shared']);
 
   const currentProject = useAppSelector(selectCurrentProject);
   const pollingInterval = useAppSelector(selectPollingInterval('operations'));
@@ -44,20 +44,17 @@ const OperationsTable: FC = () => {
     value: formatOperationsDate(subDays(new Date(), 1)),
   });
 
-  const operationsList = useQueryPolling(
-    () =>
-      useGetOperationsQuery({
-        projectId: Number(currentProject),
-        startDate: startDate.value,
-        endDate,
-        offset: pagination.pageIndex * pagination.pageSize,
-        limit: pagination.pageSize,
-        ...(sorting?.[0] ? { sortBy: manageSortingOrder(sorting[0]) } : {}),
-      }),
-    pollingInterval,
-  );
+  const operationsListRequest = useGetOperationsQuery({
+    projectId: Number(currentProject),
+    startDate: startDate.value,
+    endDate,
+    offset: pagination.pageIndex * pagination.pageSize,
+    limit: pagination.pageSize,
+    ...(sorting?.[0] ? { sortBy: manageSortingOrder(sorting[0]) } : {}),
+  });
+  const operationsList = useQueryPolling(operationsListRequest, pollingInterval);
 
-  const columns = useMemo<MRT_ColumnDef<OperationsTableValues>[]>(() => operationTableColumns(t), [i18n.language]);
+  const columns = useMemo<MRT_ColumnDef<OperationsTableValues>[]>(() => operationTableColumns(t), [t]);
 
   const data = useGetOperationsTableData(operationsList.data?.data);
 


### PR DESCRIPTION
Enable PostgreSQL data storage on the server's system disk instead of creating an external data disk. Users can select 'local' as `volume_type` or set `volume_size` to 0.

This option is now available across all cloud providers (AWS, Azure, GCP, DigitalOcean, Hetzner) and reflected in the UI with proper pricing calculations.

<img width="3584" height="2108" alt="image" src="https://github.com/user-attachments/assets/a72a5d9d-d452-49b9-a364-8d9acf785677" />

Closes: https://github.com/autobase-tech/autobase/issues/1531, https://github.com/autobase-tech/autobase/issues/783