### PR TITLE
Create AWS S3 backup bucket before EC2 instances

### DIFF
--- a/automation/roles/cloud_resources/tasks/aws.yml
+++ b/automation/roles/cloud_resources/tasks/aws.yml
@@ -129,6 +129,23 @@
           vpc-id: "{{ vpc_id }}"
       register: vpc_info
 
+    # S3 bucket (Backups)
+    - name: "AWS: Create S3 bucket '{{ aws_s3_bucket_name | default('') }}'"
+      amazon.aws.s3_bucket:
+        access_key: "{{ lookup('ansible.builtin.env', 'AWS_ACCESS_KEY_ID') }}"
+        secret_key: "{{ lookup('ansible.builtin.env', 'AWS_SECRET_ACCESS_KEY') }}"
+        name: "{{ aws_s3_bucket_name }}"
+        region: "{{ aws_s3_bucket_region }}"
+        object_lock_enabled: "{{ aws_s3_bucket_object_lock_enabled }}"
+        encryption: "{{ aws_s3_bucket_encryption }}"
+        public_access:
+          block_public_acls: "{{ aws_s3_bucket_block_public_acls }}"
+          ignore_public_acls: "{{ aws_s3_bucket_ignore_public_acls }}"
+        state: present
+      when:
+        - (pgbackrest_install | bool or wal_g_install | bool)
+        - aws_s3_bucket_create | bool
+
     # Security Group (Firewall)
     - name: "AWS: Create or modify Security Group"
       amazon.aws.ec2_security_group:
@@ -588,22 +605,6 @@
         (item == 'replica' and server_count | int > 1) or
         (item in ['sync', 'async'] and server_count | int > 1 and synchronous_mode | bool))
 
-    # S3 bucket (Backups)
-    - name: "AWS: Create S3 bucket '{{ aws_s3_bucket_name | default('') }}'"
-      amazon.aws.s3_bucket:
-        access_key: "{{ lookup('ansible.builtin.env', 'AWS_ACCESS_KEY_ID') }}"
-        secret_key: "{{ lookup('ansible.builtin.env', 'AWS_SECRET_ACCESS_KEY') }}"
-        name: "{{ aws_s3_bucket_name }}"
-        region: "{{ aws_s3_bucket_region }}"
-        object_lock_enabled: "{{ aws_s3_bucket_object_lock_enabled }}"
-        encryption: "{{ aws_s3_bucket_encryption }}"
-        public_access:
-          block_public_acls: "{{ aws_s3_bucket_block_public_acls }}"
-          ignore_public_acls: "{{ aws_s3_bucket_ignore_public_acls }}"
-        state: present
-      when:
-        - (pgbackrest_install | bool or wal_g_install | bool)
-        - aws_s3_bucket_create | bool
   when: state == 'present'
 
 # Info


### PR DESCRIPTION
Move S3 bucket creation to the beginning of AWS provisioning. This ensures backup storage is available before creating EC2 instances and load balancers, preventing partially provisioned infrastructure when S3 creation fails.