### PR TITLE
Add restart_pgnode playbook

### DIFF
--- a/automation/README.md
+++ b/automation/README.md
@@ -99,7 +99,8 @@ Autobase adheres to a modular design separating atomic logic (roles) and orchest
 #### Maintenance
 
 - `config_pgcluster` – Reconfigure PostgreSQL cluster settings (users, databases, extensions, etc.) after the initial deployment.
-- `restart_pgcluster` – Restart PostgreSQL cluster services.
+- `restart_pgcluster` – Restart PostgreSQL in the entire cluster.
+- `restart_pgnode` – Restart PostgreSQL on a specific Patroni node. Set the required `patroni_restart_node_name` to the Patroni node name.
 - `switchover_pgcluster` – Switch the Patroni leader role to a replica.
 - `failover_pgcluster` – Promote the Patroni replica when there is no healthy Patroni leader.
 - `reinit_pgcluster` – Rebuild a Patroni replica. Set the required `patroni_reinit_member_name` to the Patroni node name.

--- a/automation/playbooks/restart_pgnode.yml
+++ b/automation/playbooks/restart_pgnode.yml
@@ -1,0 +1,156 @@
+---
+- name: vitabaks.autobase.restart_pgnode | Restart PostgreSQL Cluster node
+  hosts: postgres_cluster
+  gather_facts: true
+  become: true
+  become_method: sudo
+  any_errors_fatal: true
+  tasks:
+    - name: Gather package facts
+      ansible.builtin.package_facts:
+        manager: auto
+      check_mode: false
+      when: ansible_facts.packages is not defined
+
+    - name: Define bind_address
+      ansible.builtin.import_role:
+        name: vitabaks.autobase.bind_address
+      when: bind_address is not defined
+
+    - name: Set default variables
+      ansible.builtin.import_role:
+        name: vitabaks.autobase.common
+
+    - name: Require Patroni restart node name
+      ansible.builtin.assert:
+        that: patroni_restart_node_name | default('') | length > 0
+        fail_msg: >-
+          Set patroni_restart_node_name to the Patroni node name to restart.
+      when: inventory_hostname == groups['postgres_cluster'][0]
+
+    - name: Validate Patroni restart node exists
+      ansible.builtin.assert:
+        that: >-
+          patroni_restart_node_name | default('') in
+          (groups.get('postgres_cluster', [])
+          | map('extract', hostvars)
+          | map(attribute='ansible_hostname')
+          | list)
+        fail_msg: >-
+          Patroni restart node '{{ patroni_restart_node_name | default('') }}' was not found in cluster
+          '{{ patroni_cluster_name | default('postgres-cluster') }}'.
+      when: inventory_hostname == groups['postgres_cluster'][0]
+
+    - name: "[Prepare] Get Patroni Cluster Leader Node"
+      ansible.builtin.uri:
+        url: >-
+          {{ patroni_restapi_protocol | default('https') }}://{{ patroni_restapi_connect_addr
+            | default(patroni_bind_address | default(bind_address, true), true) }}:{{ patroni_restapi_port
+            | default('8008') }}/leader
+        status_code: 200
+        ca_path: "{{ patroni_restapi_cafile | default(omit, true) }}"
+      register: restart_node_patroni_leader_result
+      changed_when: false
+      failed_when: false
+      check_mode: false
+      environment:
+        no_proxy: "{{ patroni_bind_address | default(bind_address, true) }}"
+      when:
+        - (groups.get('postgres_cluster', [])
+            | map('extract', hostvars)
+            | selectattr('patroni_leader_result.status', 'defined')
+            | selectattr('patroni_leader_result.status', 'equalto', 200)
+            | list | length) == 0
+
+    - name: "[Prepare] Set Patroni leader result variable"
+      ansible.builtin.set_fact:
+        leader_result: >-
+          {{
+            restart_node_patroni_leader_result
+            if restart_node_patroni_leader_result.status is defined
+            else patroni_leader_result | default({})
+          }}
+      changed_when: false
+
+    - name: The Patroni cluster is unhealthy
+      ansible.builtin.fail:
+        msg: >
+          No healthy leader node detected in cluster '{{ patroni_cluster_name | default('postgres-cluster') }}'.
+          Please ensure the cluster is up and node responds on REST API port ({{ patroni_restapi_port | default('8008') }}).
+      when:
+        - inventory_hostname == groups['postgres_cluster'][0]
+        - (groups.get('postgres_cluster', [])
+            | map('extract', hostvars)
+            | selectattr('leader_result.status', 'defined')
+            | selectattr('leader_result.status', 'equalto', 200)
+            | list | length) == 0
+
+    - name: '[Prepare] Add host to group "primary" (in-memory inventory)'
+      ansible.builtin.add_host:
+        name: "{{ item }}"
+        groups: primary
+        postgresql_exists: true
+      when:
+        - groups.get('primary', []) | length < 1
+        - hostvars[item]['leader_result']['status'] | default(0) == 200
+      loop: "{{ groups['postgres_cluster'] }}"
+      changed_when: false
+      check_mode: false
+
+    - name: '[Prepare] Add hosts to group "secondary" (in-memory inventory)'
+      ansible.builtin.add_host:
+        name: "{{ item }}"
+        groups: secondary
+        postgresql_exists: true
+      when:
+        - groups.get('secondary', []) | length < 1
+        - hostvars[item]['leader_result']['status'] | default(0) == 503
+      loop: "{{ groups['postgres_cluster'] }}"
+      changed_when: false
+      check_mode: false
+
+    - name: "Print Patroni Cluster info"
+      ansible.builtin.debug:
+        msg:
+          - "Cluster Name: {{ patroni_cluster_name | default('postgres-cluster') }}"
+          - "Cluster Leader: {{ ansible_hostname }}"
+      when:
+        - groups.get('primary', []) | length > 0
+        - inventory_hostname in groups['primary']
+
+    - name: Get current Patroni passwords
+      ansible.builtin.import_role:
+        name: vitabaks.autobase.pre_checks
+        tasks_from: passwords
+      vars:
+        source_group: primary
+        postgresql_cluster_maintenance: true
+      when: patroni_superuser_password | default('') | length < 1
+
+    - name: Stop read-only traffic on replica
+      ansible.builtin.import_role:
+        name: vitabaks.autobase.update
+        tasks_from: stop_traffic
+      when:
+        - ansible_hostname == patroni_restart_node_name | default('')
+        - inventory_hostname in groups.get('secondary', [])
+
+    - name: Stop services
+      ansible.builtin.import_role:
+        name: vitabaks.autobase.update
+        tasks_from: stop_services
+      when: ansible_hostname == patroni_restart_node_name | default('')
+
+    - name: Start services
+      ansible.builtin.import_role:
+        name: vitabaks.autobase.update
+        tasks_from: start_services
+      when: ansible_hostname == patroni_restart_node_name | default('')
+
+    - name: Start read-only traffic on replica
+      ansible.builtin.import_role:
+        name: vitabaks.autobase.update
+        tasks_from: start_traffic
+      when:
+        - ansible_hostname == patroni_restart_node_name | default('')
+        - inventory_hostname in groups.get('secondary', [])

--- a/automation/roles/patroni/README.md
+++ b/automation/roles/patroni/README.md
@@ -20,6 +20,7 @@ This role installs and configures [Patroni](https://github.com/patroni/patroni),
 | `patroni_failover_force`           | `false`              | Allow failover when a healthy Patroni leader is detected.                                                         |
 | `patroni_reinit_member_name`        | `""`                 | Patroni replica node name to rebuild with `reinit_pgcluster`.                                                   |
 | `patroni_reinit_wait`               | `false`              | Wait for the reinitialized replica to become healthy, up to `cluster_restore_timeout`.                          |
+| `patroni_restart_node_name`          | `""`                 | Patroni node name to restart with `restart_pgnode`.                                    |
 
 ### Installation Configuration
 

--- a/automation/roles/update/README.md
+++ b/automation/roles/update/README.md
@@ -153,3 +153,4 @@ When using load balancing for read-only traffic (the "Type A" and "Type C" schem
 
 This role depends on:
 - `vitabaks.autobase.common` - Provides common variables and configurations
+- `vitabaks.autobase.patroni` - Uses the `switchover` task


### PR DESCRIPTION
Add a new Ansible playbook `restart_pgnode.yml` to restart PostgreSQL on a specific Patroni node. Set the required `patroni_restart_node_name` to the Patroni node name.