### PR TITLE
Add restore_pgcluster playbook

### DIFF
--- a/automation/README.md
+++ b/automation/README.md
@@ -116,6 +116,7 @@ Autobase adheres to a modular design separating atomic logic (roles) and orchest
   - `pg_logical_switchover_rollback` -  Switches PostgreSQL traffic back to the source cluster.
   - `pg_logical_replication_stop` - Clean up publications, subscriptions, and replication slots.
 - `backup_list` – Display the list of pgBackRest or WAL-G backups in text or JSON format.
+- `restore_pgcluster` – Restore the current PostgreSQL cluster from a pgBackRest or WAL-G backup.
 
 #### Scaling
 

--- a/automation/playbooks/restore_pgcluster.yml
+++ b/automation/playbooks/restore_pgcluster.yml
@@ -5,7 +5,6 @@
   become_method: sudo
   gather_facts: true
   any_errors_fatal: true
-  environment: "{{ proxy_env | default({}) }}"
   vars:
     restore_pgcluster_selected_tool: >-
       {{ restore_pgcluster_tool | default(
@@ -16,19 +15,17 @@
     patroni_cluster_bootstrap_method: "{{ restore_pgcluster_selected_tool }}"
     patroni_create_replica_methods:
       - "{{ 'pgbackrest' if restore_pgcluster_selected_tool == 'pgbackrest' else 'wal_g' }}"
-    restore_pgcluster_selected_bootstrap_command: >-
-      {{ pgbackrest_patroni_cluster_restore_command
-         if restore_pgcluster_selected_tool == 'pgbackrest'
-         else wal_g_patroni_cluster_bootstrap_command }}
     postgresql_restore_command: >-
       {{ pgbackrest_restore_command
          if restore_pgcluster_selected_tool == 'pgbackrest'
          else wal_g_restore_command }}
+    restore_pgcluster_selected_bootstrap_command: >-
+      {{ pgbackrest_patroni_cluster_restore_command
+         if restore_pgcluster_selected_tool == 'pgbackrest'
+         else wal_g_patroni_cluster_bootstrap_command }}
     disable_archive_command: false
     keep_patroni_dynamic_json: true
-    patroni_config_reload: false
     point_in_time_recovery: true
-    postgresql_exists: true
 
   pre_tasks:
     - name: Gather package facts
@@ -81,6 +78,8 @@
 
   roles:
     - role: vitabaks.autobase.patroni
+      vars:
+        patroni_config_reload: false
 
   tasks:
     - name: PostgreSQL cluster restore completed

--- a/automation/playbooks/restore_pgcluster.yml
+++ b/automation/playbooks/restore_pgcluster.yml
@@ -1,0 +1,88 @@
+---
+- name: vitabaks.autobase.restore_pgcluster | Restore PostgreSQL Cluster
+  hosts: postgres_cluster
+  become: true
+  become_method: sudo
+  gather_facts: true
+  any_errors_fatal: true
+  environment: "{{ proxy_env | default({}) }}"
+  vars:
+    restore_pgcluster_selected_tool: >-
+      {{ restore_pgcluster_tool | default(
+        'pgbackrest' if pgbackrest_install | default(false) | bool
+        else 'wal-g' if wal_g_install | default(false) | bool
+        else ''
+      ) | lower }}
+    patroni_cluster_bootstrap_method: "{{ restore_pgcluster_selected_tool }}"
+    patroni_create_replica_methods:
+      - "{{ 'pgbackrest' if restore_pgcluster_selected_tool == 'pgbackrest' else 'wal_g' }}"
+    restore_pgcluster_selected_bootstrap_command: >-
+      {{ pgbackrest_patroni_cluster_restore_command
+         if restore_pgcluster_selected_tool == 'pgbackrest'
+         else wal_g_patroni_cluster_bootstrap_command }}
+    postgresql_restore_command: >-
+      {{ pgbackrest_restore_command
+         if restore_pgcluster_selected_tool == 'pgbackrest'
+         else wal_g_restore_command }}
+    disable_archive_command: false
+    keep_patroni_dynamic_json: true
+    patroni_config_reload: false
+    point_in_time_recovery: true
+    postgresql_exists: true
+
+  pre_tasks:
+    - name: Gather package facts
+      ansible.builtin.package_facts:
+        manager: auto
+      check_mode: false
+
+    - name: Define bind_address
+      ansible.builtin.import_role:
+        name: vitabaks.autobase.bind_address
+      when: bind_address is not defined
+
+    - name: Set default variables
+      ansible.builtin.import_role:
+        name: vitabaks.autobase.common
+
+    - name: Validate restore parameters
+      ansible.builtin.assert:
+        that:
+          - restore_pgcluster_selected_tool in ['pgbackrest', 'wal-g']
+          - restore_pgcluster_selected_tool != 'pgbackrest' or pgbackrest_install | bool
+          - restore_pgcluster_selected_tool != 'wal-g' or wal_g_install | bool
+          - not (restore_immediate | default(false) | bool and restore_target_time | default('') | length > 0)
+          - postgresql_restore_command | default('') | trim | length > 0
+          - restore_pgcluster_selected_bootstrap_command | default('') | trim | length > 0
+        fail_msg: >-
+          Enable exactly one backup tool with 'pgbackrest_install' or 'wal_g_install'.
+          If both tools are enabled, set 'restore_pgcluster_tool' to 'pgbackrest' or 'wal-g'.
+          'restore_immediate' and 'restore_target_time' cannot be used together.
+          The selected backup tool must provide non-empty PostgreSQL restore and bootstrap commands.
+      run_once: true
+
+    - name: Validate automatic backup tool selection
+      ansible.builtin.assert:
+        that:
+          - (pgbackrest_install | bool) != (wal_g_install | bool)
+        fail_msg: >-
+          Automatic restore tool selection requires exactly one enabled backup tool.
+          Set 'restore_pgcluster_tool' to 'pgbackrest' or 'wal-g'.
+      when: restore_pgcluster_tool | default('') | length == 0
+      run_once: true
+
+    - name: Get current Patroni passwords
+      ansible.builtin.import_role:
+        name: vitabaks.autobase.pre_checks
+        tasks_from: passwords
+      vars:
+        postgresql_cluster_maintenance: true
+        source_group: master
+
+  roles:
+    - role: vitabaks.autobase.patroni
+
+  tasks:
+    - name: PostgreSQL cluster restore completed
+      ansible.builtin.include_role:
+        name: vitabaks.autobase.deploy_finish

--- a/automation/playbooks/restore_pgcluster.yml
+++ b/automation/playbooks/restore_pgcluster.yml
@@ -20,9 +20,17 @@
          if restore_pgcluster_selected_tool == 'pgbackrest'
          else wal_g_restore_command }}
     restore_pgcluster_selected_bootstrap_command: >-
-      {{ pgbackrest_patroni_cluster_restore_command
+      {{ pgbackrest_patroni_cluster_bootstrap_command
          if restore_pgcluster_selected_tool == 'pgbackrest'
          else wal_g_patroni_cluster_bootstrap_command }}
+    restore_pgcluster_selected_target_action: >-
+      {{ pgbackrest_restore_target_action
+         if restore_pgcluster_selected_tool == 'pgbackrest'
+         else wal_g_restore_target_action }}
+    restore_pgcluster_selected_target_timeline: >-
+      {{ pgbackrest_restore_target_timeline
+         if restore_pgcluster_selected_tool == 'pgbackrest'
+         else wal_g_restore_target_timeline }}
     disable_archive_command: false
     keep_patroni_dynamic_json: true
     point_in_time_recovery: true
@@ -66,11 +74,26 @@
         fail_msg: >-
           The selected backup tool must provide a non-empty Patroni bootstrap command.
 
-    - name: Validate PITR target settings
+    - name: Validate PITR target action
+      ansible.builtin.assert:
+        that:
+          - restore_pgcluster_selected_target_action in ['pause', 'promote', 'shutdown']
+        fail_msg: >-
+          'restore_target_action' must be pause, promote, or shutdown.
+
+    - name: Validate PITR target timeline
+      ansible.builtin.assert:
+        that:
+          - restore_pgcluster_selected_target_timeline | string | trim | length > 0
+        fail_msg: >-
+          'restore_target_timeline' must not be empty.
+
+    - name: Validate that PITR targets do not conflict
       ansible.builtin.assert:
         that:
           - not (restore_immediate | default(false) | bool and restore_target_time | default('') | length > 0)
-        fail_msg: "'restore_immediate' and 'restore_target_time' cannot be used together."
+        fail_msg: >-
+          'restore_immediate' and 'restore_target_time' cannot be used together.
 
     - name: Check that a pgBackRest backup is available before restore
       ansible.builtin.command:

--- a/automation/playbooks/restore_pgcluster.yml
+++ b/automation/playbooks/restore_pgcluster.yml
@@ -162,7 +162,7 @@
         else current_setting('data_directory') || '/' || pg_current_logfile()
         end"
       vars:
-        psql_command: "{{ pg_old_bindir }}/psql -h 127.0.0.1 -p {{ postgresql_port }} -U {{ patroni_superuser_username }} -d postgres"
+        psql_command: "{{ postgresql_bin_dir }}/psql -h 127.0.0.1 -p {{ postgresql_port }} -U {{ patroni_superuser_username }} -d postgres"
       environment:
         PGPASSWORD: "{{ patroni_superuser_password }}"
       register: postgresql_log_file_result

--- a/automation/playbooks/restore_pgcluster.yml
+++ b/automation/playbooks/restore_pgcluster.yml
@@ -42,28 +42,16 @@
       ansible.builtin.import_role:
         name: vitabaks.autobase.common
 
-    - name: Validate restore backup tool selection
-      ansible.builtin.assert:
-        that:
-          - restore_pgcluster_selected_tool in ['pgbackrest', 'wal-g']
-        fail_msg: "Set 'restore_pgcluster_tool' to 'pgbackrest' or 'wal-g'."
-
-    - name: Validate automatic backup tool selection
+    - name: Validate backup tool
       ansible.builtin.assert:
         that:
           - (pgbackrest_install | bool) != (wal_g_install | bool)
+          - >-
+            restore_pgcluster_selected_tool ==
+            ('pgbackrest' if pgbackrest_install | bool else 'wal-g')
         fail_msg: >-
-          Automatic restore tool selection requires exactly one enabled backup tool.
-          Set 'restore_pgcluster_tool' to 'pgbackrest' or 'wal-g' when both tools are enabled.
-      when: restore_pgcluster_tool | default('') | length == 0
-
-    - name: Validate selected backup tool is enabled
-      ansible.builtin.assert:
-        that:
-          - restore_pgcluster_selected_tool != 'pgbackrest' or pgbackrest_install | bool
-          - restore_pgcluster_selected_tool != 'wal-g' or wal_g_install | bool
-        fail_msg: >-
-          Enable the selected backup tool with 'pgbackrest_install' or 'wal_g_install'.
+          Enable exactly one backup tool with 'pgbackrest_install' or 'wal_g_install'.
+          If set, 'restore_pgcluster_tool' must match the enabled tool.
 
     - name: Validate PostgreSQL restore command
       ansible.builtin.assert:

--- a/automation/playbooks/restore_pgcluster.yml
+++ b/automation/playbooks/restore_pgcluster.yml
@@ -97,6 +97,18 @@
           The pgBackRest option '--target-action' must be pause, promote, or shutdown.
       when: restore_pgcluster_selected_tool == 'pgbackrest'
 
+    - name: Validate pgBackRest target timeline recovery type
+      ansible.builtin.assert:
+        that:
+          - >-
+            '--target-timeline=' not in restore_pgcluster_selected_bootstrap_command or
+            restore_pgcluster_selected_bootstrap_command
+            is search('(^|\s)--type=(default|lsn|name|standby|time|xid)(\s|$)')
+        fail_msg: >-
+          The pgBackRest option '--target-timeline' requires '--type' to be
+          default, lsn, name, standby, time, or xid.
+      when: restore_pgcluster_selected_tool == 'pgbackrest'
+
     - name: Validate PITR target action
       ansible.builtin.assert:
         that:

--- a/automation/playbooks/restore_pgcluster.yml
+++ b/automation/playbooks/restore_pgcluster.yml
@@ -68,6 +68,48 @@
       when: restore_pgcluster_tool | default('') | length == 0
       run_once: true
 
+    - name: Check that a pgBackRest backup is available before restore
+      ansible.builtin.command: >-
+        pgbackrest --stanza={{ pgbackrest_stanza }} --type=full --output=json info
+      become_user: postgres
+      register: pgbackrest_backup_check_result
+      changed_when: false
+      failed_when: false
+      when:
+        - inventory_hostname == groups['master'][0]
+        - restore_pgcluster_selected_tool == 'pgbackrest'
+
+    - name: Stop restore when pgBackRest backup is unavailable
+      ansible.builtin.fail:
+        msg: "Cannot restore PostgreSQL: no accessible pgBackRest backup was found for stanza '{{ pgbackrest_stanza }}'."
+      when:
+        - inventory_hostname == groups['master'][0]
+        - restore_pgcluster_selected_tool == 'pgbackrest'
+        - pgbackrest_backup_check_result.rc != 0
+          or ((pgbackrest_backup_check_result.stdout | from_json)
+              | map(attribute='backup') | flatten | length) == 0
+
+    - name: Check that a WAL-G backup is available before restore
+      ansible.builtin.command: "{{ wal_g_path }} backup-list --json"
+      args:
+        expand_argument_vars: true
+      become_user: postgres
+      register: wal_g_backup_check_result
+      changed_when: false
+      failed_when: false
+      when:
+        - inventory_hostname == groups['master'][0]
+        - restore_pgcluster_selected_tool == 'wal-g'
+
+    - name: Stop restore when WAL-G backup is unavailable
+      ansible.builtin.fail:
+        msg: "Cannot restore PostgreSQL: no accessible WAL-G backup was found."
+      when:
+        - inventory_hostname == groups['master'][0]
+        - restore_pgcluster_selected_tool == 'wal-g'
+        - wal_g_backup_check_result.rc != 0
+          or (wal_g_backup_check_result.stdout | from_json | length) == 0
+
     - name: Get current Patroni passwords
       ansible.builtin.import_role:
         name: vitabaks.autobase.pre_checks

--- a/automation/playbooks/restore_pgcluster.yml
+++ b/automation/playbooks/restore_pgcluster.yml
@@ -60,12 +60,14 @@
         fail_msg: >-
           Enable exactly one backup tool with 'pgbackrest_install' or 'wal_g_install'.
           If set, 'restore_pgcluster_tool' must match the enabled tool.
+      when: inventory_hostname == groups['master'][0]
 
     - name: Validate PostgreSQL restore command
       ansible.builtin.assert:
         that:
           - postgresql_restore_command | default('') | trim | length > 0
         fail_msg: The selected backup tool must provide a non-empty PostgreSQL restore command.
+      when: inventory_hostname == groups['master'][0]
 
     - name: Validate Patroni bootstrap command
       ansible.builtin.assert:
@@ -73,6 +75,7 @@
           - restore_pgcluster_selected_bootstrap_command | default('') | trim | length > 0
         fail_msg: >-
           The selected backup tool must provide a non-empty Patroni bootstrap command.
+      when: inventory_hostname == groups['master'][0]
 
     - name: Validate pgBackRest target action recovery type
       ansible.builtin.assert:
@@ -84,7 +87,9 @@
         fail_msg: >-
           The pgBackRest option '--target-action' requires '--type' to be
           immediate, lsn, name, time, or xid.
-      when: restore_pgcluster_selected_tool == 'pgbackrest'
+      when:
+        - inventory_hostname == groups['master'][0]
+        - restore_pgcluster_selected_tool == 'pgbackrest'
 
     - name: Validate pgBackRest target action value
       ansible.builtin.assert:
@@ -95,7 +100,9 @@
             is search('(^|\s)--target-action=(pause|promote|shutdown)(\s|$)')
         fail_msg: >-
           The pgBackRest option '--target-action' must be pause, promote, or shutdown.
-      when: restore_pgcluster_selected_tool == 'pgbackrest'
+      when:
+        - inventory_hostname == groups['master'][0]
+        - restore_pgcluster_selected_tool == 'pgbackrest'
 
     - name: Validate pgBackRest target timeline recovery type
       ansible.builtin.assert:
@@ -107,7 +114,9 @@
         fail_msg: >-
           The pgBackRest option '--target-timeline' requires '--type' to be
           default, lsn, name, standby, time, or xid.
-      when: restore_pgcluster_selected_tool == 'pgbackrest'
+      when:
+        - inventory_hostname == groups['master'][0]
+        - restore_pgcluster_selected_tool == 'pgbackrest'
 
     - name: Validate PITR target action
       ansible.builtin.assert:
@@ -115,6 +124,7 @@
           - restore_pgcluster_selected_target_action in ['pause', 'promote', 'shutdown']
         fail_msg: >-
           'restore_target_action' must be pause, promote, or shutdown.
+      when: inventory_hostname == groups['master'][0]
 
     - name: Validate PITR target timeline
       ansible.builtin.assert:
@@ -122,6 +132,7 @@
           - restore_pgcluster_selected_target_timeline | string | trim | length > 0
         fail_msg: >-
           'restore_target_timeline' must not be empty.
+      when: inventory_hostname == groups['master'][0]
 
     - name: Validate that PITR targets do not conflict
       ansible.builtin.assert:
@@ -129,6 +140,7 @@
           - not (restore_immediate | default(false) | bool and restore_target_time | default('') | length > 0)
         fail_msg: >-
           'restore_immediate' and 'restore_target_time' cannot be used together.
+      when: inventory_hostname == groups['master'][0]
 
     - name: Check that a pgBackRest backup is available before restore
       ansible.builtin.command:

--- a/automation/playbooks/restore_pgcluster.yml
+++ b/automation/playbooks/restore_pgcluster.yml
@@ -42,29 +42,32 @@
       ansible.builtin.import_role:
         name: vitabaks.autobase.common
 
-    - name: Validate restore parameters
+    - name: Validate backup tool
       ansible.builtin.assert:
         that:
-          - restore_pgcluster_selected_tool in ['pgbackrest', 'wal-g']
           - restore_pgcluster_selected_tool != 'pgbackrest' or pgbackrest_install | bool
           - restore_pgcluster_selected_tool != 'wal-g' or wal_g_install | bool
-          - not (restore_immediate | default(false) | bool and restore_target_time | default('') | length > 0)
-          - postgresql_restore_command | default('') | trim | length > 0
-          - restore_pgcluster_selected_bootstrap_command | default('') | trim | length > 0
         fail_msg: >-
-          Enable exactly one backup tool with 'pgbackrest_install' or 'wal_g_install'.
-          If both tools are enabled, set 'restore_pgcluster_tool' to 'pgbackrest' or 'wal-g'.
-          'restore_immediate' and 'restore_target_time' cannot be used together.
-          The selected backup tool must provide non-empty PostgreSQL restore and bootstrap commands.
+          Enable the selected backup tool with 'pgbackrest_install' or 'wal_g_install'.
 
-    - name: Validate automatic backup tool selection
+    - name: Validate PostgreSQL restore command
       ansible.builtin.assert:
         that:
-          - (pgbackrest_install | bool) != (wal_g_install | bool)
+          - postgresql_restore_command | default('') | trim | length > 0
+        fail_msg: The selected backup tool must provide a non-empty PostgreSQL restore command.
+
+    - name: Validate Patroni bootstrap command
+      ansible.builtin.assert:
+        that:
+          - restore_pgcluster_selected_bootstrap_command | default('') | trim | length > 0
         fail_msg: >-
-          Automatic restore tool selection requires exactly one enabled backup tool.
-          Set 'restore_pgcluster_tool' to 'pgbackrest' or 'wal-g'.
-      when: restore_pgcluster_tool | default('') | length == 0
+          The selected backup tool must provide a non-empty Patroni bootstrap command.
+
+    - name: Validate PITR target settings
+      ansible.builtin.assert:
+        that:
+          - not (restore_immediate | default(false) | bool and restore_target_time | default('') | length > 0)
+        fail_msg: "'restore_immediate' and 'restore_target_time' cannot be used together."
 
     - name: Check that a pgBackRest backup is available before restore
       ansible.builtin.command: >-

--- a/automation/playbooks/restore_pgcluster.yml
+++ b/automation/playbooks/restore_pgcluster.yml
@@ -42,7 +42,22 @@
       ansible.builtin.import_role:
         name: vitabaks.autobase.common
 
-    - name: Validate backup tool
+    - name: Validate restore backup tool selection
+      ansible.builtin.assert:
+        that:
+          - restore_pgcluster_selected_tool in ['pgbackrest', 'wal-g']
+        fail_msg: "Set 'restore_pgcluster_tool' to 'pgbackrest' or 'wal-g'."
+
+    - name: Validate automatic backup tool selection
+      ansible.builtin.assert:
+        that:
+          - (pgbackrest_install | bool) != (wal_g_install | bool)
+        fail_msg: >-
+          Automatic restore tool selection requires exactly one enabled backup tool.
+          Set 'restore_pgcluster_tool' to 'pgbackrest' or 'wal-g' when both tools are enabled.
+      when: restore_pgcluster_tool | default('') | length == 0
+
+    - name: Validate selected backup tool is enabled
       ansible.builtin.assert:
         that:
           - restore_pgcluster_selected_tool != 'pgbackrest' or pgbackrest_install | bool

--- a/automation/playbooks/restore_pgcluster.yml
+++ b/automation/playbooks/restore_pgcluster.yml
@@ -153,6 +153,74 @@
         patroni_config_reload: false
 
   tasks:
+    - name: Get current PostgreSQL log file
+      ansible.builtin.command: >-
+        {{ psql_command }} -tAXc "
+        select case
+        when pg_current_logfile() is null then ''
+        when pg_current_logfile() like '/%' then pg_current_logfile()
+        else current_setting('data_directory') || '/' || pg_current_logfile()
+        end"
+      vars:
+        psql_command: "{{ pg_old_bindir }}/psql -h 127.0.0.1 -p {{ postgresql_port }} -U {{ patroni_superuser_username }} -d postgres"
+      environment:
+        PGPASSWORD: "{{ patroni_superuser_password }}"
+      register: postgresql_log_file_result
+      changed_when: false
+      failed_when: false
+      when: inventory_hostname == groups['master'][0]
+
+    - name: Collect PostgreSQL recovery details
+      ansible.builtin.shell: |
+        set -o pipefail
+        awk '
+        /starting backup recovery/ {
+            capture = 1
+            block = ""
+        }
+        capture {
+            block = block $0 ORS
+
+            if ($0 ~ /database system is ready to accept connections/ ||
+                $0 ~ /database system is shut down/ ||
+                $0 ~ /recovery has paused/ ||
+                $0 ~ /recovery ended before configured recovery target was reached/) {
+                latest = block
+                capture = 0
+            }
+        }
+        END {
+            printf "%s", capture ? block : latest
+        }
+        ' {{ postgresql_log_file_result.stdout | quote }} |
+        grep -E \
+          -e '(backup|archive) recovery' \
+          -e 'redo (starts|done)|consistent recovery state reached' \
+          -e 'recovery (stopping|has paused|ended)' \
+          -e 'last completed transaction|selected new timeline ID' \
+          -e 'database system is (ready to accept connections|shut down)' \
+          -e 'FATAL' \
+          -e 'PANIC'
+      args:
+        executable: /bin/bash
+      become: true
+      become_user: postgres
+      register: postgresql_recovery_details_result
+      changed_when: false
+      failed_when: false
+      when:
+        - inventory_hostname == groups['master'][0]
+        - postgresql_log_file_result.rc | default(1) == 0
+        - postgresql_log_file_result.stdout | default('') | trim | length > 0
+
+    - name: PostgreSQL recovery details
+      ansible.builtin.debug:
+        msg: >-
+          {{ postgresql_recovery_details_result.stdout_lines
+             if postgresql_recovery_details_result.stdout_lines | default([]) | length > 0
+             else ['PostgreSQL recovery details were not found in the current log file.'] }}
+      when: inventory_hostname == groups['master'][0]
+
     - name: PostgreSQL cluster restore completed
       ansible.builtin.include_role:
         name: vitabaks.autobase.deploy_finish

--- a/automation/playbooks/restore_pgcluster.yml
+++ b/automation/playbooks/restore_pgcluster.yml
@@ -198,9 +198,7 @@
           -e 'redo (starts|done)|consistent recovery state reached' \
           -e 'recovery (stopping|has paused|ended)' \
           -e 'last completed transaction|selected new timeline ID' \
-          -e 'database system is (ready to accept connections|shut down)' \
-          -e 'FATAL' \
-          -e 'PANIC'
+          -e 'database system is (ready to accept connections|shut down)'
       args:
         executable: /bin/bash
       become: true

--- a/automation/playbooks/restore_pgcluster.yml
+++ b/automation/playbooks/restore_pgcluster.yml
@@ -73,8 +73,16 @@
         fail_msg: "'restore_immediate' and 'restore_target_time' cannot be used together."
 
     - name: Check that a pgBackRest backup is available before restore
-      ansible.builtin.command: >-
-        pgbackrest --stanza={{ pgbackrest_stanza }} --type=full --output=json info
+      ansible.builtin.command:
+        argv:
+          - pgbackrest
+          - "--stanza={{ pgbackrest_stanza }}"
+          - >-
+            {{ '--set=' + pgbackrest_restore_backup_name
+               if pgbackrest_restore_backup_name | length > 0
+               else '--type=full' }}
+          - --output=json
+          - info
       become: true
       become_user: postgres
       register: pgbackrest_backup_check_result
@@ -86,7 +94,10 @@
 
     - name: Stop restore when pgBackRest backup is unavailable
       ansible.builtin.fail:
-        msg: "Cannot restore PostgreSQL: no accessible pgBackRest backup was found for stanza '{{ pgbackrest_stanza }}'."
+        msg: >-
+          Cannot restore PostgreSQL: pgBackRest backup
+          '{{ pgbackrest_restore_backup_name | default('') }}'
+          is not accessible for stanza '{{ pgbackrest_stanza }}'.
       when:
         - inventory_hostname == groups['master'][0]
         - restore_pgcluster_selected_tool == 'pgbackrest'
@@ -109,12 +120,23 @@
 
     - name: Stop restore when WAL-G backup is unavailable
       ansible.builtin.fail:
-        msg: "Cannot restore PostgreSQL: no accessible WAL-G backup was found."
+        msg: >-
+          Cannot restore PostgreSQL: WAL-G backup
+          '{{ wal_g_restore_backup_name | default('') }}' is not accessible.
       when:
         - inventory_hostname == groups['master'][0]
         - restore_pgcluster_selected_tool == 'wal-g'
-        - wal_g_backup_check_result.rc != 0
+        - >-
+          wal_g_backup_check_result.rc != 0
           or (wal_g_backup_check_result.stdout | from_json | length) == 0
+          or (
+            wal_g_restore_backup_name != 'LATEST'
+            and (
+              wal_g_backup_check_result.stdout | from_json
+              | selectattr('backup_name', 'equalto', wal_g_restore_backup_name)
+              | list | length
+            ) == 0
+          )
 
     - name: Get current Patroni passwords
       ansible.builtin.import_role:

--- a/automation/playbooks/restore_pgcluster.yml
+++ b/automation/playbooks/restore_pgcluster.yml
@@ -74,6 +74,29 @@
         fail_msg: >-
           The selected backup tool must provide a non-empty Patroni bootstrap command.
 
+    - name: Validate pgBackRest target action recovery type
+      ansible.builtin.assert:
+        that:
+          - >-
+            '--target-action=' not in restore_pgcluster_selected_bootstrap_command or
+            restore_pgcluster_selected_bootstrap_command
+            is search('(^|\s)--type=(immediate|lsn|name|time|xid)(\s|$)')
+        fail_msg: >-
+          The pgBackRest option '--target-action' requires '--type' to be
+          immediate, lsn, name, time, or xid.
+      when: restore_pgcluster_selected_tool == 'pgbackrest'
+
+    - name: Validate pgBackRest target action value
+      ansible.builtin.assert:
+        that:
+          - >-
+            '--target-action=' not in restore_pgcluster_selected_bootstrap_command or
+            restore_pgcluster_selected_bootstrap_command
+            is search('(^|\s)--target-action=(pause|promote|shutdown)(\s|$)')
+        fail_msg: >-
+          The pgBackRest option '--target-action' must be pause, promote, or shutdown.
+      when: restore_pgcluster_selected_tool == 'pgbackrest'
+
     - name: Validate PITR target action
       ansible.builtin.assert:
         that:

--- a/automation/playbooks/restore_pgcluster.yml
+++ b/automation/playbooks/restore_pgcluster.yml
@@ -96,7 +96,7 @@
       ansible.builtin.fail:
         msg: >-
           Cannot restore PostgreSQL: pgBackRest backup
-          '{{ pgbackrest_restore_backup_name | default('') }}'
+          {{ pgbackrest_restore_backup_name | default('') }}
           is not accessible for stanza '{{ pgbackrest_stanza }}'.
       when:
         - inventory_hostname == groups['master'][0]
@@ -122,7 +122,8 @@
       ansible.builtin.fail:
         msg: >-
           Cannot restore PostgreSQL: WAL-G backup
-          '{{ wal_g_restore_backup_name | default('') }}' is not accessible.
+          {{ wal_g_restore_backup_name | default('') }}
+          is not accessible.
       when:
         - inventory_hostname == groups['master'][0]
         - restore_pgcluster_selected_tool == 'wal-g'

--- a/automation/playbooks/restore_pgcluster.yml
+++ b/automation/playbooks/restore_pgcluster.yml
@@ -56,7 +56,6 @@
           If both tools are enabled, set 'restore_pgcluster_tool' to 'pgbackrest' or 'wal-g'.
           'restore_immediate' and 'restore_target_time' cannot be used together.
           The selected backup tool must provide non-empty PostgreSQL restore and bootstrap commands.
-      run_once: true
 
     - name: Validate automatic backup tool selection
       ansible.builtin.assert:
@@ -66,11 +65,11 @@
           Automatic restore tool selection requires exactly one enabled backup tool.
           Set 'restore_pgcluster_tool' to 'pgbackrest' or 'wal-g'.
       when: restore_pgcluster_tool | default('') | length == 0
-      run_once: true
 
     - name: Check that a pgBackRest backup is available before restore
       ansible.builtin.command: >-
         pgbackrest --stanza={{ pgbackrest_stanza }} --type=full --output=json info
+      become: true
       become_user: postgres
       register: pgbackrest_backup_check_result
       changed_when: false
@@ -93,6 +92,7 @@
       ansible.builtin.command: "{{ wal_g_path }} backup-list --json"
       args:
         expand_argument_vars: true
+      become: true
       become_user: postgres
       register: wal_g_backup_check_result
       changed_when: false

--- a/automation/roles/common/defaults/main.yml
+++ b/automation/roles/common/defaults/main.yml
@@ -871,13 +871,17 @@ pgbackrest_patroni_cluster_restore_command: >-
 pgbackrest_patroni_cluster_bootstrap_command: >-
   {{ pgbackrest_patroni_cluster_restore_command
      ~ (' --target-action=' ~ pgbackrest_restore_target_action
-        if '--target-action=' not in pgbackrest_patroni_cluster_restore_command else '')
+        if pgbackrest_patroni_cluster_restore_command
+           is search('(^|\s)--type=(immediate|lsn|name|time|xid)(\s|$)')
+           and '--target-action=' not in pgbackrest_patroni_cluster_restore_command else '')
      ~ (' --target-timeline=' ~ pgbackrest_restore_target_timeline
         if '--target-timeline=' not in pgbackrest_patroni_cluster_restore_command else '') }}
 pgbackrest_patroni_replica_restore_command: >-
   {{ (pgbackrest_patroni_cluster_restore_command
       | regex_replace('(^|\s)--target-action=\S+', ''))
-     ~ ' --target-action=pause'
+     ~ (' --target-action=pause'
+        if pgbackrest_patroni_cluster_restore_command
+           is search('(^|\s)--type=(immediate|lsn|name|time|xid)(\s|$)') else '')
      ~ (' --target-timeline=' ~ pgbackrest_restore_target_timeline
         if '--target-timeline=' not in pgbackrest_patroni_cluster_restore_command else '') }}
 pgbackrest_patroni_cluster_bootstrap_recovery_conf:

--- a/automation/roles/common/defaults/main.yml
+++ b/automation/roles/common/defaults/main.yml
@@ -677,7 +677,7 @@ patroni_create_replica_methods:
   - basebackup
 
 pgbackrest:
-  - { option: "command", value: "{{ pgbackrest_patroni_cluster_restore_command }}" }
+  - { option: "command", value: "{{ pgbackrest_patroni_replica_restore_command }}" }
   - { option: "keep_data", value: "True" }
   - { option: "no_params", value: "True" }
 wal_g:
@@ -745,6 +745,8 @@ wal_g_archive_command: "{{ wal_g_path }} wal-push %p"
 wal_g_restore_command: "{{ wal_g_path }} wal-fetch %f %p"
 wal_g_restore_immediate: "{{ restore_immediate | default(false) }}"
 wal_g_restore_target_time: "{{ restore_target_time | default('') }}" # e.g. "2026-06-26 11:00:00+00"
+wal_g_restore_target_action: "{{ restore_target_action | default('promote') | lower }}" # pause, promote, or shutdown
+wal_g_restore_target_timeline: "{{ restore_target_timeline | default('latest') | string }}" # current, latest, or a timeline ID
 wal_g_restore_backup_name: "{{ restore_backup_name | default('LATEST') }}" # or a specific backup name from `wal-g backup-list`
 wal_g_patroni_cluster_bootstrap_command: >-
   {{ wal_g_path }} backup-fetch {{ postgresql_data_dir }} {{ wal_g_restore_backup_name }}
@@ -752,8 +754,8 @@ wal_g_patroni_cluster_bootstrap_recovery_conf: >-
   {{
     [
       {'restore_command': wal_g_restore_command},
-      {'recovery_target_action': 'promote'},
-      {'recovery_target_timeline': 'latest'}
+      {'recovery_target_action': wal_g_restore_target_action},
+      {'recovery_target_timeline': wal_g_restore_target_timeline}
     ]
     + ([{'recovery_target_time': wal_g_restore_target_time}] if wal_g_restore_target_time | length > 0
        else ([{'recovery_target': 'immediate'}] if wal_g_restore_immediate | bool else []))
@@ -829,7 +831,6 @@ pgbackrest_conf:
   stanza: # [stanza_name] section
     - { option: "process-max", value: "4" }
     - { option: "log-level-console", value: "info" }
-    - { option: "recovery-option", value: "recovery_target_action=promote" }
     - { option: "pg1-socket-path", value: "{{ postgresql_unix_socket_dir }}" }
     - { option: "pg1-path", value: "{{ postgresql_data_dir }}" }
 #    - { option: "", value: "" }
@@ -858,6 +859,8 @@ pgbackrest_archive_command: "pgbackrest --stanza={{ pgbackrest_stanza }} archive
 pgbackrest_restore_command: "pgbackrest --stanza={{ pgbackrest_stanza }} archive-get %f %p"
 pgbackrest_restore_immediate: "{{ restore_immediate | default(false) }}"
 pgbackrest_restore_target_time: "{{ restore_target_time | default('') }}" # e.g. "2026-06-26 11:00:00+00"
+pgbackrest_restore_target_action: "{{ restore_target_action | default('promote') | lower }}" # pause, promote, or shutdown
+pgbackrest_restore_target_timeline: "{{ restore_target_timeline | default('latest') | string }}" # current, latest, or a timeline ID
 pgbackrest_restore_backup_name: "{{ restore_backup_name | default('') }}" # e.g. "20260625-120000F_20260626-120000I"; empty means latest
 pgbackrest_patroni_cluster_restore_command: >-
   {{ '/usr/bin/pgbackrest --stanza=' ~ pgbackrest_stanza
@@ -865,10 +868,22 @@ pgbackrest_patroni_cluster_restore_command: >-
      ~ (' --type=time --target="' ~ pgbackrest_restore_target_time ~ '"' if pgbackrest_restore_target_time | length > 0
         else (' --type=immediate' if pgbackrest_restore_immediate | bool else ''))
      ~ ' --delta restore' }}
+pgbackrest_patroni_cluster_bootstrap_command: >-
+  {{ pgbackrest_patroni_cluster_restore_command
+     ~ (' --target-action=' ~ pgbackrest_restore_target_action
+        if '--target-action=' not in pgbackrest_patroni_cluster_restore_command else '')
+     ~ (' --target-timeline=' ~ pgbackrest_restore_target_timeline
+        if '--target-timeline=' not in pgbackrest_patroni_cluster_restore_command else '') }}
+pgbackrest_patroni_replica_restore_command: >-
+  {{ (pgbackrest_patroni_cluster_restore_command
+      | regex_replace('(^|\s)--target-action=\S+', ''))
+     ~ ' --target-action=pause'
+     ~ (' --target-timeline=' ~ pgbackrest_restore_target_timeline
+        if '--target-timeline=' not in pgbackrest_patroni_cluster_restore_command else '') }}
 pgbackrest_patroni_cluster_bootstrap_recovery_conf:
   - restore_command: "{{ pgbackrest_restore_command }}"
-  - recovery_target_action: promote
-  - recovery_target_timeline: latest
+  - recovery_target_action: "{{ pgbackrest_restore_target_action }}"
+  - recovery_target_timeline: "{{ pgbackrest_restore_target_timeline }}"
 pgbackrest_patroni_cluster_clean_bootstrap: false  # false: use delta restore for PITR into existing data dir; true: clean data directory before restore.
 
 # By default, the cron jobs is created on the database server.

--- a/automation/roles/common/defaults/main.yml
+++ b/automation/roles/common/defaults/main.yml
@@ -866,7 +866,7 @@ pgbackrest_patroni_cluster_restore_command: >-
   {{ '/usr/bin/pgbackrest --stanza=' ~ pgbackrest_stanza
      ~ (' --set=' ~ pgbackrest_restore_backup_name if pgbackrest_restore_backup_name | length > 0 else '')
      ~ (' --type=time --target="' ~ pgbackrest_restore_target_time ~ '"' if pgbackrest_restore_target_time | length > 0
-        else (' --type=immediate' if pgbackrest_restore_immediate | bool else ''))
+        else (' --type=immediate' if pgbackrest_restore_immediate | bool else ' --type=default'))
      ~ ' --delta restore' }}
 pgbackrest_patroni_cluster_bootstrap_command: >-
   {{ pgbackrest_patroni_cluster_restore_command
@@ -875,7 +875,9 @@ pgbackrest_patroni_cluster_bootstrap_command: >-
            is search('(^|\s)--type=(immediate|lsn|name|time|xid)(\s|$)')
            and '--target-action=' not in pgbackrest_patroni_cluster_restore_command else '')
      ~ (' --target-timeline=' ~ pgbackrest_restore_target_timeline
-        if '--target-timeline=' not in pgbackrest_patroni_cluster_restore_command else '') }}
+        if pgbackrest_patroni_cluster_restore_command
+           is search('(^|\s)--type=(default|lsn|name|standby|time|xid)(\s|$)')
+           and '--target-timeline=' not in pgbackrest_patroni_cluster_restore_command else '') }}
 pgbackrest_patroni_replica_restore_command: >-
   {{ (pgbackrest_patroni_cluster_restore_command
       | regex_replace('(^|\s)--target-action=\S+', ''))
@@ -883,7 +885,9 @@ pgbackrest_patroni_replica_restore_command: >-
         if pgbackrest_patroni_cluster_restore_command
            is search('(^|\s)--type=(immediate|lsn|name|time|xid)(\s|$)') else '')
      ~ (' --target-timeline=' ~ pgbackrest_restore_target_timeline
-        if '--target-timeline=' not in pgbackrest_patroni_cluster_restore_command else '') }}
+        if pgbackrest_patroni_cluster_restore_command
+           is search('(^|\s)--type=(default|lsn|name|standby|time|xid)(\s|$)')
+           and '--target-timeline=' not in pgbackrest_patroni_cluster_restore_command else '') }}
 pgbackrest_patroni_cluster_bootstrap_recovery_conf:
   - restore_command: "{{ pgbackrest_restore_command }}"
   - recovery_target_action: "{{ pgbackrest_restore_target_action }}"

--- a/automation/roles/patroni/handlers/main.yml
+++ b/automation/roles/patroni/handlers/main.yml
@@ -6,7 +6,9 @@
     enabled: true
     state: reloaded
   listen: "reload patroni"
-  when: postgresql_cluster_maintenance | default(false) | bool # exclude for initial deployment.
+  when:
+    - postgresql_cluster_maintenance | default(false) | bool # exclude for initial deployment.
+    - patroni_config_reload | default(true) | bool
 
 - name: Reload postgres
   become: true

--- a/automation/roles/patroni/tasks/main.yml
+++ b/automation/roles/patroni/tasks/main.yml
@@ -767,18 +767,6 @@
           failed_when: false
           when: inventory_hostname == groups['master'][0]
 
-        - name: Check PostgreSQL recovery log
-          ansible.builtin.command: "grep -A2 'recovery stopping' /tmp/pg_recovery_{{ ansible_date_time.date }}.log"
-          register: pg_recovery_result
-          changed_when: false
-          failed_when: false
-          when: inventory_hostname == groups['master'][0]
-
-        - name: PostgreSQL recovery details
-          ansible.builtin.debug:
-            msg: "{{ pg_recovery_result.stdout_lines }}"
-          when: pg_recovery_result.stdout_lines is defined
-
         - name: Check that PostgreSQL is stopped
           ansible.builtin.command: "{{ postgresql_bin_dir }}/pg_ctl status -D {{ postgresql_data_dir }}"
           register: pg_ctl_status_result

--- a/automation/roles/patroni/tasks/main.yml
+++ b/automation/roles/patroni/tasks/main.yml
@@ -790,6 +790,7 @@
       ansible.builtin.stat:
         path: "{{ postgresql_data_dir }}/patroni.dynamic.json"
       register: patroni_dynamic_json
+      when: not keep_patroni_dynamic_json | bool or disable_archive_command | bool
 
     - name: Remove patroni.dynamic.json file
       ansible.builtin.file:

--- a/automation/roles/patroni/tasks/main.yml
+++ b/automation/roles/patroni/tasks/main.yml
@@ -683,20 +683,16 @@
       when: inventory_hostname == groups['master'][0]
 
     - block: # for pgbackrest only (for use --delta restore)
-        - name: Run "{{ pgbackrest_patroni_cluster_restore_command | default('') }}" on Master
-          ansible.builtin.command: >
-            {{ pgbackrest_patroni_cluster_restore_command }}
-            {{ '--target-action=promote' if pgbackrest_patroni_cluster_restore_command is search('--type=') else '' }}
+        - name: Run "{{ pgbackrest_patroni_cluster_bootstrap_command | default('') }}" on Master
+          ansible.builtin.command: "{{ pgbackrest_patroni_cluster_bootstrap_command }}"
           async: "{{ cluster_restore_timeout | default(86400) }}" # timeout 24 hours
           poll: 0
           register: pgbackrest_restore_master
           when: inventory_hostname == groups['master'][0]
 
           # if patroni_create_replica_methods: "pgbackrest"
-        - name: Run "{{ pgbackrest_patroni_cluster_restore_command | default('') }}" on Replica
-          ansible.builtin.command: >
-            {{ pgbackrest_patroni_cluster_restore_command }}
-            {{ '--target-action=pause' if pgbackrest_patroni_cluster_restore_command is search('--type=') else '' }}
+        - name: Run "{{ pgbackrest_patroni_replica_restore_command | default('') }}" on Replica
+          ansible.builtin.command: "{{ pgbackrest_patroni_replica_restore_command }}"
           async: "{{ cluster_restore_timeout | default(86400) }}" # timeout 24 hours
           poll: 0
           register: pgbackrest_restore_replica

--- a/automation/roles/patroni/tasks/main.yml
+++ b/automation/roles/patroni/tasks/main.yml
@@ -1,12 +1,14 @@
 ---
 - name: Make sure handlers are flushed immediately
   ansible.builtin.meta: flush_handlers
+  when: not point_in_time_recovery | default(false) | bool
 
 # pip install
 - ansible.builtin.import_tasks: pip.yml
   when:
     - patroni_installation_method == "pip"
     - pip_package not in system_packages
+    - not point_in_time_recovery | default(false) | bool
   vars:
     pip_package: "python{{ python_version | default('3') }}-pip"
   tags: patroni, patroni_install, pip
@@ -71,7 +73,10 @@
         PATH: "{{ ansible_env.PATH }}:/usr/local/bin:/usr/bin"
         PIP_BREAK_SYSTEM_PACKAGES: "1"
       when: patroni_pip_package_repo | length < 1 and patroni_install_version != "latest"
-  when: installation_method == "packages" and patroni_installation_method == "pip"
+  when:
+    - installation_method == "packages"
+    - patroni_installation_method == "pip"
+    - not point_in_time_recovery | default(false) | bool
   environment: "{{ proxy_env | default({}) }}"
   tags: patroni, patroni_install
 
@@ -117,7 +122,10 @@
         PATH: "{{ ansible_env.PATH }}:/usr/local/bin:/usr/bin"
         PIP_BREAK_SYSTEM_PACKAGES: "1"
       when: patroni_pip_package_repo | length > 0
-  when: installation_method == "packages" and patroni_installation_method == "pip"
+  when:
+    - installation_method == "packages"
+    - patroni_installation_method == "pip"
+    - not point_in_time_recovery | default(false) | bool
   tags: patroni, patroni_install
 
 - block: # installation_method: "packages" and patroni_installation_method: "rpm/deb"
@@ -189,7 +197,10 @@
       retries: 3
       when: ansible_os_family == "RedHat" and patroni_rpm_package_repo | length > 0
   environment: "{{ proxy_env | default({}) }}"
-  when: installation_method == "packages" and (patroni_installation_method == "rpm" or patroni_installation_method == "deb")
+  when:
+    - installation_method == "packages"
+    - patroni_installation_method in ['rpm', 'deb']
+    - not point_in_time_recovery | default(false) | bool
   tags: patroni, patroni_install
 
 # Patroni configure
@@ -200,6 +211,7 @@
     owner: postgres
     group: postgres
     mode: "0750"
+  when: not point_in_time_recovery | default(false) | bool
   tags: patroni, patroni_conf
 
 # TLS (etcd)
@@ -216,6 +228,7 @@
     - tls_cert_generate | bool
     - dcs_type == "etcd"
     - not dcs_exists | bool
+    - not point_in_time_recovery | default(false) | bool
   tags: patroni, patroni_conf
 
 # TLS (consul)
@@ -232,6 +245,7 @@
     - tls_cert_generate | bool
     - dcs_type == "consul"
     - not dcs_exists | bool
+    - not point_in_time_recovery | default(false) | bool
   tags: patroni, patroni_conf
 
 - name: Create patroni config file
@@ -246,7 +260,9 @@
     group: postgres
     state: directory
     mode: "0750"
-  when: patroni_log_destination == 'logfile'
+  when:
+    - patroni_log_destination == 'logfile'
+    - not point_in_time_recovery | default(false) | bool
   tags: patroni, patroni_conf
 
 - block: # if cluster_scaling (add_node.yml)
@@ -326,7 +342,9 @@
         loop_var: patroni_config_with_cluster_vip_item
         label: "{{ patroni_config_with_cluster_vip_item.line }}"
       when: not with_haproxy_load_balancing|bool and not pgbouncer_install|bool and (cluster_vip is defined and cluster_vip | length > 0)
-  when: cluster_scaling is defined and cluster_scaling | bool
+  when:
+    - cluster_scaling is defined and cluster_scaling | bool
+    - not point_in_time_recovery | default(false) | bool
   tags: patroni, patroni_conf
 
 - name: Copy systemd service file "/etc/systemd/system/patroni.service"
@@ -336,6 +354,7 @@
     owner: postgres
     group: postgres
     mode: "0644"
+  when: not point_in_time_recovery | default(false) | bool
   tags: patroni, patroni_conf, patroni_service
 
 - name: Prepare PostgreSQL | create statistics directory (if not already exists)
@@ -347,6 +366,7 @@
     - postgresql_stats_temp_directory_path is defined
     - postgresql_stats_temp_directory_path != 'none'
     - postgresql_version | int <= 14
+    - not point_in_time_recovery | default(false) | bool
   tags: patroni, pgsql_stats_tmp
 
 - name: Prepare PostgreSQL | mount the statistics directory in memory (tmpfs)
@@ -360,6 +380,7 @@
     - postgresql_stats_temp_directory_path is defined
     - postgresql_stats_temp_directory_path != 'none'
     - postgresql_version | int <= 14
+    - not point_in_time_recovery | default(false) | bool
   tags: patroni, pgsql_stats_tmp
 
 - name: Prepare PostgreSQL | make sure the postgresql log directory "{{ postgresql_log_dir | default('') }}" exists
@@ -369,7 +390,7 @@
     group: postgres
     state: directory
     mode: "0700"
-  tags: patroni
+  tags: patroni, point_in_time_recovery
 
 - name: Prepare PostgreSQL | make sure the custom WAL directory "{{ postgresql_wal_dir | default('') }}" exists
   ansible.builtin.file:
@@ -379,41 +400,36 @@
     state: directory
     mode: "0700"
   when: postgresql_wal_dir is defined and postgresql_wal_dir | length > 0
-  tags: patroni, custom_wal_dir
+  tags: patroni, point_in_time_recovery, custom_wal_dir
+
+- name: Prepare PostgreSQL | make sure PostgreSQL home directory "{{ postgresql_home_dir | default('') }}"
+  ansible.builtin.file:
+    path: "{{ postgresql_home_dir }}"
+    state: directory
+    owner: postgres
+    group: postgres
+    mode: "0755"
+  tags: patroni, point_in_time_recovery
+
+- name: Prepare PostgreSQL | make sure PostgreSQL data directory "{{ postgresql_data_dir | default('') }}" exists
+  ansible.builtin.file:
+    path: "{{ postgresql_data_dir }}"
+    owner: postgres
+    group: postgres
+    state: directory
+    mode: "0700"
+  tags: patroni, point_in_time_recovery
+
+- name: Prepare PostgreSQL | make sure PostgreSQL unix socket directory "{{ postgresql_unix_socket_dir | default('') }}" exists
+  ansible.builtin.file:
+    path: "{{ postgresql_unix_socket_dir }}"
+    owner: postgres
+    group: postgres
+    state: directory
+    mode: "02775"
+  tags: patroni, point_in_time_recovery
 
 - block: # when postgresql NOT exists or PITR
-    - name: Prepare PostgreSQL | make sure PostgreSQL home directory "{{ postgresql_home_dir | default('') }}"
-      ansible.builtin.file:
-        path: "{{ postgresql_home_dir }}"
-        state: directory
-        owner: postgres
-        group: postgres
-        mode: "0755"
-
-    - name: Prepare PostgreSQL | make sure PostgreSQL data directory "{{ postgresql_data_dir | default('') }}" exists
-      ansible.builtin.file:
-        path: "{{ postgresql_data_dir }}"
-        owner: postgres
-        group: postgres
-        state: directory
-        mode: "0700"
-
-    - name: Prepare PostgreSQL | make sure PostgreSQL unix socket directory "{{ postgresql_unix_socket_dir | default('') }}" exists
-      ansible.builtin.file:
-        path: "{{ postgresql_unix_socket_dir }}"
-        owner: postgres
-        group: postgres
-        state: directory
-        mode: "02775"
-
-    - name: Prepare PostgreSQL | make sure PostgreSQL log directory "{{ postgresql_log_dir | default('') }}" exists
-      ansible.builtin.file:
-        path: "{{ postgresql_log_dir }}"
-        owner: postgres
-        group: postgres
-        state: directory
-        mode: "0700"
-
     # for Debian based distros only
     # patroni bootstrap failure is possible if the PostgreSQL config files are missing
     - name: Prepare PostgreSQL | make sure PostgreSQL config directory exists
@@ -458,14 +474,6 @@
             name: patroni
             state: stopped
 
-        - name: Prepare PostgreSQL | make sure the postgres home directory "{{ postgresql_home_dir | default('') }}"
-          ansible.builtin.file:
-            path: "{{ postgresql_home_dir }}"
-            state: directory
-            owner: postgres
-            group: postgres
-            mode: "0755"
-
         - name: Prepare PostgreSQL | make sure the data directory "{{ postgresql_data_dir | default('') }}" is empty
           ansible.builtin.file:
             path: "{{ postgresql_data_dir }}"
@@ -476,22 +484,6 @@
           loop:
             - absent
             - directory
-
-        - name: Prepare PostgreSQL | make sure PostgreSQL unix socket directory "{{ postgresql_unix_socket_dir | default('') }}" exists
-          ansible.builtin.file:
-            path: "{{ postgresql_unix_socket_dir }}"
-            owner: postgres
-            group: postgres
-            state: directory
-            mode: "02775"
-
-        - name: Prepare PostgreSQL | make sure PostgreSQL log directory "{{ postgresql_log_dir | default('') }}" exists
-          ansible.builtin.file:
-            path: "{{ postgresql_log_dir }}"
-            owner: postgres
-            group: postgres
-            state: directory
-            mode: "0700"
 
         - name: Prepare PostgreSQL | make sure the custom WAL directory "{{ postgresql_wal_dir | default('') }}" is empty
           ansible.builtin.file:
@@ -1127,8 +1119,10 @@
         name: "postgresql@{{ postgresql_version }}-{{ postgresql_cluster_name }}"
         enabled: false
         daemon_reload: true
-  when: ansible_os_family == "Debian" and
-    postgresql_packages|join(" ") is not search("postgrespro")
+  when:
+    - ansible_os_family == "Debian"
+    - postgresql_packages | join(" ") is not search("postgrespro")
+    - not point_in_time_recovery | default(false) | bool
   tags: patroni, postgresql_disable
 
 # "RedHat"
@@ -1137,8 +1131,10 @@
     name: "postgresql-{{ postgresql_version }}"
     enabled: false
     daemon_reload: true
-  when: ansible_os_family == "RedHat" and
-    postgresql_packages|join(" ") is not search("postgrespro")
+  when:
+    - ansible_os_family == "RedHat"
+    - postgresql_packages | join(" ") is not search("postgrespro")
+    - not point_in_time_recovery | default(false) | bool
   tags: patroni, postgresql_disable
 
 # PostgresPro
@@ -1147,7 +1143,9 @@
     name: "postgrespro-std-{{ postgresql_version }}"
     enabled: false
     daemon_reload: true
-  when: postgresql_packages|join(" ") is search("postgrespro-std")
+  when:
+    - postgresql_packages | join(" ") is search("postgrespro-std")
+    - not point_in_time_recovery | default(false) | bool
   tags: patroni, postgresql_disable
 
 # PATRONICTL_CONFIG_FILE (patroni v1.6.1 and higher)
@@ -1162,6 +1160,7 @@
     mode: "0644"
     create: true
   register: patronictl_env_result
+  when: not point_in_time_recovery | default(false) | bool
   tags: patroni, patroni_env
 
 - name: Add PATRONICTL_CONFIG_FILE to /etc/profile.d/patroni.sh
@@ -1173,4 +1172,5 @@
     owner: root
     group: root
     mode: "0644"
+  when: not point_in_time_recovery | default(false) | bool
   tags: patroni, patroni_env

--- a/automation/roles/patroni/templates/patroni.yml.j2
+++ b/automation/roles/patroni/templates/patroni.yml.j2
@@ -82,24 +82,24 @@ bootstrap:
   method: {{ patroni_cluster_bootstrap_method }}
 {% if patroni_cluster_bootstrap_method == 'wal-g' %}
   wal-g:
-    command: {{ wal_g_patroni_cluster_bootstrap_command }}
+    command: {{ wal_g_patroni_cluster_bootstrap_command | to_json }}
     no_params: True
     recovery_conf:
       {% for item in wal_g_patroni_cluster_bootstrap_recovery_conf %}
       {% for key, value in item.items() %}
-      {{ key }}: {{ value }}
+      {{ key }}: {{ value | to_json }}
       {% endfor %}
       {% endfor %}
 {% endif %}
 {% if patroni_cluster_bootstrap_method == 'pgbackrest' %}
   pgbackrest:
-    command: "{{ pgbackrest_patroni_cluster_restore_command }}"
+    command: {{ pgbackrest_patroni_cluster_restore_command | to_json }}
     keep_existing_recovery_conf: True
     no_params: True
     recovery_conf:
       {% for item in pgbackrest_patroni_cluster_bootstrap_recovery_conf %}
       {% for key, value in item.items() %}
-      {{ key }}: {{ value }}
+      {{ key }}: {{ value | to_json }}
       {% endfor %}
       {% endfor %}
 {% endif %}

--- a/automation/roles/patroni/templates/patroni.yml.j2
+++ b/automation/roles/patroni/templates/patroni.yml.j2
@@ -93,7 +93,7 @@ bootstrap:
 {% endif %}
 {% if patroni_cluster_bootstrap_method == 'pgbackrest' %}
   pgbackrest:
-    command: {{ pgbackrest_patroni_cluster_restore_command | to_json }}
+    command: {{ pgbackrest_patroni_cluster_bootstrap_command | to_json }}
     keep_existing_recovery_conf: True
     no_params: True
     recovery_conf:

--- a/automation/roles/pgbackrest/README.md
+++ b/automation/roles/pgbackrest/README.md
@@ -20,12 +20,12 @@ Installs and configures [pgBackRest](https://github.com/pgbackrest/pgbackrest) f
 | `pgbackrest_restore_command` | `"pgbackrest --stanza={{ pgbackrest_stanza }} archive-get %f %p"` | WAL restore_command helper string. |
 | `pgbackrest_restore_target_time` | `""` | Optional PITR target time, for example `"2020-06-01 11:00:00+03"`. Adds `--type=time --target=...` to the cluster restore command. |
 | `pgbackrest_restore_immediate` | `false` | Set to `true` to add `--type=immediate`. A non-empty `pgbackrest_restore_target_time` takes precedence. |
-| `pgbackrest_restore_target_action` | `{{ restore_target_action \| default('promote') }}` | Action after reaching the target: pause, promote, or shutdown. |
+| `pgbackrest_restore_target_action` | `{{ restore_target_action \| default('promote') }}` | Action after reaching the target: pause, promote, or shutdown. Added to the pgBackRest command only when targeted recovery is configured. |
 | `pgbackrest_restore_target_timeline` | `{{ restore_target_timeline \| default('latest') }}` | Timeline to recover along: current, latest, or a timeline ID. |
 | `pgbackrest_restore_backup_name` | `""` | Optional backup set name added as `--set=...`. An empty value lets pgBackRest restore the latest backup set. |
 | `pgbackrest_patroni_cluster_restore_command` | `"/usr/bin/pgbackrest --stanza={{ pgbackrest_stanza }} --delta restore"` | Base restore command. Includes the configured backup set and time or immediate recovery target. |
 | `pgbackrest_patroni_cluster_bootstrap_command` | Derived | Cluster bootstrap/master command with target action and timeline options. |
-| `pgbackrest_patroni_replica_restore_command` | Derived | Replica restore command. Uses pause at a configured PITR target and the selected timeline. |
+| `pgbackrest_patroni_replica_restore_command` | Derived | Replica restore command. Uses pause only at a configured PITR target and applies the selected timeline. |
 | `pgbackrest_patroni_cluster_bootstrap_recovery_conf` | [...] | List for Patroni recovery parameters (restore_command, recovery_target_action, etc.). |
 | `pgbackrest_patroni_cluster_clean_bootstrap` | `false` | Controls how Patroni bootstraps from a pgBackRest backup: false – delta restore into the existing data directory (faster, reuses unchanged files). true – clean restore into an empty data directory (wipes existing contents first). |
 | `pgbackrest_cron_jobs` | [...] | Cron jobs for backups (full/diff). Created on DB host by default, or on repo_host if defined. |

--- a/automation/roles/pgbackrest/README.md
+++ b/automation/roles/pgbackrest/README.md
@@ -21,9 +21,9 @@ Installs and configures [pgBackRest](https://github.com/pgbackrest/pgbackrest) f
 | `pgbackrest_restore_target_time` | `""` | Optional PITR target time, for example `"2020-06-01 11:00:00+03"`. Adds `--type=time --target=...` to the cluster restore command. |
 | `pgbackrest_restore_immediate` | `false` | Set to `true` to add `--type=immediate`. A non-empty `pgbackrest_restore_target_time` takes precedence. |
 | `pgbackrest_restore_target_action` | `{{ restore_target_action \| default('promote') }}` | Action after reaching the target: pause, promote, or shutdown. Added to the pgBackRest command only when targeted recovery is configured. |
-| `pgbackrest_restore_target_timeline` | `{{ restore_target_timeline \| default('latest') }}` | Timeline to recover along: current, latest, or a timeline ID. |
+| `pgbackrest_restore_target_timeline` | `{{ restore_target_timeline \| default('latest') }}` | Timeline to recover along: current, latest, or a timeline ID. Not passed to pgBackRest for immediate recovery. |
 | `pgbackrest_restore_backup_name` | `""` | Optional backup set name added as `--set=...`. An empty value lets pgBackRest restore the latest backup set. |
-| `pgbackrest_patroni_cluster_restore_command` | `"/usr/bin/pgbackrest --stanza={{ pgbackrest_stanza }} --delta restore"` | Base restore command. Includes the configured backup set and time or immediate recovery target. |
+| `pgbackrest_patroni_cluster_restore_command` | `"/usr/bin/pgbackrest --stanza={{ pgbackrest_stanza }} --type=default --delta restore"` | Base restore command. Includes the configured backup set and recovery type. |
 | `pgbackrest_patroni_cluster_bootstrap_command` | Derived | Cluster bootstrap/master command with target action and timeline options. |
 | `pgbackrest_patroni_replica_restore_command` | Derived | Replica restore command. Uses pause only at a configured PITR target and applies the selected timeline. |
 | `pgbackrest_patroni_cluster_bootstrap_recovery_conf` | [...] | List for Patroni recovery parameters (restore_command, recovery_target_action, etc.). |

--- a/automation/roles/pgbackrest/README.md
+++ b/automation/roles/pgbackrest/README.md
@@ -20,8 +20,12 @@ Installs and configures [pgBackRest](https://github.com/pgbackrest/pgbackrest) f
 | `pgbackrest_restore_command` | `"pgbackrest --stanza={{ pgbackrest_stanza }} archive-get %f %p"` | WAL restore_command helper string. |
 | `pgbackrest_restore_target_time` | `""` | Optional PITR target time, for example `"2020-06-01 11:00:00+03"`. Adds `--type=time --target=...` to the cluster restore command. |
 | `pgbackrest_restore_immediate` | `false` | Set to `true` to add `--type=immediate`. A non-empty `pgbackrest_restore_target_time` takes precedence. |
-| `pgbackrest_restore_backup_set` | `""` | Optional backup set name added as `--set=...`. An empty value lets pgBackRest restore the latest backup set. |
-| `pgbackrest_patroni_cluster_restore_command` | `"/usr/bin/pgbackrest --stanza={{ pgbackrest_stanza }} --delta restore"` | Command used for cluster restore/bootstrap. Includes the configured backup set and time or immediate recovery target. |
+| `pgbackrest_restore_target_action` | `{{ restore_target_action \| default('promote') }}` | Action after reaching the target: pause, promote, or shutdown. |
+| `pgbackrest_restore_target_timeline` | `{{ restore_target_timeline \| default('latest') }}` | Timeline to recover along: current, latest, or a timeline ID. |
+| `pgbackrest_restore_backup_name` | `""` | Optional backup set name added as `--set=...`. An empty value lets pgBackRest restore the latest backup set. |
+| `pgbackrest_patroni_cluster_restore_command` | `"/usr/bin/pgbackrest --stanza={{ pgbackrest_stanza }} --delta restore"` | Base restore command. Includes the configured backup set and time or immediate recovery target. |
+| `pgbackrest_patroni_cluster_bootstrap_command` | Derived | Cluster bootstrap/master command with target action and timeline options. |
+| `pgbackrest_patroni_replica_restore_command` | Derived | Replica restore command. Uses pause at a configured PITR target and the selected timeline. |
 | `pgbackrest_patroni_cluster_bootstrap_recovery_conf` | [...] | List for Patroni recovery parameters (restore_command, recovery_target_action, etc.). |
 | `pgbackrest_patroni_cluster_clean_bootstrap` | `false` | Controls how Patroni bootstraps from a pgBackRest backup: false – delta restore into the existing data directory (faster, reuses unchanged files). true – clean restore into an empty data directory (wipes existing contents first). |
 | `pgbackrest_cron_jobs` | [...] | Cron jobs for backups (full/diff). Created on DB host by default, or on repo_host if defined. |

--- a/automation/roles/pgbackrest/tasks/auto_conf.yml
+++ b/automation/roles/pgbackrest/tasks/auto_conf.yml
@@ -31,7 +31,6 @@
         - { option: "backup-standby", value: "{{ 'y' if groups['postgres_cluster'] | length > 1 else 'n' }}" }
       stanza:
         - { option: "log-level-console", value: "info" }
-        - { option: "recovery-option", value: "recovery_target_action=promote" }
         - { option: "pg1-path", value: "{{ postgresql_data_dir }}" }
   delegate_to: localhost
   run_once: true # noqa run-once
@@ -63,7 +62,6 @@
         - { option: "backup-standby", value: "{{ 'y' if groups['postgres_cluster'] | length > 1 else 'n' }}" }
       stanza:
         - { option: "log-level-console", value: "info" }
-        - { option: "recovery-option", value: "recovery_target_action=promote" }
         - { option: "pg1-path", value: "{{ postgresql_data_dir }}" }
   no_log: true # do not output contents to the ansible log
   when: cloud_provider | default('') | lower == 'gcp'
@@ -101,7 +99,6 @@
         - { option: "backup-standby", value: "{{ 'y' if groups['postgres_cluster'] | length > 1 else 'n' }}" }
       stanza:
         - { option: "log-level-console", value: "info" }
-        - { option: "recovery-option", value: "recovery_target_action=promote" }
         - { option: "pg1-path", value: "{{ postgresql_data_dir }}" }
   no_log: true # do not output contents to the ansible log
   when: cloud_provider | default('') | lower == 'azure'
@@ -139,7 +136,6 @@
         - { option: "backup-standby", value: "{{ 'y' if groups['postgres_cluster'] | length > 1 else 'n' }}" }
       stanza:
         - { option: "log-level-console", value: "info" }
-        - { option: "recovery-option", value: "recovery_target_action=promote" }
         - { option: "pg1-path", value: "{{ postgresql_data_dir }}" }
   vars:
     default_region: "{{ (server_location in ['nyc1', 'nyc2']) | ternary('nyc3', server_location) }}"
@@ -178,7 +174,6 @@
         - { option: "backup-standby", value: "{{ 'y' if groups['postgres_cluster'] | length > 1 else 'n' }}" }
       stanza:
         - { option: "log-level-console", value: "info" }
-        - { option: "recovery-option", value: "recovery_target_action=promote" }
         - { option: "pg1-path", value: "{{ postgresql_data_dir }}" }
   vars:
     default_region: "{{ (server_location in ['hel1', 'fsn1', 'nbg1']) | ternary(server_location, 'nbg1') }}"

--- a/automation/roles/upgrade/tasks/recovery_target.yml
+++ b/automation/roles/upgrade/tasks/recovery_target.yml
@@ -55,17 +55,23 @@
   retries: 360
   delay: 10
   vars:
-    psql_command: "{{ pg_old_bindir }}/psql -h 127.0.0.1 -p {{ postgresql_port }} -U {{ patroni_superuser_username }}"
+    psql_command: "{{ pg_old_bindir }}/psql -h 127.0.0.1 -p {{ postgresql_port }} -U {{ patroni_superuser_username }} -d postgres"
   environment:
     PGPASSWORD: "{{ patroni_superuser_password }}"
   when: inventory_hostname in groups['primary']
 
-- name: "Get the current PostgreSQL log file"
-  ansible.builtin.shell: |
-    set -o pipefail;
-    ls -t {{ postgresql_log_dir }} | grep .{{ postgresql_log_format | default('log') }} | head -n 1
-  args:
-    executable: /bin/bash
+- name: Get current PostgreSQL log file
+  ansible.builtin.command: >-
+    {{ psql_command }} -tAXc "
+    select case
+    when pg_current_logfile() is null then ''
+    when pg_current_logfile() like '/%' then pg_current_logfile()
+    else current_setting('data_directory') || '/' || pg_current_logfile()
+    end"
+  vars:
+    psql_command: "{{ pg_old_bindir }}/psql -h 127.0.0.1 -p {{ postgresql_port }} -U {{ patroni_superuser_username }} -d postgres"
+  environment:
+    PGPASSWORD: "{{ patroni_superuser_password }}"
   register: pg_log_filename
   changed_when: false
   ignore_errors: true

--- a/automation/roles/wal_g/README.md
+++ b/automation/roles/wal_g/README.md
@@ -16,6 +16,8 @@ This role installs and configures [WAL-G](https://github.com/wal-g/wal-g), an ar
 | wal_g_restore_backup_name | `LATEST` | Backup name passed to `backup-fetch`. Set a name from `wal-g backup-list` to restore a specific backup. |
 | wal_g_restore_target_time | `""` | Optional PITR target time, for example `"2026-06-26 11:00:00+00"`. |
 | wal_g_restore_immediate | `false` | Set to `true` to stop recovery as soon as the restored backup becomes consistent. A non-empty `wal_g_restore_target_time` takes precedence. |
+| wal_g_restore_target_action | `{{ restore_target_action \| default('promote') }}` | Action after reaching the target: pause, promote, or shutdown. |
+| wal_g_restore_target_timeline | `{{ restore_target_timeline \| default('latest') }}` | Timeline to recover along: current, latest, or a timeline ID. |
 | wal_g_patroni_cluster_bootstrap_command | `{{ wal_g_path }} backup-fetch {{ postgresql_data_dir }} {{ wal_g_restore_backup_name }}` | Patroni bootstrap command for recovery from a WAL-G backup. |
 | wal_g_patroni_cluster_bootstrap_recovery_conf | [...] | Recovery parameters generated from `wal_g_restore_target_time` or `wal_g_restore_immediate`. |
 | wal_g_backup_command | [...] | Parts that form the backup command (joined into a single string for cron). |


### PR DESCRIPTION
Add a new Ansible playbook `restore_pgcluster.yml` to restore PostgreSQL clusters from pgBackRest or WAL‑G backup.


New variables:
- `restore_backup_name`, default: '' (empty means latest)
- `restore_target_time`, default: '' (optional, for PITR)
- `restore_target_timeline`, default: 'latest'
- `restore_target_action`, default: 'promote' ('pause' for replicas)
- `restore_immediate`, default: false