### PR TITLE
Add authorized_keys role to config_pgcluster

### DIFF
--- a/automation/playbooks/config_pgcluster.yml
+++ b/automation/playbooks/config_pgcluster.yml
@@ -177,6 +177,7 @@
     - role: vitabaks.autobase.locales
     - role: vitabaks.autobase.ntp
     - role: vitabaks.autobase.ssh_keys
+    - role: vitabaks.autobase.authorized_keys
     - role: vitabaks.autobase.copy
     - role: vitabaks.autobase.pgpass
     - role: vitabaks.autobase.cron


### PR DESCRIPTION
Include the authorized_keys role in the config_pgcluster playbook to manage SSH authorized keys as part of the cluster configuration.