### PR TITLE
Manage present/absent entries for ssh_public_keys

### DIFF
--- a/automation/roles/authorized_keys/README.md
+++ b/automation/roles/authorized_keys/README.md
@@ -1,17 +1,17 @@
 # Ansible Role: authorized_keys
 
-Adds SSH public keys to ~/.ssh/authorized_keys of the remote user detected via `whoami`.
+Adds or removes SSH public keys in ~/.ssh/authorized_keys of the remote user detected via `whoami`.
 
 ## Description
 - Detects target user with `whoami` on the managed host.
 - Ensures ~/.ssh and authorized_keys exist with secure permissions.
-- Idempotent: adds keys without duplicates or removing other keys.
+- Idempotent: manages only explicitly listed keys without affecting other keys.
 
 ## Role Variables
 
 | Variable          | Type          | Default    | Description |
 |-------------------|---------------|------------|-------------|
-| ssh_public_keys   | string or list| undefined  | Public key(s) to add. Accepts a list of key lines or a single string; if string, keys may be separated by newlines or commas. Extra quotes are stripped. If undefined/empty, the role does nothing. |
+| ssh_public_keys   | string or list| []         | Public keys to manage. String items are added. Mapping items accept `entry` and an optional `state` (`present` by default or `absent`). A single string may contain keys separated by newlines or commas. Extra quotes are stripped. |
 
 Note: The target user is the actual SSH user (resolved via `whoami`) and cannot be overridden by a variable.
 
@@ -29,6 +29,16 @@ Single string (newline-separated):
 ssh_public_keys: |
   ssh-ed25519 AAAAC3... user1@example
   ssh-rsa AAAAB3... user2@example
+```
+
+Use a mapping to remove a key:
+
+```yaml
+ssh_public_keys:
+  - entry: "ssh-ed25519 AAAAC3... user1@example"
+    state: present
+  - entry: "ssh-rsa AAAAB3... user2@example"
+    state: absent
 ```
 
 ## Dependencies

--- a/automation/roles/authorized_keys/tasks/main.yml
+++ b/automation/roles/authorized_keys/tasks/main.yml
@@ -6,11 +6,11 @@
       register: system_user
       changed_when: false
 
-    - name: "Add public keys to ~{{ system_user.stdout | default('') }}/.ssh/authorized_keys"
+    - name: "Manage public keys in ~{{ system_user.stdout | default('') }}/.ssh/authorized_keys"
       ansible.posix.authorized_key:
         user: "{{ system_user.stdout }}"
-        key: "{{ item | replace(\"'\", '') | replace('\"', '') | trim }}"
-        state: present
+        key: "{{ authorized_key_entry | replace(\"'\", '') | replace('\"', '') | trim }}"
+        state: "{{ authorized_key_state }}"
       loop: >-
         {{
           (ssh_public_keys
@@ -20,6 +20,11 @@
           | list)
           if ssh_public_keys is string else ssh_public_keys
         }}
+      loop_control:
+        label: "{{ authorized_key_entry | replace(\"'\", '') | replace('\"', '') | trim }} ({{ authorized_key_state }})"
+      vars:
+        authorized_key_entry: "{{ item.entry if item is mapping else item }}"
+        authorized_key_state: "{{ item.state | default('present') if item is mapping else 'present' }}"
   when:
     - ssh_public_keys is defined
     - ssh_public_keys | length > 0

--- a/automation/roles/common/defaults/main.yml
+++ b/automation/roles/common/defaults/main.yml
@@ -1066,6 +1066,8 @@ ssh_known_hosts: "{{ groups['postgres_cluster'] }}"
 
 # List of public SSH keys to be added to the database server's ~/.ssh/authorized_keys file.
 ssh_public_keys: []
+#  - "ssh-ed25519 AAAAC3... user1@example"
+#  - { entry: "ssh-rsa AAAAB3... user2@example", state: "absent" } # remove a public key
 
 # sudo
 sudo_users:


### PR DESCRIPTION
Support managing (adding or removing) SSH public keys by accepting mapping items with `entry` and `state` (present/absent). 

Task changes compute `authorized_key_entry` and `authorized_key_state`, update the authorized_key module call and loop labels. Default `ssh_public_keys` set to an empty list with example entries in common defaults.