### PR TITLE
Console: Improve cluster creation form

### DIFF
--- a/console/ui/src/entities/cluster/expert-mode/extensions-block/ui/index.tsx
+++ b/console/ui/src/entities/cluster/expert-mode/extensions-block/ui/index.tsx
@@ -67,7 +67,7 @@ const ExtensionsBlock: FC = () => {
     <Spinner />
   ) : (
     <ErrorBoundary fallback={<ErrorBox />}>
-      <Box width="60vw">
+      <Box width="100%">
         <Stack direction="column" gap={2} width="100%">
           <Typography fontWeight="bold" marginBottom="8px">
             {t('extensions')}

--- a/console/ui/src/entities/cluster/postgres-version-block/ui/index.tsx
+++ b/console/ui/src/entities/cluster/postgres-version-block/ui/index.tsx
@@ -7,6 +7,8 @@ import { PostgresVersionBlockProps } from '@entities/cluster/postgres-version-bl
 
 const PostgresVersionBox: FC<PostgresVersionBlockProps> = ({ postgresVersions }) => {
   const { t } = useTranslation('clusters');
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
   const {
     control,
     formState: { errors },
@@ -26,13 +28,34 @@ const PostgresVersionBox: FC<PostgresVersionBlockProps> = ({ postgresVersions })
             fullWidth
             value={value}
             onChange={onChange}
+            renderValue={(selectedVersion) => String(selectedVersion)}
             error={!!errors[CLUSTER_FORM_FIELD_NAMES.POSTGRES_VERSION]}
-            helperText={errors[CLUSTER_FORM_FIELD_NAMES.POSTGRES_VERSION]?.message}>
-            {postgresVersions.map((version) => (
-              <MenuItem key={version?.major_version} value={version?.major_version}>
-                {version?.major_version}
-              </MenuItem>
-            ))}
+            helperText={errors[CLUSTER_FORM_FIELD_NAMES.POSTGRES_VERSION]?.message}
+            MenuProps={{
+              PaperProps: {
+                sx: { maxHeight: '200px' },
+              },
+            }}>
+            {postgresVersions.map((version) => {
+              const isEndOfLife =
+                version.end_of_life && new Date(`${version.end_of_life}T00:00:00`).getTime() < today.getTime();
+              const versionDetails = [
+                version.release_date ? `Release: ${version.release_date}` : null,
+                version.end_of_life ? `EOL: ${version.end_of_life}` : null,
+              ]
+                .filter(Boolean)
+                .join(', ');
+
+              return (
+                <MenuItem
+                  key={version?.major_version}
+                  value={version?.major_version}
+                  sx={isEndOfLife ? { color: 'error.main' } : undefined}>
+                  {version?.major_version}
+                  {versionDetails ? `\u00A0\u00A0(${versionDetails})` : ''}
+                </MenuItem>
+              );
+            })}
           </Select>
         )}
       />

--- a/console/ui/src/pages/add-cluster/ui/index.tsx
+++ b/console/ui/src/pages/add-cluster/ui/index.tsx
@@ -74,7 +74,7 @@ const AddCluster: FC = () => {
 
   const clustersForm = (
     <Stack direction="row">
-      <Box width="75vw">
+      <Box width="100%" maxWidth="1000px">
         <ClusterForm
           deploymentsData={deployments.data?.data ?? []}
           environmentsData={environments.data?.data ?? []}

--- a/console/ui/src/shared/ui/slider-box/lib/functions.ts
+++ b/console/ui/src/shared/ui/slider-box/lib/functions.ts
@@ -1,17 +1,85 @@
 import { GenerateMarkType, GenerateSliderMarksType } from '@shared/ui/slider-box/model/types.ts';
 
+const formatMarkLabel = (value: number, marksAdditionalLabel: string) => {
+  if (marksAdditionalLabel === 'GB' && value >= 1000) {
+    const tbValue = value / 1000;
+    return `${Number.isInteger(tbValue) ? tbValue : tbValue.toFixed(1)} TB`;
+  }
+
+  return `${value} ${marksAdditionalLabel}`;
+};
+
 const generateMark: GenerateMarkType = (value, marksAdditionalLabel) => ({
   value,
-  label: `${value} ${marksAdditionalLabel}`,
+  label: formatMarkLabel(value, marksAdditionalLabel),
 });
 
-export const generateSliderMarks: GenerateSliderMarksType = (min, max, amount, marksAdditionalLabel) => {
-  const step = (max - min) / (amount - 1);
-  const marksArray = [];
+const getMarkRoundingStep = (step: number) => {
+  if (step <= 1) {
+    return 1;
+  }
 
-  for (let i = min; i < max + step; i += step) {
-    marksArray.push(generateMark(Math.trunc(i), marksAdditionalLabel));
+  return 10 ** Math.floor(Math.log10(step));
+};
+
+const getNiceTbStep = (maxTb: number, amount: number) => {
+  if (maxTb <= amount) {
+    return 1;
+  }
+
+  const rawStep = maxTb / (amount - 1);
+  const magnitude = 10 ** Math.floor(Math.log10(rawStep));
+  const normalizedStep = rawStep / magnitude;
+
+  if (normalizedStep <= 2) {
+    return 2 * magnitude;
+  }
+
+  if (normalizedStep <= 5) {
+    return 5 * magnitude;
+  }
+
+  return 10 * magnitude;
+};
+
+const generateTbSliderMarks: GenerateSliderMarksType = (min, max, amount, marksAdditionalLabel) => {
+  const maxTb = max / 1000;
+  const tbStep = getNiceTbStep(maxTb, amount);
+  const marksArray = [generateMark(min, marksAdditionalLabel)];
+  const firstTbMark = Math.ceil(min / 1000 / tbStep) * tbStep;
+
+  for (let tbValue = firstTbMark; tbValue < maxTb; tbValue += tbStep) {
+    const value = tbValue * 1000;
+
+    if (value !== min) {
+      marksArray.push(generateMark(value, marksAdditionalLabel));
+    }
+  }
+
+  if (marksArray[marksArray.length - 1]?.value !== max) {
+    marksArray.push(generateMark(max, marksAdditionalLabel));
   }
 
   return marksArray;
+};
+
+export const generateSliderMarks: GenerateSliderMarksType = (min, max, amount, marksAdditionalLabel) => {
+  if (amount <= 1) {
+    return [generateMark(min, marksAdditionalLabel)];
+  }
+
+  if (marksAdditionalLabel === 'GB' && max >= 1000) {
+    return generateTbSliderMarks(min, max, amount, marksAdditionalLabel);
+  }
+
+  const step = (max - min) / (amount - 1);
+  const roundingStep = getMarkRoundingStep(step);
+  const marksArray = [generateMark(min, marksAdditionalLabel)];
+
+  for (let i = 1; i < amount - 1; i += 1) {
+    const value = min + step * i;
+    marksArray.push(generateMark(Math.round(value / roundingStep) * roundingStep, marksAdditionalLabel));
+  }
+
+  return [...marksArray, generateMark(max, marksAdditionalLabel)];
 };

--- a/console/ui/src/shared/ui/slider-box/ui/index.tsx
+++ b/console/ui/src/shared/ui/slider-box/ui/index.tsx
@@ -72,7 +72,7 @@ const ClusterSliderBox: FC<SliderBoxProps> = ({
       border={`1px solid ${theme.palette.divider}`}
       height="100px"
       borderRadius="8px"
-      overflow="hidden">
+      overflow="visible">
       <Box
         display="flex"
         alignItems="center"
@@ -102,7 +102,7 @@ const ClusterSliderBox: FC<SliderBoxProps> = ({
         flexDirection="column"
         justifyContent="center"
         width="100%"
-        padding="32px">
+        padding={topRightElements ? '32px' : '32px 32px 24px'}>
         {topRightElements ?? null}
         <Slider
           value={allowZero ? sliderValue : amount}
@@ -113,6 +113,9 @@ const ClusterSliderBox: FC<SliderBoxProps> = ({
           min={allowZero ? 0 : min}
           max={max}
           marks={sliderMarks}
+          sx={{
+            '& .MuiSlider-markLabel': { marginTop: '-8px' },
+          }}
         />
       </Box>
     </Box>


### PR DESCRIPTION
Limit the cluster creation form width on large screens and keep the summary panel alongside it. Limit the PostgreSQL version dropdown to approximately five entries, show each version’s release/end-of-life date, and highlight unsupported versions. And minor style updates.