### PR TITLE
fix problem with host identification in /etc/hosts

### DIFF
--- a/automation/roles/hostname/README.md
+++ b/automation/roles/hostname/README.md
@@ -10,7 +10,7 @@ Sets the system hostname and ensures it is reflected in /etc/hosts for local res
 
 ## Behavior
 - Uses the Ansible hostname module to set the hostname.
-- Adds/updates the localhost line in /etc/hosts to include the current ansible_hostname.
+- Rewrites the `127.0.0.1` line in `/etc/hosts` so `ansible_hostname` is the first alias and `localhost` is the second. This makes `hostname -f` return the short hostname (glibc's FQDN resolution returns the first alias on the matching `/etc/hosts` line) instead of `localhost`, preventing duplicate-FQDN issues across cluster nodes.
 
 ## Dependencies
 

--- a/automation/roles/hostname/tasks/main.yml
+++ b/automation/roles/hostname/tasks/main.yml
@@ -12,6 +12,6 @@
         state: present
       no_log: true
       loop:
-        - { regexp: '^127\.0\.0\.1[ \t]+localhost', line: "127.0.0.1 localhost {{ ansible_hostname }}" }
+        - { regexp: '^127\.0\.0\.1\b', line: "127.0.0.1 {{ ansible_hostname }} localhost" }
   when: hostname is defined and hostname | length > 0
   tags: hostname


### PR DESCRIPTION
## fix(hostname): correct `hostname -f` returning `localhost` on all supported OSes

### Problem

The `hostname` role writes `127.0.0.1 localhost <hostname>` to `/etc/hosts`.
glibc resolves `hostname -f` by returning the **first alias** on the `127.0.0.1`
line whose aliases contain the short hostname — so it returns `localhost`,
not the actual hostname. Every cluster node reports its FQDN as `localhost`,
breaking software that keys on FQDN for node identity.

Affects all 7 supported distros (RedHat/CentOS/Rocky/Alma/Oracle ≥8, Ubuntu
≥22.04, Debian ≥11) — all glibc.

### Fix

`automation/roles/hostname/tasks/main.yml`:

```diff
-        - { regexp: '^127\.0\.0\.1[ \t]+localhost', line: "127.0.0.1 localhost {{ ansible_hostname }}" }
+        - { regexp: '^127\.0\.0\.1\b', line: "127.0.0.1 {{ ansible_hostname }} localhost" }
1. Swap alias order — hostname is now the first alias, so hostname -f
returns the short hostname. localhost still resolves as the second alias.
2. Broaden regexp — ^127\.0\.0\.1\b replaces ^127\.0\.0\.1[ \t]+localhost.
The new line no longer matches the old regexp (it starts with
127.0.0.1 <hostname>, not 127.0.0.1 localhost), so without broadening
lineinfile would append a duplicate line on every run. \b prevents
matching 127.0.0.11.
Idempotency
Both edits ship together because they are coupled: the alias swap requires the
regexp broaden to stay idempotent (the new line must still match on the 2nd
converge, or lineinfile appends a duplicate → molecule idempotence action
fails).
Verification
- ansible-lint on automation/roles/hostname/ — 0 failures, 0 warnings
- make molecule-test (idempotence action catches duplicate-line regression)