### PR TITLE
Add reinit_pgcluster playbook

### DIFF
--- a/automation/README.md
+++ b/automation/README.md
@@ -99,10 +99,11 @@ Autobase adheres to a modular design separating atomic logic (roles) and orchest
 #### Maintenance
 
 - `config_pgcluster` – Reconfigure PostgreSQL cluster settings (users, databases, extensions, etc.) after the initial deployment.
-- `update_pgcluster` – Perform rolling updates of PostgreSQL or system packages with minimal downtime.
 - `restart_pgcluster` – Restart PostgreSQL cluster services.
 - `switchover_pgcluster` – Switch the Patroni leader role to a replica.
 - `failover_pgcluster` – Promote the Patroni replica when there is no healthy Patroni leader.
+- `reinit_pgcluster` – Rebuild a Patroni replica. Set the required `patroni_reinit_member_name` to the Patroni node name.
+- `update_pgcluster` – Perform rolling updates of PostgreSQL or system packages with minimal downtime.
 - `pg_upgrade` – Perform a major version in-place upgrade of PostgreSQL with minimal downtime.
   - `pg_upgrade_rollback` - Performs a rollback of a PostgreSQL upgrade (if possible).
 - `pg_logical_upgrade` - Upgrades the target cluster and converting a physical replica into a logical replica.

--- a/automation/playbooks/reinit_pgcluster.yml
+++ b/automation/playbooks/reinit_pgcluster.yml
@@ -100,11 +100,10 @@
 
 - name: vitabaks.autobase.reinit_pgcluster | Reinitialize Patroni replica
   hosts: primary
-  gather_facts: false
+  gather_facts: true
   become: true
   become_method: sudo
   any_errors_fatal: true
-  environment: "{{ proxy_env | default({}) }}"
   tasks:
     - name: Validate Patroni reinit member
       ansible.builtin.assert:

--- a/automation/playbooks/reinit_pgcluster.yml
+++ b/automation/playbooks/reinit_pgcluster.yml
@@ -114,7 +114,7 @@
     - name: Validate Patroni reinit member
       ansible.builtin.assert:
         that:
-          - patroni_reinit_member_name in
+          - patroni_reinit_member_name | default('') in
             (groups.get('secondary', [])
             | map('extract', hostvars)
             | map(attribute='ansible_hostname')
@@ -128,8 +128,14 @@
         name: vitabaks.autobase.patroni
         tasks_from: reinit
 
-    - name: Inform about Patroni reinitialization progress
+    - name: Inform about asynchronous Patroni reinitialization
       ansible.builtin.debug:
         msg:
           - "Reinitialization request for Patroni replica '{{ patroni_reinit_member_name }}' was accepted."
           - "Please wait until the replica is healthy before continuing."
+      when: not (patroni_reinit_wait | default(false) | bool)
+
+    - name: Confirm Patroni replica reinitialization is complete
+      ansible.builtin.debug:
+        msg: "Patroni replica '{{ patroni_reinit_member_name }}' was reinitialized and is healthy."
+      when: patroni_reinit_wait | default(false) | bool

--- a/automation/playbooks/reinit_pgcluster.yml
+++ b/automation/playbooks/reinit_pgcluster.yml
@@ -6,6 +6,12 @@
   become_method: sudo
   any_errors_fatal: true
   tasks:
+    - name: Require Patroni reinit member name
+      ansible.builtin.assert:
+        that: patroni_reinit_member_name | default('') | length > 0
+        fail_msg: >-
+          Set patroni_reinit_member_name to the Patroni replica node name to reinitialize.
+
     - name: Gather package facts
       ansible.builtin.package_facts:
         manager: auto
@@ -108,7 +114,6 @@
     - name: Validate Patroni reinit member
       ansible.builtin.assert:
         that:
-          - patroni_reinit_member_name | default('') | length > 0
           - patroni_reinit_member_name in
             (groups.get('secondary', [])
             | map('extract', hostvars)

--- a/automation/playbooks/reinit_pgcluster.yml
+++ b/automation/playbooks/reinit_pgcluster.yml
@@ -11,6 +11,7 @@
         that: patroni_reinit_member_name | default('') | length > 0
         fail_msg: >-
           Set patroni_reinit_member_name to the Patroni replica node name to reinitialize.
+      when: inventory_hostname == groups['postgres_cluster'][0]
 
     - name: Gather package facts
       ansible.builtin.package_facts:

--- a/automation/playbooks/reinit_pgcluster.yml
+++ b/automation/playbooks/reinit_pgcluster.yml
@@ -127,3 +127,9 @@
       ansible.builtin.import_role:
         name: vitabaks.autobase.patroni
         tasks_from: reinit
+
+    - name: Inform about Patroni reinitialization progress
+      ansible.builtin.debug:
+        msg:
+          - "Reinitialization request for Patroni replica '{{ patroni_reinit_member_name }}' was accepted."
+          - "Please wait until the replica is healthy before continuing."

--- a/automation/playbooks/reinit_pgcluster.yml
+++ b/automation/playbooks/reinit_pgcluster.yml
@@ -1,0 +1,125 @@
+---
+- name: vitabaks.autobase.reinit_pgcluster | Prepare PostgreSQL Cluster Reinitialization
+  hosts: postgres_cluster
+  gather_facts: true
+  become: true
+  become_method: sudo
+  any_errors_fatal: true
+  tasks:
+    - name: Gather package facts
+      ansible.builtin.package_facts:
+        manager: auto
+      check_mode: false
+      when: ansible_facts.packages is not defined
+
+    - name: Define bind_address
+      ansible.builtin.import_role:
+        name: vitabaks.autobase.bind_address
+      when: bind_address is not defined
+
+    - name: Set default variables
+      ansible.builtin.import_role:
+        name: vitabaks.autobase.common
+
+    - name: "[Prepare] Get Patroni Cluster Leader Node"
+      ansible.builtin.uri:
+        url: >-
+          {{ patroni_restapi_protocol | default('https') }}://{{ patroni_restapi_connect_addr
+            | default(patroni_bind_address | default(bind_address, true), true) }}:{{ patroni_restapi_port
+            | default('8008') }}/leader
+        status_code: 200
+        ca_path: "{{ patroni_restapi_cafile | default(omit, true) }}"
+      register: reinit_patroni_leader_result
+      changed_when: false
+      failed_when: false
+      check_mode: false
+      environment:
+        no_proxy: "{{ patroni_bind_address | default(bind_address, true) }}"
+      when:
+        - (groups.get('postgres_cluster', [])
+            | map('extract', hostvars)
+            | selectattr('patroni_leader_result.status', 'defined')
+            | selectattr('patroni_leader_result.status', 'equalto', 200)
+            | list | length) == 0
+
+    - name: "[Prepare] Set Patroni leader result variable"
+      ansible.builtin.set_fact:
+        leader_result: >-
+          {{
+            reinit_patroni_leader_result
+            if reinit_patroni_leader_result.status is defined
+            else patroni_leader_result | default({})
+          }}
+      changed_when: false
+
+    - name: The Patroni cluster is unhealthy
+      ansible.builtin.fail:
+        msg: >
+          No healthy leader node detected in cluster '{{ patroni_cluster_name | default('postgres-cluster') }}'.
+          Please ensure the cluster is up and node responds on REST API port ({{ patroni_restapi_port | default('8008') }}).
+      when:
+        - inventory_hostname == groups['postgres_cluster'][0]
+        - (groups.get('postgres_cluster', [])
+            | map('extract', hostvars)
+            | selectattr('leader_result.status', 'defined')
+            | selectattr('leader_result.status', 'equalto', 200)
+            | list | length) == 0
+
+    - name: '[Prepare] Add host to group "primary" (in-memory inventory)'
+      ansible.builtin.add_host:
+        name: "{{ item }}"
+        groups: primary
+        postgresql_exists: true
+      when:
+        - groups.get('primary', []) | length < 1
+        - hostvars[item]['leader_result']['status'] | default(0) == 200
+      loop: "{{ groups['postgres_cluster'] }}"
+      changed_when: false
+      check_mode: false
+
+    - name: '[Prepare] Add hosts to group "secondary" (in-memory inventory)'
+      ansible.builtin.add_host:
+        name: "{{ item }}"
+        groups: secondary
+        postgresql_exists: true
+      when:
+        - groups.get('secondary', []) | length < 1
+        - hostvars[item]['leader_result']['status'] | default(0) == 503
+      loop: "{{ groups['postgres_cluster'] }}"
+      changed_when: false
+      check_mode: false
+
+    - name: Print Patroni Cluster info
+      ansible.builtin.debug:
+        msg:
+          - "Cluster Name: {{ patroni_cluster_name | default('postgres-cluster') }}"
+          - "Cluster Leader: {{ ansible_hostname }}"
+      when:
+        - groups.get('primary', []) | length > 0
+        - inventory_hostname in groups['primary']
+
+- name: vitabaks.autobase.reinit_pgcluster | Reinitialize Patroni replica
+  hosts: primary
+  gather_facts: false
+  become: true
+  become_method: sudo
+  any_errors_fatal: true
+  environment: "{{ proxy_env | default({}) }}"
+  tasks:
+    - name: Validate Patroni reinit member
+      ansible.builtin.assert:
+        that:
+          - patroni_reinit_member_name | default('') | length > 0
+          - patroni_reinit_member_name in
+            (groups.get('secondary', [])
+            | map('extract', hostvars)
+            | map(attribute='ansible_hostname')
+            | list)
+        fail_msg: >-
+          Reinit member '{{ patroni_reinit_member_name | default('') }}' is not a Patroni replica in cluster
+          '{{ patroni_cluster_name | default('postgres-cluster') }}'.
+
+    - name: Reinitialize Patroni replica
+      ansible.builtin.import_role:
+        name: vitabaks.autobase.patroni
+        tasks_from: reinit

--- a/automation/roles/common/defaults/main.yml
+++ b/automation/roles/common/defaults/main.yml
@@ -597,6 +597,7 @@ patroni_switchover_candidate_name: "" # optional Patroni node name to promote du
 patroni_failover_candidate_name: "" # optional Patroni node name to promote during failover.
 patroni_failover_force: false # allow failover when a healthy Patroni leader is detected.
 patroni_reinit_member_name: "" # Patroni replica node name to reinitialize.
+patroni_reinit_wait: false # wait for the reinitialized replica to become healthy.
 
 patroni_use_unix_socket: true # specifies that Patroni should prefer to use unix sockets to connect to the cluster.
 patroni_use_unix_socket_repl: true # specifies that Patroni should prefer to use unix sockets for replication user cluster connection.

--- a/automation/roles/common/defaults/main.yml
+++ b/automation/roles/common/defaults/main.yml
@@ -596,6 +596,7 @@ patroni_failsafe_mode: true # enable Patroni DCS failsafe mode
 patroni_switchover_candidate_name: "" # optional Patroni node name to promote during switchover.
 patroni_failover_candidate_name: "" # optional Patroni node name to promote during failover.
 patroni_failover_force: false # allow failover when a healthy Patroni leader is detected.
+patroni_reinit_member_name: "" # Patroni replica node name to reinitialize.
 
 patroni_use_unix_socket: true # specifies that Patroni should prefer to use unix sockets to connect to the cluster.
 patroni_use_unix_socket_repl: true # specifies that Patroni should prefer to use unix sockets for replication user cluster connection.

--- a/automation/roles/patroni/README.md
+++ b/automation/roles/patroni/README.md
@@ -19,6 +19,7 @@ This role installs and configures [Patroni](https://github.com/patroni/patroni),
 | `patroni_failover_candidate_name`  | `""`                 | Optional Patroni node name to promote during a failover.                                                          |
 | `patroni_failover_force`           | `false`              | Allow failover when a healthy Patroni leader is detected.                                                         |
 | `patroni_reinit_member_name`        | `""`                 | Patroni replica node name to rebuild with `reinit_pgcluster`.                                                   |
+| `patroni_reinit_wait`               | `false`              | Wait for the reinitialized replica to become healthy, up to `cluster_restore_timeout`.                          |
 
 ### Installation Configuration
 

--- a/automation/roles/patroni/README.md
+++ b/automation/roles/patroni/README.md
@@ -18,6 +18,7 @@ This role installs and configures [Patroni](https://github.com/patroni/patroni),
 | `patroni_switchover_candidate_name` | `""`                | Optional Patroni node name to promote during a switchover.                                                        |
 | `patroni_failover_candidate_name`  | `""`                 | Optional Patroni node name to promote during a failover.                                                          |
 | `patroni_failover_force`           | `false`              | Allow failover when a healthy Patroni leader is detected.                                                         |
+| `patroni_reinit_member_name`        | `""`                 | Patroni replica node name to rebuild with `reinit_pgcluster`.                                                   |
 
 ### Installation Configuration
 

--- a/automation/roles/patroni/tasks/reinit.yml
+++ b/automation/roles/patroni/tasks/reinit.yml
@@ -1,0 +1,9 @@
+---
+- name: Reinitialize the selected Patroni replica
+  become: true
+  become_user: postgres
+  ansible.builtin.command: >-
+    patronictl -c /etc/patroni/patroni.yml reinit {{ patroni_cluster_name }}
+    {{ patroni_reinit_member_name }} --force
+  environment:
+    PATH: "{{ ansible_env.PATH | default('') }}:/usr/bin:/usr/local/bin"

--- a/automation/roles/patroni/tasks/reinit.yml
+++ b/automation/roles/patroni/tasks/reinit.yml
@@ -7,3 +7,29 @@
     {{ patroni_reinit_member_name }} --force
   environment:
     PATH: "{{ ansible_env.PATH | default('') }}:/usr/bin:/usr/local/bin"
+
+- name: Wait for Patroni replica reinitialization to complete
+  ansible.builtin.uri:
+    url: >-
+      {{ patroni_restapi_protocol | default('https') }}://{{ hostvars[reinit_member].patroni_restapi_connect_addr
+        | default(hostvars[reinit_member].patroni_bind_address
+        | default(hostvars[reinit_member].bind_address, true), true) }}:{{ patroni_restapi_port
+        | default('8008') }}/replica
+    status_code: 200
+    ca_path: "{{ patroni_restapi_cafile | default(omit, true) }}"
+  register: patroni_reinit_replica_result
+  changed_when: false
+  failed_when: false
+  check_mode: false
+  until: patroni_reinit_replica_result.status | default(0) == 200
+  retries: "{{ (cluster_restore_timeout | default(86400) | int) // 30 }}"
+  delay: 30
+  environment:
+    no_proxy: "{{ patroni_bind_address | default(bind_address, true) }}"
+  loop: "{{ groups.get('secondary', []) }}"
+  loop_control:
+    loop_var: reinit_member
+    label: "{{ reinit_member }}"
+  when:
+    - patroni_reinit_wait | default(false) | bool
+    - hostvars[reinit_member].ansible_hostname == patroni_reinit_member_name | default('')


### PR DESCRIPTION
 Includes a new playbook `reinit_pgcluster.yml` that validates and rebuilds a selected replica via patronictl, required variable `patroni_reinit_member_name`. 

Useful for recovering replicas with corrupted data or inconsistent state.