### PR TITLE
Manage present/absent entries for hosts and DNS

### DIFF
--- a/automation/roles/common/defaults/main.yml
+++ b/automation/roles/common/defaults/main.yml
@@ -937,7 +937,7 @@ netdata_conf:
 nameservers: []
 #  - "1.1.1.1" # Cloudflare DNS (primary)
 #  - "8.8.8.8" # Google DNS (secondary)
-#  - { nameserver: "9.9.9.9", state: "absent" } # remove a DNS server entry
+#  - { entry: "9.9.9.9", state: "absent" } # remove a DNS server entry
 
 # /etc/hosts (optional)
 etc_hosts: []

--- a/automation/roles/common/defaults/main.yml
+++ b/automation/roles/common/defaults/main.yml
@@ -937,10 +937,12 @@ netdata_conf:
 nameservers: []
 #  - "1.1.1.1" # Cloudflare DNS (primary)
 #  - "8.8.8.8" # Google DNS (secondary)
+#  - { nameserver: "9.9.9.9", state: "absent" } # remove a DNS server entry
 
 # /etc/hosts (optional)
 etc_hosts: []
 #  - "10.128.64.143 pgbackrest.minio.local minio.local s3.eu-west-3.amazonaws.com"  # example (MinIO)
+#  - { entry: "10.0.0.11 db1 db1.local", state: "absent" } # remove a host entry
 #  - ""
 
 # NTP (Network Time Protocol) service

--- a/automation/roles/etc_hosts/README.md
+++ b/automation/roles/etc_hosts/README.md
@@ -1,12 +1,12 @@
 # Ansible Role: etc_hosts
 
-Adds or updates entries in /etc/hosts on target machines. Useful for PostgreSQL cluster nodes to resolve peers by name without external DNS.
+Adds, updates, or removes entries in /etc/hosts on target machines. Useful for PostgreSQL cluster nodes to resolve peers by name without external DNS.
 
 ## Variables
 
 | Variable   | Default | Description |
 |------------|---------|-------------|
-| etc_hosts  | []      | List of full-line host records to ensure in /etc/hosts. Each item should be the exact line you want present (e.g., "10.0.0.11 db1 db1.local"). |
+| etc_hosts  | []      | List of full-line host records to manage in /etc/hosts. String items are added. Mapping items accept `entry` and an optional `state` (`present` by default or `absent`). |
 
 ### Example 
 
@@ -15,8 +15,18 @@ etc_hosts:
   - "10.128.64.143 pgbackrest.minio.local minio.local s3.eu-west-3.amazonaws.com" 
 ```
 
+Use a mapping to remove an entry:
+
+```yaml
+etc_hosts:
+  - entry: "10.0.0.11 db1 db1.local"
+    state: present
+  - entry: "10.0.0.12 db2 db2.local"
+    state: absent
+```
+
 ## Notes
-- The role uses lineinfile with a regexp anchored to the beginning of the line, matching the provided text. Provide the full desired line to avoid duplicates.
+- The role matches the full provided entry. Provide the full line to add or remove.
 - unsafe_writes is enabled to avoid CI-related file lock issues.
 
 ## Dependencies

--- a/automation/roles/etc_hosts/tasks/main.yml
+++ b/automation/roles/etc_hosts/tasks/main.yml
@@ -1,11 +1,17 @@
 ---
-- name: Add entries into /etc/hosts file
+- name: Manage entries in /etc/hosts file
   ansible.builtin.lineinfile:
     path: /etc/hosts
-    regexp: "^{{ item }}"
-    line: "{{ item }}"
+    regexp: '^{{ etc_hosts_entry | regex_escape }}[ \t]*(?:#.*)?$'
+    line: "{{ etc_hosts_entry }}"
+    state: "{{ etc_hosts_entry_state }}"
     unsafe_writes: true # to prevent failures in CI
   loop: "{{ etc_hosts }}"
+  loop_control:
+    label: "{{ etc_hosts_entry }} ({{ etc_hosts_entry_state }})"
+  vars:
+    etc_hosts_entry: "{{ item.entry if item is mapping else item }}"
+    etc_hosts_entry_state: "{{ item.state | default('present') if item is mapping else 'present' }}"
   when:
     - etc_hosts is defined
     - etc_hosts | length > 0

--- a/automation/roles/resolv_conf/README.md
+++ b/automation/roles/resolv_conf/README.md
@@ -6,7 +6,7 @@ A role to manage system DNS resolvers by ensuring /etc/resolv.conf exists and ma
 
 | Variable     | Default | Description |
 |--------------|---------|-------------|
-| nameservers  | [] | List of DNS servers to manage in /etc/resolv.conf. String items are added. Mapping items accept `nameserver` and an optional `state` (`present` by default or `absent`). |
+| nameservers  | [] | List of DNS servers to manage in /etc/resolv.conf. String items are added. Mapping items accept `entry` and an optional `state` (`present` by default or `absent`). |
 
 Existing string-only configurations remain supported:
 
@@ -20,9 +20,9 @@ Use a mapping to remove a nameserver entry:
 
 ```yaml
 nameservers:
-  - nameserver: "1.1.1.1"
+  - entry: "1.1.1.1"
     state: present
-  - nameserver: "8.8.8.8"
+  - entry: "8.8.8.8"
     state: absent
 ```
 

--- a/automation/roles/resolv_conf/README.md
+++ b/automation/roles/resolv_conf/README.md
@@ -1,14 +1,32 @@
 # Ansible Role: resolv_conf
 
-A role to manage system DNS resolvers by ensuring /etc/resolv.conf exists and contains the provided nameserver entries.
+A role to manage system DNS resolvers by ensuring /etc/resolv.conf exists and managing the provided nameserver entries.
 
 ## Role Variables
 
 | Variable     | Default | Description |
 |--------------|---------|-------------|
-| nameservers  | not set (role does nothing if empty) | List of DNS servers to add to /etc/resolv.conf (e.g., ["1.1.1.1", "8.8.8.8"]). If inherited from the common role, the default is Cloudflare + Google. |
+| nameservers  | [] | List of DNS servers to manage in /etc/resolv.conf. String items are added. Mapping items accept `nameserver` and an optional `state` (`present` by default or `absent`). |
 
-Note: Existing lines are not removed or reordered; duplicates are avoided per entry via regexp.
+Existing string-only configurations remain supported:
+
+```yaml
+nameservers:
+  - "1.1.1.1"
+  - "8.8.8.8"
+```
+
+Use a mapping to remove a nameserver entry:
+
+```yaml
+nameservers:
+  - nameserver: "1.1.1.1"
+    state: present
+  - nameserver: "8.8.8.8"
+    state: absent
+```
+
+Note: Unlisted lines are not removed or reordered; duplicates are avoided per entry via regexp.
 
 ## Dependencies
 

--- a/automation/roles/resolv_conf/tasks/main.yml
+++ b/automation/roles/resolv_conf/tasks/main.yml
@@ -14,14 +14,20 @@
         mode: u=rw,g=r,o=r
       when: not resolv_conf.stat.exists
 
-    - name: Add DNS server(s) into /etc/resolv.conf
+    - name: Manage DNS server entries in /etc/resolv.conf
       ansible.builtin.lineinfile:
         path: /etc/resolv.conf
-        regexp: "^nameserver {{ item }}"
+        regexp: '^nameserver[ \t]+{{ resolv_conf_nameserver | regex_escape }}[ \t]*(?:#.*)?$'
         insertbefore: "^options"
-        line: "nameserver {{ item }}"
+        line: "nameserver {{ resolv_conf_nameserver }}"
+        state: "{{ resolv_conf_entry_state }}"
         unsafe_writes: true # to prevent failures in CI
       loop: "{{ nameservers }}"
+      loop_control:
+        label: "{{ resolv_conf_nameserver }} ({{ resolv_conf_entry_state }})"
+      vars:
+        resolv_conf_nameserver: "{{ item.nameserver if item is mapping else item }}"
+        resolv_conf_entry_state: "{{ item.state | default('present') if item is mapping else 'present' }}"
   when:
     - nameservers is defined
     - nameservers | length > 0

--- a/automation/roles/resolv_conf/tasks/main.yml
+++ b/automation/roles/resolv_conf/tasks/main.yml
@@ -26,7 +26,7 @@
       loop_control:
         label: "{{ resolv_conf_nameserver }} ({{ resolv_conf_entry_state }})"
       vars:
-        resolv_conf_nameserver: "{{ item.nameserver if item is mapping else item }}"
+        resolv_conf_nameserver: "{{ item.entry if item is mapping else item }}"
         resolv_conf_entry_state: "{{ item.state | default('present') if item is mapping else 'present' }}"
   when:
     - nameservers is defined


### PR DESCRIPTION
Support mapping items with state (present/absent) for etc_hosts and resolv_conf roles. Task changes parse item as mapping or string, use regex_escape for robust matching, expose state to ansible.builtin.lineinfile, and add loop_control labels. 

Enables removing entries from /etc/hosts and /etc/resolv.conf while preserving unsafe_writes.