### PR TITLE
Allow host names in node_to_remove

### DIFF
--- a/automation/README.md
+++ b/automation/README.md
@@ -122,5 +122,5 @@ Autobase adheres to a modular design separating atomic logic (roles) and orchest
 
 #### Removal
 
-- `remove_node` – Remove a node from an existing cluster. Set the required `node_to_remove` to the node name.
+- `remove_node` – Remove a node from an existing cluster. Set the required `node_to_remove` to the node's `inventory_hostname` or `ansible_hostname`.
 - `remove_cluster` – Remove the PostgreSQL cluster and, optionally, its DCS (etcd or Consul), including all data.

--- a/automation/README.md
+++ b/automation/README.md
@@ -122,5 +122,5 @@ Autobase adheres to a modular design separating atomic logic (roles) and orchest
 
 #### Removal
 
-- `remove_node` – Remove a node from an existing cluster.
+- `remove_node` – Remove a node from an existing cluster. Set the required `node_to_remove` to the node name.
 - `remove_cluster` – Remove the PostgreSQL cluster and, optionally, its DCS (etcd or Consul), including all data.

--- a/automation/playbooks/remove_node.yml
+++ b/automation/playbooks/remove_node.yml
@@ -21,16 +21,13 @@
     # Normalize supported node aliases for reliable group and hostvars lookups.
     - name: Resolve node_to_remove to its inventory hostname
       ansible.builtin.set_fact:
-        target_node_input: "{{ node_to_remove | default('') }}"
         target_node: >-
           {%- set requested_node = node_to_remove | default('') -%}
           {%- set resolved = namespace(name=requested_node) -%}
           {%- for host in groups['all'] | default([]) -%}
           {%- set aliases = [
             host,
-            hostvars[host].ansible_hostname | default(''),
-            hostvars[host].ansible_host | default(''),
-            hostvars[host].bind_address | default('')
+            hostvars[host].ansible_hostname | default('')
           ] -%}
           {%- if requested_node in aliases -%}
           {%- set resolved.name = host -%}
@@ -45,8 +42,8 @@
         that:
           - target_node in (groups['all'] | default([]))
         fail_msg: >-
-          Node '{{ target_node_input }}' was not found in the inventory. Specify
-          its inventory_hostname, ansible_hostname, ansible_host, or bind_address.
+          Node '{{ node_to_remove | default('') }}' was not found in the inventory. Specify
+          its inventory_hostname or ansible_hostname.
       tags: always
 
     - name: Define passwords

--- a/automation/playbooks/remove_node.yml
+++ b/automation/playbooks/remove_node.yml
@@ -3,8 +3,6 @@
   hosts: postgres_cluster:etcd_cluster:consul_instances
   become: true
   gather_facts: true
-  vars:
-    target_node: "{{ node_to_remove | default('') }}"
 
   pre_tasks:
     - name: Validate that node_to_remove is specified
@@ -13,11 +11,42 @@
         msg: >-
           Please specify the node_to_remove variable with the node
           to remove from the cluster.
-      when: target_node | length == 0
+      when: node_to_remove | default('') | length == 0
 
     - name: Define bind_address
       ansible.builtin.include_role:
         name: vitabaks.autobase.bind_address
+      tags: always
+
+    # Normalize supported node aliases for reliable group and hostvars lookups.
+    - name: Resolve node_to_remove to its inventory hostname
+      ansible.builtin.set_fact:
+        target_node_input: "{{ node_to_remove | default('') }}"
+        target_node: >-
+          {%- set requested_node = node_to_remove | default('') -%}
+          {%- set resolved = namespace(name=requested_node) -%}
+          {%- for host in groups['all'] | default([]) -%}
+          {%- set aliases = [
+            host,
+            hostvars[host].ansible_hostname | default(''),
+            hostvars[host].ansible_host | default(''),
+            hostvars[host].bind_address | default('')
+          ] -%}
+          {%- if requested_node in aliases -%}
+          {%- set resolved.name = host -%}
+          {%- endif -%}
+          {%- endfor -%}
+          {{- resolved.name -}}
+      tags: always
+
+    - name: Validate that node_to_remove matches an inventory host
+      run_once: true # noqa run-once
+      ansible.builtin.assert:
+        that:
+          - target_node in (groups['all'] | default([]))
+        fail_msg: >-
+          Node '{{ target_node_input }}' was not found in the inventory. Specify
+          its inventory_hostname, ansible_hostname, ansible_host, or bind_address.
       tags: always
 
     - name: Define passwords
@@ -33,8 +62,6 @@
   hosts: postgres_cluster
   become: true
   gather_facts: true
-  vars:
-    target_node: "{{ node_to_remove | default('') }}"
 
   pre_tasks:
     - block:
@@ -151,8 +178,6 @@
   hosts: etcd_cluster
   become: true
   gather_facts: false
-  vars:
-    target_node: "{{ node_to_remove | default('') }}"
 
   tasks:
     - block:
@@ -170,13 +195,12 @@
             ETCDCTL_API: "3"
           register: etcd_members_list_before
           changed_when: false
-          when: inventory_hostname != target_node
+          delegate_to: "{{ groups['etcd_cluster'] | difference([target_node]) | first }}"
 
         - name: Show etcd cluster members before removal
           run_once: true # noqa run-once
           ansible.builtin.debug:
             msg: "{{ etcd_members_list_before.stdout_lines }}"
-          when: inventory_hostname != target_node
 
         - name: Remove target node from etcd cluster
           ansible.builtin.include_role:
@@ -200,13 +224,12 @@
           until: etcd_members_list_after.rc == 0
           retries: 3
           delay: 5
-          when: inventory_hostname != target_node
+          delegate_to: "{{ groups['etcd_cluster'] | difference([target_node]) | first }}"
 
         - name: Show etcd cluster members after removal
           run_once: true # noqa run-once
           ansible.builtin.debug:
             msg: "{{ etcd_members_list_after.stdout_lines }}"
-          when: inventory_hostname != target_node
       when: dcs_type | default('etcd') == 'etcd'
       tags: etcd
 
@@ -215,7 +238,6 @@
   become: true
   gather_facts: true
   vars:
-    target_node: "{{ node_to_remove | default('') }}"
     consul_http_addr: "{% if consul_tls_enable | default(true) | bool %}https{% else %}http{% endif %}://127.0.0.1:8500"
     consul_ca_flag: "{% if consul_tls_enable | default(true) | bool %}-ca-file=/etc/consul/tls/ca.crt{% endif %}"
     consul_client_flags: >-
@@ -344,8 +366,6 @@
   hosts: postgres_cluster
   become: true
   gather_facts: true
-  vars:
-    target_node: "{{ node_to_remove | default('') }}"
   tasks:
     - name: Update patroni config file
       ansible.builtin.include_role:

--- a/automation/roles/etcd/tasks/member_remove.yml
+++ b/automation/roles/etcd/tasks/member_remove.yml
@@ -32,6 +32,7 @@
         ETCDCTL_API: "3"
       register: etcd_members_json
       changed_when: false
+      delegate_to: "{{ groups['etcd_cluster'] | difference([target_node]) | first }}"
 
     - name: Extract target node etcd member ID
       run_once: true # noqa run-once
@@ -72,7 +73,7 @@
       vars:
         target_etcd_member_id_hex: "{{ '%x' % (target_etcd_member_id | int) if (target_etcd_member_id | int) > 0 else '' }}"
       when: target_etcd_member_id | default(0) | int > 0
-  when: inventory_hostname != target_node | default('')
+      delegate_to: "{{ groups['etcd_cluster'] | difference([target_node]) | first }}"
   tags: etcd, etcd_member_remove
 
 - block:


### PR DESCRIPTION
Allow `node_to_remove` to accept a host name (`ansible_hostname`) in addition to the inventory host identifier when removing a cluster node.