### PR TITLE
Automate pgBackRest restore command

### DIFF
--- a/automation/roles/common/defaults/main.yml
+++ b/automation/roles/common/defaults/main.yml
@@ -847,12 +847,12 @@ pgbackrest_server_conf:
 
 pgbackrest_archive_command: "pgbackrest --stanza={{ pgbackrest_stanza }} archive-push %p"
 pgbackrest_restore_command: "pgbackrest --stanza={{ pgbackrest_stanza }} archive-get %f %p"
-pgbackrest_restore_immediate: false
-pgbackrest_restore_target_time: "" # e.g. "2026-06-26 11:00:00+00"
-pgbackrest_restore_backup_set: "" # e.g. "20260625-120000F_20260626-120000I"; empty means latest
+pgbackrest_restore_immediate: "{{ restore_immediate | default(false) }}"
+pgbackrest_restore_target_time: "{{ restore_target_time | default('') }}" # e.g. "2026-06-26 11:00:00+00"
+pgbackrest_restore_backup_name: "{{ restore_backup_name | default('') }}" # e.g. "20260625-120000F_20260626-120000I"; empty means latest
 pgbackrest_patroni_cluster_restore_command: >-
   {{ '/usr/bin/pgbackrest --stanza=' ~ pgbackrest_stanza
-     ~ (' --set=' ~ pgbackrest_restore_backup_set if pgbackrest_restore_backup_set | length > 0 else '')
+     ~ (' --set=' ~ pgbackrest_restore_backup_name if pgbackrest_restore_backup_name | length > 0 else '')
      ~ (' --type=time --target="' ~ pgbackrest_restore_target_time ~ '"' if pgbackrest_restore_target_time | length > 0
         else (' --type=immediate' if pgbackrest_restore_immediate | bool else ''))
      ~ ' --delta restore' }}

--- a/automation/roles/common/defaults/main.yml
+++ b/automation/roles/common/defaults/main.yml
@@ -847,8 +847,15 @@ pgbackrest_server_conf:
 
 pgbackrest_archive_command: "pgbackrest --stanza={{ pgbackrest_stanza }} archive-push %p"
 pgbackrest_restore_command: "pgbackrest --stanza={{ pgbackrest_stanza }} archive-get %f %p"
-pgbackrest_patroni_cluster_restore_command: "/usr/bin/pgbackrest --stanza={{ pgbackrest_stanza }} --delta restore" # restore from latest backup
-#  '/usr/bin/pgbackrest --stanza={{ pgbackrest_stanza }} --type=time "--target=2020-06-01 11:00:00+03" --delta restore'  # Point-in-Time Recovery (example)
+pgbackrest_restore_immediate: false
+pgbackrest_restore_target_time: "" # e.g. "2026-06-26 11:00:00+00"
+pgbackrest_restore_backup_set: "" # e.g. "20260625-120000F_20260626-120000I"; empty means latest
+pgbackrest_patroni_cluster_restore_command: >-
+  {{ '/usr/bin/pgbackrest --stanza=' ~ pgbackrest_stanza
+     ~ (' --set=' ~ pgbackrest_restore_backup_set if pgbackrest_restore_backup_set | length > 0 else '')
+     ~ (' --type=time --target="' ~ pgbackrest_restore_target_time ~ '"' if pgbackrest_restore_target_time | length > 0
+        else (' --type=immediate' if pgbackrest_restore_immediate | bool else ''))
+     ~ ' --delta restore' }}
 pgbackrest_patroni_cluster_bootstrap_recovery_conf:
   - restore_command: "{{ pgbackrest_restore_command }}"
   - recovery_target_action: promote

--- a/automation/roles/pgbackrest/README.md
+++ b/automation/roles/pgbackrest/README.md
@@ -18,7 +18,10 @@ Installs and configures [pgBackRest](https://github.com/pgbackrest/pgbackrest) f
 | `pgbackrest_server_conf.global` | [...] | Global options for a dedicated repo server (generated when repo_host is set). |
 | `pgbackrest_archive_command` | `"pgbackrest --stanza={{ pgbackrest_stanza }} archive-push %p"` | WAL archive_command helper string. |
 | `pgbackrest_restore_command` | `"pgbackrest --stanza={{ pgbackrest_stanza }} archive-get %f %p"` | WAL restore_command helper string. |
-| `pgbackrest_patroni_cluster_restore_command` | `"/usr/bin/pgbackrest --stanza={{ pgbackrest_stanza }} --delta restore"` | Command used for cluster restore/bootstrap. |
+| `pgbackrest_restore_target_time` | `""` | Optional PITR target time, for example `"2020-06-01 11:00:00+03"`. Adds `--type=time --target=...` to the cluster restore command. |
+| `pgbackrest_restore_immediate` | `false` | Set to `true` to add `--type=immediate`. A non-empty `pgbackrest_restore_target_time` takes precedence. |
+| `pgbackrest_restore_backup_set` | `""` | Optional backup set name added as `--set=...`. An empty value lets pgBackRest restore the latest backup set. |
+| `pgbackrest_patroni_cluster_restore_command` | `"/usr/bin/pgbackrest --stanza={{ pgbackrest_stanza }} --delta restore"` | Command used for cluster restore/bootstrap. Includes the configured backup set and time or immediate recovery target. |
 | `pgbackrest_patroni_cluster_bootstrap_recovery_conf` | [...] | List for Patroni recovery parameters (restore_command, recovery_target_action, etc.). |
 | `pgbackrest_patroni_cluster_clean_bootstrap` | `false` | Controls how Patroni bootstraps from a pgBackRest backup: false – delta restore into the existing data directory (faster, reuses unchanged files). true – clean restore into an empty data directory (wipes existing contents first). |
 | `pgbackrest_cron_jobs` | [...] | Cron jobs for backups (full/diff). Created on DB host by default, or on repo_host if defined. |


### PR DESCRIPTION
Introduce configurable restore options for pgBackRest: `pgbackrest_restore_immediate`, `pgbackrest_restore_target_time`, and `pgbackrest_restore_backup_set`.

Update the Patroni cluster restore Jinja command to include --set for a backup set and to choose between time-based PITR (--type=time --target=...) or --type=immediate (target time takes precedence).