### PR TITLE
Skip filesystem resize play when state is absent

### DIFF
--- a/automation/playbooks/cloud_resources.yml
+++ b/automation/playbooks/cloud_resources.yml
@@ -24,7 +24,7 @@
       tags: always
 
 - name: vitabaks.autobase.cloud_resources | Resize filesystem
-  hosts: postgres_cluster
+  hosts: "{{ 'postgres_cluster' if (state | default('present')) != 'absent' else [] }}"
   become: true
   become_method: sudo
   gather_facts: true


### PR DESCRIPTION
Skip the filesystem resize play during cluster deletion (`state=absent`).

This prevents Ansible from gathering facts or attempting to connect to PostgreSQL hosts that are being removed.