### PR TITLE
fix: Fetch passwords before PG upgrade

### DIFF
--- a/automation/playbooks/pg_upgrade.yml
+++ b/automation/playbooks/pg_upgrade.yml
@@ -71,6 +71,15 @@
           - "Cluster Name: {{ patroni_cluster_name | default('postgres-cluster') }}"
           - "Cluster Leader: {{ ansible_hostname }}"
       when: inventory_hostname in groups['primary'] | default([])
+
+    - name: '[Prepare] Get current passwords'
+      ansible.builtin.import_role:
+        name: vitabaks.autobase.pre_checks
+        tasks_from: passwords
+      vars:
+        source_group: primary
+        postgresql_cluster_maintenance: true
+      when: patroni_superuser_password | default('') | length < 1
   tags:
     - always
 

--- a/automation/playbooks/pg_upgrade_rollback.yml
+++ b/automation/playbooks/pg_upgrade_rollback.yml
@@ -36,6 +36,17 @@
       loop: "{{ groups['replica'] | default([]) }}"
       changed_when: false
       when: "'replica' in groups and groups['replica'] | length > 0"
+
+    - name: '[Prepare] Get current passwords'
+      become: true
+      become_user: postgres
+      ansible.builtin.import_role:
+        name: vitabaks.autobase.pre_checks
+        tasks_from: passwords
+      vars:
+        source_group: primary
+        postgresql_cluster_maintenance: true
+      when: patroni_superuser_password | default('') | length < 1
   tags:
     - always
 


### PR DESCRIPTION
The pg_upgrade playbook now retrieves current PostgreSQL passwords before running maintenance when the superuser password is not already set. This ensures upgrade steps that rely on the cluster credentials can complete successfully without requiring manual password setup.

Fixed:

```
TASK [vitabaks.autobase.upgrade : [Pre-Check] Check the current version of PostgreSQL] ***
[ERROR]: Task failed: Module failed: The command exited with a non-zero return code.
Origin: /root/.ansible/collections/ansible_collections/vitabaks/autobase/roles/upgrade/tasks/pre_checks.yml:79:3
77     - "'no pg_hba.conf entry' in socket_access_result.stderr"
78
79 - name: "[Pre-Check] Check the current version of PostgreSQL"
     ^ column 3
fatal: [172.31.39.183]: FAILED! => {"changed": false, "changed_when_result": false, "cmd": ["/usr/lib/postgresql/16/bin/psql", "-h", "127.0.0.1", "-p", "5432", "-U", "postgres", "-d", "postgres", "-tAXc", "select setting::integer/10000 from pg_settings where name = 'server_version_num'"], "delta": "0:00:00.034626", "end": "2026-08-17 22:26:16.844012", "msg": "The command exited with a non-zero return code.", "rc": 2, "start": "2026-08-17 22:26:16.809386", "stderr": "Password for user postgres: \npsql: error: connection to server at \"127.0.0.1\", port 5432 failed: fe_sendauth: no password supplied", "stderr_lines": ["Password for user postgres: ", "psql: error: connection to server at \"127.0.0.1\", port 5432 failed: fe_sendauth: no password supplied"], "stdout": "", "stdout_lines": []}
```