### PR TITLE
fix: Fetch passwords before cluster update

### DIFF
--- a/automation/playbooks/update_pgcluster.yml
+++ b/automation/playbooks/update_pgcluster.yml
@@ -80,6 +80,16 @@
       when: inventory_hostname in groups['primary'] | default([])
       tags: always
 
+    - name: '[Prepare] Get current passwords'
+      ansible.builtin.import_role:
+        name: vitabaks.autobase.pre_checks
+        tasks_from: passwords
+      vars:
+        source_group: primary
+        postgresql_cluster_maintenance: true
+      when: patroni_superuser_password | default('') | length < 1
+      tags: always
+
 - name: "(1/4) PRE-UPDATE: Perform pre-update tasks"
   hosts: "primary:secondary"
   gather_facts: true


### PR DESCRIPTION
Add a task that imports the vitabaks.autobase.pre_checks passwords task to retrieve current Patroni passwords when patroni_superuser_password is unset.

Fixed:

```
TASK [vitabaks.autobase.update : [Pre-Check] (ALL) Test PostgreSQL DB Access] ***
[ERROR]: Task failed: Module failed: The command exited with a non-zero return code.
Origin: /root/.ansible/collections/ansible_collections/vitabaks/autobase/roles/update/tasks/pre_checks.yml:2:3
1 ---
2 - name: "[Pre-Check] (ALL) Test PostgreSQL DB Access"
    ^ column 3
fatal: [172.31.41.251]: FAILED! => {"changed": false, "changed_when_result": false, "cmd": ["/usr/lib/postgresql/18/bin/psql", "-h", "127.0.0.1", "-p", "5432", "-U", "postgres", "-d", "postgres", "-tAXc", "select 1"], "delta": "0:00:00.042429", "end": "2026-08-17 13:22:12.980681", "msg": "The command exited with a non-zero return code.", "rc": 2, "start": "2026-08-17 13:22:12.938252", "stderr": "Password for user postgres: \npsql: error: connection to server at \"127.0.0.1\", port 5432 failed: fe_sendauth: no password supplied", "stderr_lines": ["Password for user postgres: ", "psql: error: connection to server at \"127.0.0.1\", port 5432 failed: fe_sendauth: no password supplied"], "stdout": "", "stdout_lines": []}
fatal: [172.31.42.44]: FAILED! => {"changed": false, "changed_when_result": false, "cmd": ["/usr/lib/postgresql/18/bin/psql", "-h", "127.0.0.1", "-p", "5432", "-U", "postgres", "-d", "postgres", "-tAXc", "select 1"], "delta": "0:00:00.044954", "end": "2026-08-17 13:22:13.031261", "msg": "The command exited with a non-zero return code.", "rc": 2, "start": "2026-08-17 13:22:12.986307", "stderr": "Password for user postgres: \npsql: error: connection to server at \"127.0.0.1\", port 5432 failed: fe_sendauth: no password supplied", "stderr_lines": ["Password for user postgres: ", "psql: error: connection to server at \"127.0.0.1\", port 5432 failed: fe_sendauth: no password supplied"], "stdout": "", "stdout_lines": []}
fatal: [172.31.43.190]: FAILED! => {"changed": false, "changed_when_result": false, "cmd": ["/usr/lib/postgresql/18/bin/psql", "-h", "127.0.0.1", "-p", "5432", "-U", "postgres", "-d", "postgres", "-tAXc", "select 1"], "delta": "0:00:00.045072", "end": "2026-08-17 13:22:13.039016", "msg": "The command exited with a non-zero return code.", "rc": 2, "start": "2026-08-17 13:22:12.993944", "stderr": "Password for user postgres: \npsql: error: connection to server at \"127.0.0.1\", port 5432 failed: fe_sendauth: no password supplied", "stderr_lines": ["Password for user postgres: ", "psql: error: connection to server at \"127.0.0.1\", port 5432 failed: fe_sendauth: no password supplied"], "stdout": "", "stdout_lines": []}
```