### PR TITLE
Run bind_address role only if undefined

### DIFF
--- a/automation/playbooks/add_node.yml
+++ b/automation/playbooks/add_node.yml
@@ -33,6 +33,7 @@
     - name: Define bind_address
       ansible.builtin.include_role:
         name: vitabaks.autobase.bind_address
+      when: bind_address is not defined
       tags: always
 
     - name: Set maintenance variable

--- a/automation/playbooks/config_pgcluster.yml
+++ b/automation/playbooks/config_pgcluster.yml
@@ -14,6 +14,7 @@
     - name: Define bind_address
       ansible.builtin.import_role:
         name: vitabaks.autobase.bind_address
+      when: bind_address is not defined
       tags: always
 
     - name: Set default variables

--- a/automation/playbooks/deploy_pgcluster.yml
+++ b/automation/playbooks/deploy_pgcluster.yml
@@ -39,6 +39,7 @@
     - name: Define bind_address
       ansible.builtin.include_role:
         name: vitabaks.autobase.bind_address
+      when: bind_address is not defined
       tags: always
 
     # Print system information

--- a/automation/playbooks/pg_logical_replication_stop.yml
+++ b/automation/playbooks/pg_logical_replication_stop.yml
@@ -14,6 +14,7 @@
     - name: Define bind_address
       ansible.builtin.include_role:
         name: vitabaks.autobase.bind_address
+      when: bind_address is not defined
 
     - name: Set default variables
       ansible.builtin.import_role:

--- a/automation/playbooks/pg_logical_switchover.yml
+++ b/automation/playbooks/pg_logical_switchover.yml
@@ -14,6 +14,7 @@
     - name: Define bind_address
       ansible.builtin.include_role:
         name: vitabaks.autobase.bind_address
+      when: bind_address is not defined
 
     - name: Set default variables
       ansible.builtin.import_role:

--- a/automation/playbooks/pg_logical_switchover_rollback.yml
+++ b/automation/playbooks/pg_logical_switchover_rollback.yml
@@ -14,6 +14,7 @@
     - name: Define bind_address
       ansible.builtin.include_role:
         name: vitabaks.autobase.bind_address
+      when: bind_address is not defined
 
     - name: Set default variables
       ansible.builtin.import_role:

--- a/automation/playbooks/pg_logical_upgrade.yml
+++ b/automation/playbooks/pg_logical_upgrade.yml
@@ -14,6 +14,7 @@
     - name: Define bind_address
       ansible.builtin.include_role:
         name: vitabaks.autobase.bind_address
+      when: bind_address is not defined
 
     - name: Set default variables
       ansible.builtin.import_role:

--- a/automation/playbooks/pg_upgrade.yml
+++ b/automation/playbooks/pg_upgrade.yml
@@ -14,6 +14,7 @@
     - name: Define bind_address
       ansible.builtin.include_role:
         name: vitabaks.autobase.bind_address
+      when: bind_address is not defined
 
     - name: Set default variables
       ansible.builtin.import_role:

--- a/automation/playbooks/pg_upgrade_rollback.yml
+++ b/automation/playbooks/pg_upgrade_rollback.yml
@@ -18,6 +18,7 @@
     - name: Define bind_address
       ansible.builtin.include_role:
         name: vitabaks.autobase.bind_address
+      when: bind_address is not defined
 
     - name: '[Prepare] Add host to group "primary" (in-memory inventory)'
       ansible.builtin.add_host:

--- a/automation/playbooks/remove_node.yml
+++ b/automation/playbooks/remove_node.yml
@@ -16,6 +16,7 @@
     - name: Define bind_address
       ansible.builtin.include_role:
         name: vitabaks.autobase.bind_address
+      when: bind_address is not defined
       tags: always
 
     # Normalize supported node aliases for reliable group and hostvars lookups.

--- a/automation/playbooks/update_pgcluster.yml
+++ b/automation/playbooks/update_pgcluster.yml
@@ -15,6 +15,7 @@
     - name: Define bind_address
       ansible.builtin.include_role:
         name: vitabaks.autobase.bind_address
+      when: bind_address is not defined
       tags: always
 
     - name: Set default variables


### PR DESCRIPTION
Add a guard to avoid redefining bind_address: each playbook now includes/imports vitabaks.autobase.bind_address only when bind_address is not defined. 