### PR TITLE
Console: Fix stale data on the Operations page

### DIFF
--- a/console/service/internal/storage/db_storage.go
+++ b/console/service/internal/storage/db_storage.go
@@ -697,7 +697,7 @@ func (s *dbStorage) GetOperations(ctx context.Context, req *GetOperationsReq) ([
 		curOffset = *req.Offset
 	}
 
-	subQuery := `where project_id = $1 and started >= $2 and finished <= $3`
+	subQuery := `where project_id = $1 and started >= $2 and started <= $3`
 
 	var (
 		extraWhere           string

--- a/console/ui/src/shared/lib/hooks.tsx
+++ b/console/ui/src/shared/lib/hooks.tsx
@@ -6,22 +6,24 @@ import { toast } from 'react-toastify';
  * Hook polls RTK query request every N milliseconds.
  * @param request - RTK request to poll.
  * @param pollingInterval - Polling interval in ms. Use 0 to disable polling.
- * @param options - Different config options.
+ * @param options - Different config options. `onPoll` replaces the default refetch callback.
  */
 export const useQueryPolling = <T extends { refetch: () => unknown }>(
   result: T,
   pollingInterval: number,
-  options?: { stop?: boolean },
+  options?: { stop?: boolean; onPoll?: () => void },
 ) => {
   const stop = options?.stop === true;
+  const onPoll = options?.onPoll;
+  const refetch = result.refetch;
 
   useEffect(() => {
     if (stop || !pollingInterval || pollingInterval <= 0) return;
-    const polling = setInterval(() => result.refetch(), pollingInterval);
+    const polling = setInterval(() => (onPoll ? onPoll() : refetch()), pollingInterval);
     return () => {
       clearInterval(polling);
     };
-  }, [pollingInterval, result, stop]);
+  }, [onPoll, pollingInterval, refetch, stop]);
 
   return result;
 };

--- a/console/ui/src/widgets/operations-table/lib/hooks.tsx
+++ b/console/ui/src/widgets/operations-table/lib/hooks.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { OPERATIONS_TABLE_COLUMN_NAMES } from '@widgets/operations-table/model/constants.ts';
 import { ResponseOperation } from '@shared/api/api/operations.ts';
 
@@ -16,3 +16,12 @@ export const useGetOperationsTableData = (data: ResponseOperation[]) =>
       })) ?? [],
     [data],
   );
+
+export const useOperationsEndDate = () => {
+  const [endDate, setEndDate] = useState(() => new Date().toISOString());
+  const refreshEndDate = useCallback(() => {
+    setEndDate(new Date().toISOString());
+  }, []);
+
+  return { endDate, refreshEndDate };
+};

--- a/console/ui/src/widgets/operations-table/ui/index.tsx
+++ b/console/ui/src/widgets/operations-table/ui/index.tsx
@@ -15,7 +15,8 @@ import {
 } from '@features/operations-table-buttons/lib/functions.ts';
 import { PAGINATION_LIMIT_OPTIONS } from '@shared/config/constants.ts';
 import { selectPollingInterval } from '@app/redux/slices/pollingIntervalSlice/pollingIntervalSlice.ts';
-import { useGetOperationsTableData } from '@widgets/operations-table/lib/hooks.tsx';
+import { useGetOperationsTableData, useOperationsEndDate } from '@widgets/operations-table/lib/hooks.tsx';
+import type { OperationsDateRange } from '@features/operations-table-buttons/model/types.ts';
 import { manageSortingOrder } from '@shared/lib/functions.ts';
 import { useQueryPolling } from '@shared/lib/hooks.tsx';
 import DefaultTable from '@shared/ui/default-table';
@@ -38,8 +39,8 @@ const OperationsTable: FC = () => {
     pageSize: PAGINATION_LIMIT_OPTIONS[1].value,
   });
 
-  const [endDate] = useState(new Date().toISOString());
-  const [startDate, setStartDate] = useState({
+  const { endDate, refreshEndDate } = useOperationsEndDate();
+  const [startDate, setStartDate] = useState<OperationsDateRange>({
     name: getOperationsDateRangeVariants(t)[0].value,
     value: formatOperationsDate(subDays(new Date(), 1)),
   });
@@ -52,7 +53,7 @@ const OperationsTable: FC = () => {
     limit: pagination.pageSize,
     ...(sorting?.[0] ? { sortBy: manageSortingOrder(sorting[0]) } : {}),
   });
-  const operationsList = useQueryPolling(operationsListRequest, pollingInterval);
+  const operationsList = useQueryPolling(operationsListRequest, pollingInterval, { onPoll: refreshEndDate });
 
   const columns = useMemo<MRT_ColumnDef<OperationsTableValues>[]>(() => operationTableColumns(t), [t]);
 
@@ -81,7 +82,7 @@ const OperationsTable: FC = () => {
 
   return (
     <>
-      <OperationsTableButtons refetch={operationsList.refetch} startDate={startDate} setStartDate={setStartDate} />
+      <OperationsTableButtons refetch={refreshEndDate} startDate={startDate} setStartDate={setStartDate} />
       <DefaultTable tableConfig={tableConfig} />
     </>
   );


### PR DESCRIPTION
Fix stale Operations data by refreshing the query’s `end_date` during manual and automatic updates. Also correct the backend date-range filter to use operation start time, ensuring new and in-progress operations are displayed consistently.