### PR TITLE
Stop THP service when disable_thp is false

### DIFF
--- a/automation/roles/transparent_huge_pages/README.md
+++ b/automation/roles/transparent_huge_pages/README.md
@@ -6,7 +6,7 @@ Disables Linux Transparent Huge Pages (THP) for better PostgreSQL performance. T
 
 | Variable    | Default | Description |
 |-------------|---------|-------------|
-| disable_thp | true    | When true, installs/enables a systemd service to disable THP and THP defrag. When false, the role does nothing. |
+| disable_thp | true    | When true, installs/enables a systemd service to disable THP and THP defrag. When false, stops and disables the service if it exists. |
 
 ## Notes
 - Idempotent; updates the unit at /etc/systemd/system/disable-transparent-huge-pages.service

--- a/automation/roles/transparent_huge_pages/tasks/main.yml
+++ b/automation/roles/transparent_huge_pages/tasks/main.yml
@@ -25,3 +25,21 @@
 
 - name: Make sure handlers are flushed immediately
   ansible.builtin.meta: flush_handlers
+
+# Disable service (if `disable_thp` is `false`)
+- block:
+    - name: Check if the disable-transparent-huge-pages service exists
+      ansible.builtin.stat:
+        path: /etc/systemd/system/disable-transparent-huge-pages.service
+      register: disable_thp_service
+
+    - name: Stop and disable the disable-transparent-huge-pages service
+      ansible.builtin.systemd:
+        name: disable-transparent-huge-pages.service
+        state: stopped
+        enabled: false
+      when: disable_thp_service.stat.exists
+  when:
+    - disable_thp is defined and not disable_thp | bool
+    - ansible_virtualization_type not in ['container', 'docker', 'lxc', 'podman']
+  tags: disable_thp, transparent_huge_pages


### PR DESCRIPTION
When the disable_thp variable is set to false, the role now actively stops and disables the disable-transparent-huge-pages service if it exists, rather than doing nothing. This allows users to clean up the service by re-running the role with disable_thp=false.

The service cleanup only runs on non-containerized environments, consistent with the service creation behavior.