### PR TITLE
Add backup_pgcluster playbook

### DIFF
--- a/automation/README.md
+++ b/automation/README.md
@@ -115,6 +115,7 @@ Autobase adheres to a modular design separating atomic logic (roles) and orchest
   - `pg_logical_switchover` - Redirects PostgreSQL traffic from the source cluster to the target cluster with near-zero downtime.
   - `pg_logical_switchover_rollback` -  Switches PostgreSQL traffic back to the source cluster.
   - `pg_logical_replication_stop` - Clean up publications, subscriptions, and replication slots.
+- `backup_pgcluster` – Run the pgBackRest or WAL-G backup command on the current Patroni leader, or on the host set in `backup_pgcluster_target`.
 - `backup_list` – Display the list of pgBackRest or WAL-G backups in text or JSON format.
 
 #### Scaling

--- a/automation/playbooks/backup_pgcluster.yml
+++ b/automation/playbooks/backup_pgcluster.yml
@@ -1,0 +1,107 @@
+---
+- name: vitabaks.autobase.backup_pgcluster | Create PostgreSQL backup
+  hosts: postgres_cluster
+  gather_facts: true
+  become: true
+  become_method: sudo
+  any_errors_fatal: true
+  tasks:
+    - name: Validate backup target
+      ansible.builtin.assert:
+        that:
+          - backup_pgcluster_target | default('leader') == 'leader'
+            or backup_pgcluster_target in groups['postgres_cluster']
+        fail_msg: >-
+          Set 'backup_pgcluster_target' to 'leader' or to an inventory hostname from
+          the 'postgres_cluster' group.
+      run_once: true
+
+    - name: Define bind_address
+      ansible.builtin.import_role:
+        name: vitabaks.autobase.bind_address
+      when: bind_address is not defined
+
+    - name: Set default variables
+      ansible.builtin.import_role:
+        name: vitabaks.autobase.common
+
+    - name: Get Patroni cluster leader
+      ansible.builtin.uri:
+        url: >-
+          {{ patroni_restapi_protocol | default('https') }}://{{ patroni_restapi_connect_addr
+            | default(patroni_bind_address | default(bind_address, true), true) }}:{{ patroni_restapi_port
+            | default('8008') }}/leader
+        status_code: 200
+        ca_path: "{{ patroni_restapi_cafile | default(omit, true) }}"
+      register: patroni_leader_result
+      changed_when: false
+      failed_when: false
+      check_mode: false
+      environment:
+        no_proxy: "{{ patroni_bind_address | default(bind_address, true) }}"
+      when: backup_pgcluster_target | default('leader') == 'leader'
+
+    - name: Fail when Patroni cluster has no healthy leader
+      ansible.builtin.fail:
+        msg: >-
+          No healthy leader node detected in cluster '{{ patroni_cluster_name | default('postgres-cluster') }}'.
+      when:
+        - backup_pgcluster_target | default('leader') == 'leader'
+        - inventory_hostname == groups['postgres_cluster'][0]
+        - (groups.get('postgres_cluster', [])
+            | map('extract', hostvars)
+            | selectattr('patroni_leader_result.status', 'defined')
+            | selectattr('patroni_leader_result.status', 'equalto', 200)
+            | list | length) == 0
+
+    - name: Add requested host to group "backup_target" (in-memory inventory)
+      ansible.builtin.add_host:
+        name: "{{ item }}"
+        groups: backup_target
+      loop: "{{ groups['postgres_cluster'] }}"
+      when:
+        - backup_pgcluster_target | default('leader') != 'leader'
+        - item == backup_pgcluster_target
+      changed_when: false
+      check_mode: false
+
+    - name: Add current Patroni leader to group "backup_target" (in-memory inventory)
+      ansible.builtin.add_host:
+        name: "{{ item }}"
+        groups: backup_target
+      loop: "{{ groups['postgres_cluster'] }}"
+      when:
+        - backup_pgcluster_target | default('leader') == 'leader'
+        - hostvars[item]['patroni_leader_result']['status'] | default(0) == 200
+      changed_when: false
+      check_mode: false
+
+- name: vitabaks.autobase.backup_pgcluster | Run backup command
+  hosts: backup_target
+  gather_facts: false
+  become: true
+  become_user: postgres
+  vars:
+    backup_pgcluster_selected_tool: >-
+      {{ 'pgbackrest' if pgbackrest_install | default(false) | bool
+         else 'wal-g' if wal_g_install | default(false) | bool
+         else '' }}
+    backup_pgcluster_command: >-
+      {{ pgbackrest_incr_backup_command if backup_pgcluster_selected_tool == 'pgbackrest'
+         else wal_g_backup_command | join('') if backup_pgcluster_selected_tool == 'wal-g'
+         else '' }}
+  tasks:
+    - name: Set default variables
+      ansible.builtin.import_role:
+        name: vitabaks.autobase.common
+
+    - name: Validate configured backup tool
+      ansible.builtin.assert:
+        that:
+          - backup_pgcluster_selected_tool in ['pgbackrest', 'wal-g']
+        fail_msg: Set either 'pgbackrest_install' or 'wal_g_install' to true.
+
+    - name: Create incremental PostgreSQL backup
+      ansible.builtin.shell: "{{ backup_pgcluster_command }}"
+      args:
+        executable: /bin/bash

--- a/automation/playbooks/backup_pgcluster.yml
+++ b/automation/playbooks/backup_pgcluster.yml
@@ -14,7 +14,6 @@
         fail_msg: >-
           Set 'backup_pgcluster_target' to 'leader' or to an inventory hostname from
           the 'postgres_cluster' group.
-      run_once: true
 
     - name: Define bind_address
       ansible.builtin.import_role:

--- a/automation/playbooks/backup_pgcluster.yml
+++ b/automation/playbooks/backup_pgcluster.yml
@@ -101,7 +101,7 @@
           - backup_pgcluster_selected_tool in ['pgbackrest', 'wal-g']
         fail_msg: Set either 'pgbackrest_install' or 'wal_g_install' to true.
 
-    - name: Create incremental PostgreSQL backup
+    - name: Create PostgreSQL backup
       ansible.builtin.shell: "{{ backup_pgcluster_command }}"
       args:
         executable: /bin/bash

--- a/automation/playbooks/backup_pgcluster.yml
+++ b/automation/playbooks/backup_pgcluster.yml
@@ -104,3 +104,14 @@
       ansible.builtin.shell: "{{ backup_pgcluster_command }}"
       args:
         executable: /bin/bash
+      async: "{{ backup_pgcluster_timeout | default(86400) }}" # timeout 24 hours
+      poll: 0
+      register: backup_pgcluster_job
+
+    - name: Wait for PostgreSQL backup to complete
+      ansible.builtin.async_status:
+        jid: "{{ backup_pgcluster_job.ansible_job_id }}"
+      register: backup_pgcluster_job_result
+      until: backup_pgcluster_job_result.finished
+      retries: "{{ (backup_pgcluster_timeout | default(86400) | int) // 10 }}" # timeout 24 hours
+      delay: 10


### PR DESCRIPTION
Run the pgBackRest or WAL-G backup command on the current Patroni leader, or on the host set in `backup_pgcluster_target`.