### PR TITLE
Add start/stop playbooks

### DIFF
--- a/automation/README.md
+++ b/automation/README.md
@@ -99,7 +99,11 @@ Autobase adheres to a modular design separating atomic logic (roles) and orchest
 #### Maintenance
 
 - `config_pgcluster` – Reconfigure PostgreSQL cluster settings (users, databases, extensions, etc.) after the initial deployment.
+- `stop_pgcluster` – Gracefully stop the entire Patroni cluster.
+- `start_pgcluster` – Start the entire Patroni cluster.
 - `restart_pgcluster` – Restart PostgreSQL in the entire cluster.
+- `stop_pgnode` – Stop PostgreSQL on a specific Patroni node. Set the required `patroni_stop_node_name` to the Patroni node name.
+- `start_pgnode` – Start PostgreSQL on a specific Patroni node. Set the required `patroni_start_node_name` to the Patroni node name.
 - `restart_pgnode` – Restart PostgreSQL on a specific Patroni node. Set the required `patroni_restart_node_name` to the Patroni node name.
 - `switchover_pgcluster` – Switch the Patroni leader role to a replica.
 - `failover_pgcluster` – Promote the Patroni replica when there is no healthy Patroni leader.

--- a/automation/playbooks/failover_pgcluster.yml
+++ b/automation/playbooks/failover_pgcluster.yml
@@ -43,7 +43,7 @@
           A healthy Patroni leader is present in cluster '{{ patroni_cluster_name | default('postgres-cluster') }}'.
           Use switchover_pgcluster.yml for a planned role change.
       when:
-        - not patroni_failover_force | bool
+        - not patroni_failover_force | default(false) | bool
         - inventory_hostname == groups['postgres_cluster'][0]
         - (groups.get('postgres_cluster', [])
             | map('extract', hostvars)

--- a/automation/playbooks/start_pgcluster.yml
+++ b/automation/playbooks/start_pgcluster.yml
@@ -1,0 +1,21 @@
+---
+- name: vitabaks.autobase.start_pgcluster | Start Patroni services
+  hosts: postgres_cluster
+  gather_facts: true
+  become: true
+  become_method: sudo
+  any_errors_fatal: true
+  tasks:
+    - name: Define bind_address
+      ansible.builtin.import_role:
+        name: vitabaks.autobase.bind_address
+      when: bind_address is not defined
+
+    - name: Set default variables
+      ansible.builtin.import_role:
+        name: vitabaks.autobase.common
+
+    - name: Start services
+      ansible.builtin.import_role:
+        name: vitabaks.autobase.update
+        tasks_from: start_services

--- a/automation/playbooks/start_pgnode.yml
+++ b/automation/playbooks/start_pgnode.yml
@@ -1,0 +1,42 @@
+---
+- name: vitabaks.autobase.start_pgnode | Start PostgreSQL Cluster node
+  hosts: postgres_cluster
+  gather_facts: true
+  become: true
+  become_method: sudo
+  any_errors_fatal: true
+  tasks:
+    - name: Define bind_address
+      ansible.builtin.import_role:
+        name: vitabaks.autobase.bind_address
+      when: bind_address is not defined
+
+    - name: Set default variables
+      ansible.builtin.import_role:
+        name: vitabaks.autobase.common
+
+    - name: Require Patroni start node name
+      ansible.builtin.assert:
+        that: patroni_start_node_name | default('') | length > 0
+        fail_msg: >-
+          Set patroni_start_node_name to the Patroni node name to start.
+      when: inventory_hostname == groups['postgres_cluster'][0]
+
+    - name: Validate Patroni start node exists
+      ansible.builtin.assert:
+        that: >-
+          patroni_start_node_name | default('') in
+          (groups.get('postgres_cluster', [])
+          | map('extract', hostvars)
+          | map(attribute='ansible_hostname')
+          | list)
+        fail_msg: >-
+          Patroni start node '{{ patroni_start_node_name | default('') }}' was not found in cluster
+          '{{ patroni_cluster_name | default('postgres-cluster') }}'.
+      when: inventory_hostname == groups['postgres_cluster'][0]
+
+    - name: Start services on the selected node
+      ansible.builtin.import_role:
+        name: vitabaks.autobase.update
+        tasks_from: start_services
+      when: ansible_hostname == patroni_start_node_name | default('')

--- a/automation/playbooks/stop_pgcluster.yml
+++ b/automation/playbooks/stop_pgcluster.yml
@@ -1,0 +1,123 @@
+---
+- name: vitabaks.autobase.stop_pgcluster | PostgreSQL Cluster shutdown
+  hosts: postgres_cluster
+  gather_facts: true
+  become: true
+  become_method: sudo
+  any_errors_fatal: true
+  tasks:
+    - name: Gather package facts
+      ansible.builtin.package_facts:
+        manager: auto
+      check_mode: false
+      when: ansible_facts.packages is not defined
+
+    - name: Define bind_address
+      ansible.builtin.import_role:
+        name: vitabaks.autobase.bind_address
+      when: bind_address is not defined
+
+    - name: Set default variables
+      ansible.builtin.import_role:
+        name: vitabaks.autobase.common
+
+    - name: "[Prepare] Get Patroni Cluster Leader Node"
+      ansible.builtin.uri:
+        url: >-
+          {{ patroni_restapi_protocol | default('https') }}://{{ patroni_restapi_connect_addr
+            | default(patroni_bind_address | default(bind_address, true), true) }}:{{ patroni_restapi_port
+            | default('8008') }}/leader
+        status_code: 200
+        ca_path: "{{ patroni_restapi_cafile | default(omit, true) }}"
+      register: stop_patroni_leader_result
+      changed_when: false
+      failed_when: false
+      check_mode: false
+      environment:
+        no_proxy: "{{ patroni_bind_address | default(bind_address, true) }}"
+      when:
+        - (groups.get('postgres_cluster', [])
+            | map('extract', hostvars)
+            | selectattr('patroni_leader_result.status', 'defined')
+            | selectattr('patroni_leader_result.status', 'equalto', 200)
+            | list | length) == 0
+
+    - name: "[Prepare] Set Patroni leader result variable"
+      ansible.builtin.set_fact:
+        leader_result: >-
+          {{
+            stop_patroni_leader_result
+            if stop_patroni_leader_result.status is defined
+            else patroni_leader_result | default({})
+          }}
+      changed_when: false
+
+    - name: The Patroni cluster is unhealthy
+      ansible.builtin.fail:
+        msg: >
+          No healthy leader node detected in cluster '{{ patroni_cluster_name | default('postgres-cluster') }}'.
+          Please ensure the cluster is up and node responds on REST API port ({{ patroni_restapi_port | default('8008') }}).
+      when:
+        - inventory_hostname == groups['postgres_cluster'][0]
+        - (groups.get('postgres_cluster', [])
+            | map('extract', hostvars)
+            | selectattr('leader_result.status', 'defined')
+            | selectattr('leader_result.status', 'equalto', 200)
+            | list | length) == 0
+
+    - name: '[Prepare] Add host to group "primary" (in-memory inventory)'
+      ansible.builtin.add_host:
+        name: "{{ item }}"
+        groups: primary
+        postgresql_exists: true
+      when:
+        - groups.get('primary', []) | length < 1
+        - hostvars[item]['leader_result']['status'] | default(0) == 200
+      loop: "{{ groups['postgres_cluster'] }}"
+      changed_when: false
+      check_mode: false
+
+    - name: '[Prepare] Add hosts to group "secondary" (in-memory inventory)'
+      ansible.builtin.add_host:
+        name: "{{ item }}"
+        groups: secondary
+        postgresql_exists: true
+      when:
+        - groups.get('secondary', []) | length < 1
+        - hostvars[item]['leader_result']['status'] | default(0) == 503
+      loop: "{{ groups['postgres_cluster'] }}"
+      changed_when: false
+      check_mode: false
+
+    - name: Get current Patroni passwords
+      ansible.builtin.import_role:
+        name: vitabaks.autobase.pre_checks
+        tasks_from: passwords
+      vars:
+        source_group: primary
+        postgresql_cluster_maintenance: true
+      when: patroni_superuser_password | default('') | length < 1
+
+- name: vitabaks.autobase.stop_pgcluster | Stop Patroni on secondaries
+  hosts: secondary
+  gather_facts: false
+  become: true
+  become_method: sudo
+  any_errors_fatal: true
+  tasks:
+    - name: Stop services
+      ansible.builtin.import_role:
+        name: vitabaks.autobase.update
+        tasks_from: stop_services
+
+- name: vitabaks.autobase.stop_pgcluster | Stop Patroni on primary
+  hosts: primary
+  gather_facts: false
+  become: true
+  become_method: sudo
+  any_errors_fatal: true
+  tasks:
+    - name: Stop services
+      ansible.builtin.import_role:
+        name: vitabaks.autobase.update
+        tasks_from: stop_services

--- a/automation/playbooks/stop_pgnode.yml
+++ b/automation/playbooks/stop_pgnode.yml
@@ -1,0 +1,125 @@
+---
+- name: vitabaks.autobase.stop_pgnode | Stop PostgreSQL Cluster node
+  hosts: postgres_cluster
+  gather_facts: true
+  become: true
+  become_method: sudo
+  any_errors_fatal: true
+  tasks:
+    - name: Gather package facts
+      ansible.builtin.package_facts:
+        manager: auto
+      check_mode: false
+      when: ansible_facts.packages is not defined
+
+    - name: Define bind_address
+      ansible.builtin.import_role:
+        name: vitabaks.autobase.bind_address
+      when: bind_address is not defined
+
+    - name: Set default variables
+      ansible.builtin.import_role:
+        name: vitabaks.autobase.common
+
+    - name: Require Patroni stop node name
+      ansible.builtin.assert:
+        that: patroni_stop_node_name | default('') | length > 0
+        fail_msg: >-
+          Set patroni_stop_node_name to the Patroni node name to stop.
+      when: inventory_hostname == groups['postgres_cluster'][0]
+
+    - name: Validate Patroni stop node exists
+      ansible.builtin.assert:
+        that: >-
+          patroni_stop_node_name | default('') in
+          (groups.get('postgres_cluster', [])
+          | map('extract', hostvars)
+          | map(attribute='ansible_hostname')
+          | list)
+        fail_msg: >-
+          Patroni stop node '{{ patroni_stop_node_name | default('') }}' was not found in cluster
+          '{{ patroni_cluster_name | default('postgres-cluster') }}'.
+      when: inventory_hostname == groups['postgres_cluster'][0]
+
+    - name: "[Prepare] Get Patroni Cluster Leader Node"
+      ansible.builtin.uri:
+        url: >-
+          {{ patroni_restapi_protocol | default('https') }}://{{ patroni_restapi_connect_addr
+            | default(patroni_bind_address | default(bind_address, true), true) }}:{{ patroni_restapi_port
+            | default('8008') }}/leader
+        status_code: 200
+        ca_path: "{{ patroni_restapi_cafile | default(omit, true) }}"
+      register: stop_node_patroni_leader_result
+      changed_when: false
+      failed_when: false
+      check_mode: false
+      environment:
+        no_proxy: "{{ patroni_bind_address | default(bind_address, true) }}"
+      when:
+        - (groups.get('postgres_cluster', [])
+            | map('extract', hostvars)
+            | selectattr('patroni_leader_result.status', 'defined')
+            | selectattr('patroni_leader_result.status', 'equalto', 200)
+            | list | length) == 0
+
+    - name: "[Prepare] Set Patroni leader result variable"
+      ansible.builtin.set_fact:
+        leader_result: >-
+          {{
+            stop_node_patroni_leader_result
+            if stop_node_patroni_leader_result.status is defined
+            else patroni_leader_result | default({})
+          }}
+      changed_when: false
+
+    - name: The Patroni cluster is unhealthy
+      ansible.builtin.fail:
+        msg: >
+          No healthy leader node detected in cluster '{{ patroni_cluster_name | default('postgres-cluster') }}'.
+          Please ensure the cluster is up and node responds on REST API port ({{ patroni_restapi_port | default('8008') }}).
+      when:
+        - inventory_hostname == groups['postgres_cluster'][0]
+        - (groups.get('postgres_cluster', [])
+            | map('extract', hostvars)
+            | selectattr('leader_result.status', 'defined')
+            | selectattr('leader_result.status', 'equalto', 200)
+            | list | length) == 0
+
+    - name: '[Prepare] Add host to group "primary" (in-memory inventory)'
+      ansible.builtin.add_host:
+        name: "{{ item }}"
+        groups: primary
+        postgresql_exists: true
+      when:
+        - groups.get('primary', []) | length < 1
+        - hostvars[item]['leader_result']['status'] | default(0) == 200
+      loop: "{{ groups['postgres_cluster'] }}"
+      changed_when: false
+      check_mode: false
+
+    - name: '[Prepare] Add hosts to group "secondary" (in-memory inventory)'
+      ansible.builtin.add_host:
+        name: "{{ item }}"
+        groups: secondary
+        postgresql_exists: true
+      when:
+        - groups.get('secondary', []) | length < 1
+        - hostvars[item]['leader_result']['status'] | default(0) == 503
+      loop: "{{ groups['postgres_cluster'] }}"
+      changed_when: false
+      check_mode: false
+
+    - name: Get current Patroni passwords
+      ansible.builtin.import_role:
+        name: vitabaks.autobase.pre_checks
+        tasks_from: passwords
+      vars:
+        source_group: primary
+        postgresql_cluster_maintenance: true
+      when: patroni_superuser_password | default('') | length < 1
+
+    - name: Stop services on the selected node
+      ansible.builtin.import_role:
+        name: vitabaks.autobase.update
+        tasks_from: stop_services
+      when: ansible_hostname == patroni_stop_node_name | default('')

--- a/automation/playbooks/switchover_pgcluster.yml
+++ b/automation/playbooks/switchover_pgcluster.yml
@@ -123,7 +123,7 @@
           | map(attribute='ansible_hostname')
           | list)
         fail_msg: >-
-          Switchover candidate '{{ patroni_switchover_candidate_name }}' is not a Patroni replica in cluster
+          Switchover candidate '{{ patroni_switchover_candidate_name | default('') }}' is not a Patroni replica in cluster
           '{{ patroni_cluster_name | default('postgres-cluster') }}'.
       when: patroni_switchover_candidate_name | default('') | length > 0
 

--- a/automation/roles/common/defaults/main.yml
+++ b/automation/roles/common/defaults/main.yml
@@ -593,11 +593,6 @@ patroni_master_start_timeout: 300
 patroni_maximum_lag_on_failover: 1048576 # (1MB) the maximum bytes a follower may lag to be able to participate in leader election.
 patroni_maximum_lag_on_replica: "100MB" # the maximum of lag that replica can be in order to be available for read-only queries.
 patroni_failsafe_mode: true # enable Patroni DCS failsafe mode
-patroni_switchover_candidate_name: "" # optional Patroni node name to promote during switchover.
-patroni_failover_candidate_name: "" # optional Patroni node name to promote during failover.
-patroni_failover_force: false # allow failover when a healthy Patroni leader is detected.
-patroni_reinit_member_name: "" # Patroni replica node name to reinitialize.
-patroni_reinit_wait: false # wait for the reinitialized replica to become healthy.
 
 patroni_use_unix_socket: true # specifies that Patroni should prefer to use unix sockets to connect to the cluster.
 patroni_use_unix_socket_repl: true # specifies that Patroni should prefer to use unix sockets for replication user cluster connection.

--- a/automation/roles/patroni/README.md
+++ b/automation/roles/patroni/README.md
@@ -21,6 +21,8 @@ This role installs and configures [Patroni](https://github.com/patroni/patroni),
 | `patroni_reinit_member_name`        | `""`                 | Patroni replica node name to rebuild with `reinit_pgcluster`.                                                   |
 | `patroni_reinit_wait`               | `false`              | Wait for the reinitialized replica to become healthy, up to `cluster_restore_timeout`.                          |
 | `patroni_restart_node_name`          | `""`                 | Patroni node name to restart with `restart_pgnode`.                                    |
+| `patroni_stop_node_name`             | `""`                 | Patroni node name to stop with `stop_pgnode`.                                                                   |
+| `patroni_start_node_name`            | `""`                 | Patroni node name to start with `start_pgnode`.                                                                 |
 
 ### Installation Configuration
 

--- a/automation/roles/patroni/tasks/reinit.yml
+++ b/automation/roles/patroni/tasks/reinit.yml
@@ -4,7 +4,7 @@
   become_user: postgres
   ansible.builtin.command: >-
     patronictl -c /etc/patroni/patroni.yml reinit {{ patroni_cluster_name }}
-    {{ patroni_reinit_member_name }} --force
+    {{ patroni_reinit_member_name | default('') }} --force
   environment:
     PATH: "{{ ansible_env.PATH | default('') }}:/usr/bin:/usr/local/bin"
 

--- a/automation/roles/update/tasks/stop_services.yml
+++ b/automation/roles/update/tasks/stop_services.yml
@@ -5,9 +5,6 @@
   become_user: postgres
   ansible.builtin.command: "{{ postgresql_bin_dir }}/pg_isready -p {{ postgresql_port }}"
   register: pg_isready_result
-  until: pg_isready_result.rc == 0
-  retries: 3
-  delay: 2
   changed_when: false
   failed_when: false
 

--- a/automation/roles/update/tasks/stop_services.yml
+++ b/automation/roles/update/tasks/stop_services.yml
@@ -1,14 +1,15 @@
 ---
-# pre-check
-- name: Check PostgreSQL is started and accepting connections
+# Check whether a checkpoint can be issued before stopping Patroni.
+- name: Check whether PostgreSQL is accepting connections
   become: true
   become_user: postgres
   ansible.builtin.command: "{{ postgresql_bin_dir }}/pg_isready -p {{ postgresql_port }}"
   register: pg_isready_result
   until: pg_isready_result.rc == 0
-  retries: 30
+  retries: 3
   delay: 2
   changed_when: false
+  failed_when: false
 
 # Stop the secondary
 - block:
@@ -19,6 +20,7 @@
         {{ postgresql_bin_dir }}/psql -h 127.0.0.1 -p {{ postgresql_port }} -U {{ patroni_superuser_username }} -d postgres -tAXc "CHECKPOINT"
       environment:
         PGPASSWORD: "{{ patroni_superuser_password }}"
+      when: pg_isready_result.rc == 0
 
     - name: "Stop Patroni service on the replica ({{ ansible_hostname | default('') }})"
       become: true
@@ -37,6 +39,7 @@
         {{ postgresql_bin_dir }}/psql -h 127.0.0.1 -p {{ postgresql_port }} -U {{ patroni_superuser_username }} -d postgres -tAXc "CHECKPOINT"
       environment:
         PGPASSWORD: "{{ patroni_superuser_password }}"
+      when: pg_isready_result.rc == 0
 
     - name: "Stop Patroni service on the leader ({{ ansible_hostname | default('') }})"
       become: true


### PR DESCRIPTION
Add four new Ansible playbooks for managing Patroni cluster and node lifecycle: `stop_pgcluster`, `start_pgcluster`, `stop_pgnode`, and `start_pgnode`. 

Update documentation with new playbook descriptions and variables (patroni_stop_node_name, patroni_start_node_name).