### PR TITLE
Do not enable sudo access for postgres by default

### DIFF
--- a/automation/roles/common/defaults/main.yml
+++ b/automation/roles/common/defaults/main.yml
@@ -1120,10 +1120,10 @@ ssh_public_keys: []
 #  - { entry: "ssh-rsa AAAAB3... user2@example", state: "absent" } # remove a public key
 
 # sudo
-sudo_users:
-  - name: "postgres"
-    nopasswd: "yes" # or "no" to require a password
-    commands: "ALL"
+sudo_users: []
+#  - name: "postgres"
+#    nopasswd: "yes" # or "no" to require a password
+#    commands: "ALL"
 #  - name: "joe" # other user (example)
 #    nopasswd: "no"
 #    commands: "/usr/bin/find, /usr/bin/less, /usr/bin/tail, /bin/kill"

--- a/automation/roles/sudo/tasks/main.yml
+++ b/automation/roles/sudo/tasks/main.yml
@@ -6,8 +6,10 @@
     content: |
       {{ item.name }}  ALL=(ALL)  NOPASSWD: ALL
     force: true
-  when: item.nopasswd == "yes" and
-    ( item.commands is not defined or item.commands == "ALL")
+  when:
+    - sudo_users | default([]) | length > 0
+    - item.nopasswd == "yes"
+    - item.commands is not defined or item.commands == "ALL"
   loop: "{{ sudo_users | list }}"
   tags: sudo
 
@@ -18,8 +20,10 @@
     content: |
       {{ item.name }}  ALL=(ALL)  NOPASSWD: {{ item.commands }}
     force: true
-  when: item.nopasswd == "yes" and
-    ( item.commands is defined and item.commands != "ALL" )
+  when:
+    - sudo_users | default([]) | length > 0
+    - item.nopasswd == "yes"
+    - item.commands is defined and item.commands != "ALL"
   loop: "{{ sudo_users | list }}"
   tags: sudo
 
@@ -30,8 +34,10 @@
     content: |
       {{ item.name }}  ALL=(ALL)  ALL
     force: true
-  when: item.nopasswd != "yes" and
-    ( item.commands is not defined or item.commands == "ALL" )
+  when:
+    - sudo_users | default([]) | length > 0
+    - item.nopasswd != "yes"
+    - item.commands is not defined or item.commands == "ALL"
   loop: "{{ sudo_users | list }}"
   tags: sudo
 
@@ -42,7 +48,9 @@
     content: |
       {{ item.name }}  ALL=(ALL)  {{ item.commands }}
     force: true
-  when: item.nopasswd != "yes" and
-    ( item.commands is defined and item.commands != "ALL" )
+  when:
+    - sudo_users | default([]) | length > 0
+    - item.nopasswd != "yes"
+    - item.commands is defined and item.commands != "ALL"
   loop: "{{ sudo_users | list }}"
   tags: sudo


### PR DESCRIPTION
The common role no longer creates a default sudo entry for postgres system user.

This makes sudo configuration opt-in and avoids granting elevated privileges unless `sudo_users` is explicitly defined in the inventory or role overrides.