### PR TITLE
Console: Add SSH private key validation

### DIFF
--- a/console/service/internal/authinfo/validation.go
+++ b/console/service/internal/authinfo/validation.go
@@ -1,0 +1,47 @@
+package authinfo
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"postgresql-cluster-console/internal/storage"
+)
+
+var cloudSecretTypes = map[string]struct{}{
+	"aws":          {},
+	"gcp":          {},
+	"azure":        {},
+	"digitalocean": {},
+	"hetzner":      {},
+}
+
+// ValidateSecretReference ensures that a stored secret belongs to the cluster project
+// and is valid for the requested local or cloud deployment.
+func ValidateSecretReference(secret *storage.SecretView, projectID int64, cloudProvider string) error {
+	if secret == nil {
+		return errors.New("secret not found")
+	}
+	if secret.ProjectID != projectID {
+		return fmt.Errorf("secret %d does not belong to project %d", secret.ID, projectID)
+	}
+
+	cloudProvider = strings.ToLower(strings.TrimSpace(cloudProvider))
+	if cloudProvider == "" {
+		switch secret.Type {
+		case "ssh_key", "password":
+			return nil
+		default:
+			return fmt.Errorf("server secret %d has unsupported type %q", secret.ID, secret.Type)
+		}
+	}
+
+	if _, ok := cloudSecretTypes[cloudProvider]; !ok {
+		return fmt.Errorf("unsupported cloud provider %q", cloudProvider)
+	}
+	if secret.Type != cloudProvider {
+		return fmt.Errorf("cloud secret %d has type %q, expected %q", secret.ID, secret.Type, cloudProvider)
+	}
+
+	return nil
+}

--- a/console/service/internal/authinfo/validation_test.go
+++ b/console/service/internal/authinfo/validation_test.go
@@ -1,0 +1,55 @@
+package authinfo
+
+import (
+	"strings"
+	"testing"
+
+	"postgresql-cluster-console/internal/storage"
+)
+
+func TestValidateSecretReference(t *testing.T) {
+	tests := []struct {
+		name          string
+		secretType    string
+		projectID     int64
+		cloudProvider string
+		wantError     string
+	}{
+		{name: "ssh key for local deployment", secretType: "ssh_key", projectID: 1},
+		{name: "password for local deployment", secretType: "password", projectID: 1},
+		{name: "aws credentials for aws", secretType: "aws", projectID: 1, cloudProvider: "aws"},
+		{name: "cloud provider is normalized", secretType: "aws", projectID: 1, cloudProvider: " AWS "},
+		{name: "gcp credentials for gcp", secretType: "gcp", projectID: 1, cloudProvider: "gcp"},
+		{name: "azure credentials for azure", secretType: "azure", projectID: 1, cloudProvider: "azure"},
+		{name: "digitalocean credentials for digitalocean", secretType: "digitalocean", projectID: 1, cloudProvider: "digitalocean"},
+		{name: "hetzner credentials for hetzner", secretType: "hetzner", projectID: 1, cloudProvider: "hetzner"},
+		{name: "reject cloud credentials for local deployment", secretType: "aws", projectID: 1, wantError: "unsupported type"},
+		{name: "reject server credentials for cloud deployment", secretType: "ssh_key", projectID: 1, cloudProvider: "aws", wantError: "expected"},
+		{name: "reject credentials for another cloud provider", secretType: "aws", projectID: 1, cloudProvider: "gcp", wantError: "expected"},
+		{name: "reject unsupported cloud provider", secretType: "aws", projectID: 1, cloudProvider: "unknown", wantError: "unsupported cloud provider"},
+		{name: "reject secret from another project", secretType: "ssh_key", projectID: 2, wantError: "does not belong to project"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			secret := &storage.SecretView{ID: 7, ProjectID: 1, Type: tt.secretType}
+			err := ValidateSecretReference(secret, tt.projectID, tt.cloudProvider)
+			if tt.wantError == "" {
+				if err != nil {
+					t.Fatalf("ValidateSecretReference() error = %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tt.wantError) {
+				t.Fatalf("ValidateSecretReference() error = %v, want error containing %q", err, tt.wantError)
+			}
+		})
+	}
+}
+
+func TestValidateSecretReferenceRejectsMissingSecret(t *testing.T) {
+	err := ValidateSecretReference(nil, 1, "")
+	if err == nil || err.Error() != "secret not found" {
+		t.Fatalf("ValidateSecretReference() error = %v, want secret not found", err)
+	}
+}

--- a/console/service/internal/controllers/cluster/post_cluster.go
+++ b/console/service/internal/controllers/cluster/post_cluster.go
@@ -51,6 +51,24 @@ func (h *postClusterHandler) Handle(param cluster.PostClustersParams) middleware
 		return cluster.NewPostClustersBadRequest().WithPayload(controllers.MakeErrorPayload(fmt.Errorf("cluster %s already exists", param.Body.Name), controllers.BaseError))
 	}
 
+	const (
+		LocationExtraVar          = "server_location"
+		CloudProviderExtraVar     = "cloud_provider"
+		ServersExtraVar           = "server_count"
+		PostgreSqlVersionExtraVar = "postgresql_version"
+		InventoryJsonEnv          = "ANSIBLE_INVENTORY_JSON"
+	)
+
+	extraVars := map[string]interface{}{}
+
+	if param.Body.ExtraVars != nil {
+		if m, ok := param.Body.ExtraVars.(map[string]interface{}); ok {
+			extraVars = m
+		} else {
+			localLog.Warn().Msg("unexpected type for extra_vars, expected map[string]interface{}")
+		}
+	}
+
 	var (
 		secretEnvs    []string
 		secretID      *int64
@@ -58,14 +76,20 @@ func (h *postClusterHandler) Handle(param cluster.PostClustersParams) middleware
 		paramLocation ParamLocation
 	)
 	if param.Body.AuthInfo != nil {
-		secretEnvs, paramLocation, err = getSecretEnvs(param.HTTPRequest.Context(), h.log, h.db, param.Body.AuthInfo.SecretID, h.cfg.EncryptionKey)
+		secretEnvs, paramLocation, err = getSecretEnvs(
+			param.HTTPRequest.Context(),
+			h.db,
+			param.Body.AuthInfo.SecretID,
+			h.cfg.EncryptionKey,
+			param.Body.ProjectID,
+			getValFromExtraVars(extraVars, CloudProviderExtraVar),
+		)
 		if err != nil {
 			localLog.Error().Err(err).Msg("failed to get secret")
 
 			return cluster.NewPostClustersBadRequest().WithPayload(controllers.MakeErrorPayload(fmt.Errorf("failed to get secret: %s", err.Error()), controllers.BaseError))
 		}
 		secretID = &param.Body.AuthInfo.SecretID
-		localLog.Trace().Strs("secretEnvs", secretEnvs).Msg("got secret")
 	} else {
 		localLog.Debug().Msg("AuthInfo is nil, secret is expected in envs from web")
 	}
@@ -76,16 +100,6 @@ func (h *postClusterHandler) Handle(param cluster.PostClustersParams) middleware
 
 	ansibleLogEnv := h.getAnsibleLogEnv(param.Body.Name)
 	localLog.Trace().Strs("file_log", ansibleLogEnv).Msg("got file log name")
-
-	extraVars := map[string]interface{}{}
-
-	if param.Body.ExtraVars != nil {
-		if m, ok := param.Body.ExtraVars.(map[string]interface{}); ok {
-			extraVars = m
-		} else {
-			localLog.Warn().Interface("extra_vars_raw", param.Body.ExtraVars).Msg("unexpected type for extra_vars, expected map[string]interface{}")
-		}
-	}
 
 	if paramLocation == EnvParamLocation {
 		param.Body.Envs = append(param.Body.Envs, secretEnvs...)
@@ -100,14 +114,6 @@ func (h *postClusterHandler) Handle(param cluster.PostClustersParams) middleware
 	param.Body.Envs = append(param.Body.Envs, ansibleLogEnv...)
 
 	h.addProxySettings(extraVars, &param, localLog)
-
-	const (
-		LocationExtraVar          = "server_location"
-		CloudProviderExtraVar     = "cloud_provider"
-		ServersExtraVar           = "server_count"
-		PostgreSqlVersionExtraVar = "postgresql_version"
-		InventoryJsonEnv          = "ANSIBLE_INVENTORY_JSON"
-	)
 
 	var (
 		serverCount      int
@@ -124,13 +130,13 @@ func (h *postClusterHandler) Handle(param cluster.PostClustersParams) middleware
 			decodedInventory, decodeErr := base64.StdEncoding.DecodeString(rawInventory)
 			if decodeErr != nil {
 				// If base64 decoding fails, treat it as plain JSON
-				localLog.Warn().Str("inventory_json", rawInventory).Err(decodeErr).Msg("base64 decode failed, trying as plain JSON")
+				localLog.Warn().Err(decodeErr).Msg("base64 decode failed, trying inventory as plain JSON")
 				decodedInventory = []byte(rawInventory)
 			}
 
 			// Try to parse the decoded inventory as JSON
 			if err := json.Unmarshal(decodedInventory, &inventoryJson); err != nil {
-				localLog.Error().Str("inventory_json", string(decodedInventory)).Err(err).Msg("failed to parse inventory json")
+				localLog.Error().Err(err).Msg("failed to parse inventory JSON")
 				inventoryJsonVal = nil // to correct insert in db
 			} else {
 				// If successfully parsed, save it and calculate server count
@@ -139,7 +145,7 @@ func (h *postClusterHandler) Handle(param cluster.PostClustersParams) middleware
 			}
 		} else {
 			// No inventory found in envs; fallback to 0
-			localLog.Warn().Str("inventory_json", "").Msg("ANSIBLE_INVENTORY_JSON not found in Envs")
+			localLog.Warn().Msg("ANSIBLE_INVENTORY_JSON not found in Envs")
 			serverCount = 0
 		}
 	} else {

--- a/console/service/internal/controllers/cluster/utils.go
+++ b/console/service/internal/controllers/cluster/utils.go
@@ -3,11 +3,11 @@ package cluster
 import (
 	"context"
 	"encoding/json"
+	"fmt"
+
+	"postgresql-cluster-console/internal/authinfo"
 	"postgresql-cluster-console/internal/storage"
 	"postgresql-cluster-console/models"
-	"postgresql-cluster-console/pkg/tracer"
-
-	"github.com/rs/zerolog"
 )
 
 type ParamLocation uint8
@@ -18,18 +18,18 @@ const (
 	ExtraVarsParamLocation ParamLocation = 2
 )
 
-func getSecretEnvs(ctx context.Context, log zerolog.Logger, db storage.IStorage, secretID int64, secretKey string) ([]string, ParamLocation, error) {
-	localLog := log.With().Str("cid", ctx.Value(tracer.CtxCidKey{}).(string)).Logger()
+func getSecretEnvs(ctx context.Context, db storage.IStorage, secretID int64, secretKey string, projectID int64, cloudProvider string) ([]string, ParamLocation, error) {
 	secretView, err := db.GetSecret(ctx, secretID)
 	if err != nil {
 		return nil, UnknownParamLocation, err
 	}
-	localLog.Trace().Any("secret_view", secretView).Msg("got secret view from db")
+	if err := authinfo.ValidateSecretReference(secretView, projectID, cloudProvider); err != nil {
+		return nil, UnknownParamLocation, err
+	}
 	secretVal, err := db.GetSecretVal(ctx, secretID, secretKey)
 	if err != nil {
 		return nil, UnknownParamLocation, err
 	}
-	localLog.Trace().Msgf("secretVal %s", string(secretVal))
 
 	switch models.SecretType(secretView.Type) {
 	case models.SecretTypeAws:
@@ -94,6 +94,6 @@ func getSecretEnvs(ctx context.Context, log zerolog.Logger, db storage.IStorage,
 
 		return []string{"ansible_user=" + sec.USERNAME, "ansible_ssh_pass=" + sec.PASSWORD, "ansible_sudo_pass=" + sec.PASSWORD}, ExtraVarsParamLocation, nil
 	default:
-		return nil, UnknownParamLocation, nil
+		return nil, UnknownParamLocation, fmt.Errorf("secret %d has unsupported type %q", secretID, secretView.Type)
 	}
 }

--- a/console/ui/src/features/add-secret/model/validation.ts
+++ b/console/ui/src/features/add-secret/model/validation.ts
@@ -3,6 +3,7 @@ import { TFunction } from 'i18next';
 import { PROVIDERS } from '@shared/config/constants.ts';
 
 import { SECRET_MODAL_CONTENT_FORM_FIELD_NAMES } from '@entities/secret-form-block/model/constants.ts';
+import { isValidSshPrivateKey } from '@shared/lib/sshPrivateKeyValidation.ts';
 
 const requiredField = ({ valueToBeRequired, t }: { valueToBeRequired: string; t: TFunction }) =>
   yup
@@ -43,7 +44,20 @@ export const AddSecretFormSchema = (t: TFunction) =>
       valueToBeRequired: PROVIDERS.HETZNER,
       t,
     }),
-    [SECRET_MODAL_CONTENT_FORM_FIELD_NAMES.SSH_PRIVATE_KEY]: requiredField({ valueToBeRequired: 'ssh_key', t }),
+    [SECRET_MODAL_CONTENT_FORM_FIELD_NAMES.SSH_PRIVATE_KEY]: yup
+      .mixed()
+      .when(SECRET_MODAL_CONTENT_FORM_FIELD_NAMES.SECRET_TYPE, ([secretType]) =>
+        secretType === 'ssh_key'
+          ? yup
+              .string()
+              .required(t('requiredField', { ns: 'validation' }))
+              .test(
+                'is valid SSH private key',
+                t('invalidSshPrivateKey', { ns: 'validation' }),
+                (value) => !value || isValidSshPrivateKey(value),
+              )
+          : yup.mixed().optional(),
+      ),
     [SECRET_MODAL_CONTENT_FORM_FIELD_NAMES.USERNAME]: requiredField({ valueToBeRequired: 'password', t }),
     [SECRET_MODAL_CONTENT_FORM_FIELD_NAMES.PASSWORD]: requiredField({ valueToBeRequired: 'password', t }),
   });

--- a/console/ui/src/shared/i18n/locales/en/validation.json
+++ b/console/ui/src/shared/i18n/locales/en/validation.json
@@ -4,6 +4,7 @@
   "sshPortRange": "SSH port must be between 1 and 65535",
   "clusterShouldHaveProperNaming": "Cluster name should have only letters, numbers, hyphens and have length equal or less than 24",
   "shouldBeACorrectV4Ip": "The value should be a valid IPv4 address",
-  "invalidSshPublicKey": "Enter a valid SSH public key (one per line)",
+  "invalidSshPublicKey": "Enter a valid SSH public key",
+  "invalidSshPrivateKey": "Enter a valid SSH private key",
   "configFormat": "Value should have \"key:value\" or \"key=value\" format"
 }

--- a/console/ui/src/shared/lib/sshPrivateKeyFormValidation.test.ts
+++ b/console/ui/src/shared/lib/sshPrivateKeyFormValidation.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { AddSecretFormSchema } from '@features/add-secret/model/validation.ts';
+import { LocalFormSchema } from '@widgets/cluster-form/model/validation.ts';
+import { SECRET_MODAL_CONTENT_FORM_FIELD_NAMES } from '@entities/secret-form-block/model/constants.ts';
+import { CLUSTER_FORM_FIELD_NAMES } from '@widgets/cluster-form/model/constants.ts';
+import { PROVIDERS } from '@shared/config/constants.ts';
+import { AUTHENTICATION_METHODS } from '@shared/model/constants.ts';
+
+const t = ((key: string) => key) as never;
+const privateKeyField = SECRET_MODAL_CONTENT_FORM_FIELD_NAMES.SSH_PRIVATE_KEY;
+
+describe('SSH private key form validation', () => {
+  it('validates private keys when an SSH secret is created', async () => {
+    await expect(
+      AddSecretFormSchema(t).validateAt(privateKeyField, {
+        [SECRET_MODAL_CONTENT_FORM_FIELD_NAMES.SECRET_TYPE]: AUTHENTICATION_METHODS.SSH,
+        [privateKeyField]: 'not a private key',
+      }),
+    ).rejects.toThrow('invalidSshPrivateKey');
+  });
+
+  it('validates an inline private key when a local cluster is created', async () => {
+    await expect(
+      LocalFormSchema(t).validateAt(privateKeyField, {
+        [CLUSTER_FORM_FIELD_NAMES.PROVIDER]: { code: PROVIDERS.LOCAL },
+        [CLUSTER_FORM_FIELD_NAMES.AUTHENTICATION_METHOD]: AUTHENTICATION_METHODS.SSH,
+        [CLUSTER_FORM_FIELD_NAMES.IS_USE_DEFINED_SECRET]: false,
+        [privateKeyField]: 'not a private key',
+      }),
+    ).rejects.toThrow('invalidSshPrivateKey');
+  });
+});

--- a/console/ui/src/shared/lib/sshPrivateKeyValidation.test.ts
+++ b/console/ui/src/shared/lib/sshPrivateKeyValidation.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import { isValidSshPrivateKey } from './sshPrivateKeyValidation';
+
+const OPENSSH_ED25519_KEY = `-----BEGIN OPENSSH PRIVATE KEY-----
+b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtzc2gtZW
+QyNTUxOQAAACBTRRUtAmauQjO7I0OvniI2O9cmvZZoVjRqMJ2uh7MhFgAAAIjovJGI6LyR
+iAAAAAtzc2gtZWQyNTUxOQAAACBTRRUtAmauQjO7I0OvniI2O9cmvZZoVjRqMJ2uh7MhFg
+AAAEDCcL45+Xx6+8xCwB72fSl6cDhMWiq4+ddWh85WyHS9alNFFS0CZq5CM7sjQ6+eIjY7
+1ya9lmhWNGowna6HsyEWAAAAAAECAwQF
+-----END OPENSSH PRIVATE KEY-----`;
+
+const PKCS8_EC_KEY = `-----BEGIN PRIVATE KEY-----
+MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgUMb1V/1Ix+pFTN0g
+KQ+CA7LR8wtT4xlmBl/ySKS4GK2hRANCAAR/2V0JNDnlN4lvAsDiPexojB1MzTzZ
+TUgrrHRa/fNsiLzI2XgU6Mcv+Q+G6wtFk9KLBN6NRznduNGqgPvHGCLX
+-----END PRIVATE KEY-----`;
+
+const EC_KEY = `-----BEGIN EC PRIVATE KEY-----
+MHcCAQEEID3a8eX56IFqD3nJx6ls6t7WkK2tKty8DS2MzIfoN0oKoAoGCCqGSM49
+AwEHoUQDQgAEVyV198NISNSaIZcHRir5oIMrEIHg1LK/Box9QUMW3crfXNcvewUK
+L0MNZecKWKbWkMDCfOp1Vp8jnAIkORbjtw==
+-----END EC PRIVATE KEY-----`;
+
+describe('isValidSshPrivateKey', () => {
+  it('accepts valid OpenSSH and PEM private key formats', () => {
+    expect(isValidSshPrivateKey(OPENSSH_ED25519_KEY)).toBe(true);
+    expect(isValidSshPrivateKey(PKCS8_EC_KEY)).toBe(true);
+    expect(isValidSshPrivateKey(EC_KEY)).toBe(true);
+  });
+
+  it('accepts CRLF line endings and surrounding whitespace', () => {
+    expect(isValidSshPrivateKey(`\n${OPENSSH_ED25519_KEY.replace(/\n/g, '\r\n')}\n`)).toBe(true);
+  });
+
+  it('rejects arbitrary text, a public key, and malformed base64', () => {
+    expect(isValidSshPrivateKey('not a private key')).toBe(false);
+    expect(isValidSshPrivateKey('ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIMalformed')).toBe(false);
+    expect(
+      isValidSshPrivateKey(`-----BEGIN OPENSSH PRIVATE KEY-----
+not_base64!
+-----END OPENSSH PRIVATE KEY-----`),
+    ).toBe(false);
+  });
+
+  it('rejects mismatched PEM boundaries and truncated key data', () => {
+    expect(isValidSshPrivateKey(OPENSSH_ED25519_KEY.replace('END OPENSSH', 'END RSA'))).toBe(false);
+    expect(isValidSshPrivateKey(OPENSSH_ED25519_KEY.replace('1ya9lmhWNGowna6HsyEWAAAAAAECAwQF', 'AAAA'))).toBe(false);
+    expect(isValidSshPrivateKey(PKCS8_EC_KEY.replace('MIGHAgEA', 'MAECAQA='))).toBe(false);
+  });
+});

--- a/console/ui/src/shared/lib/sshPrivateKeyValidation.ts
+++ b/console/ui/src/shared/lib/sshPrivateKeyValidation.ts
@@ -1,0 +1,263 @@
+const PEM_LABELS = new Set([
+  'OPENSSH PRIVATE KEY',
+  'PRIVATE KEY',
+  'ENCRYPTED PRIVATE KEY',
+  'RSA PRIVATE KEY',
+  'EC PRIVATE KEY',
+  'DSA PRIVATE KEY',
+]);
+
+const OPENSSH_CIPHERS = new Set([
+  'none',
+  '3des-cbc',
+  'aes128-cbc',
+  'aes192-cbc',
+  'aes256-cbc',
+  'aes128-ctr',
+  'aes192-ctr',
+  'aes256-ctr',
+  'aes128-gcm@openssh.com',
+  'aes256-gcm@openssh.com',
+  'chacha20-poly1305@openssh.com',
+]);
+
+// PKCS#8 algorithms that OpenSSH can load from a generic PRIVATE KEY envelope.
+const SSH_PKCS8_ALGORITHM_OIDS = new Set([
+  '2a864886f70d010101', // rsaEncryption
+  '2a8648ce380401', // id-dsa
+  '2a8648ce3d0201', // id-ecPublicKey
+]);
+
+const textDecoder = new TextDecoder();
+
+type BinaryPart = { value: Uint8Array; nextOffset: number };
+type DerNode = { tag: number; valueOffset: number; endOffset: number; nextOffset: number };
+
+const decodeBase64 = (value: string): Uint8Array | null => {
+  if (!value || !/^[A-Za-z0-9+/]+={0,2}$/.test(value) || value.length % 4 === 1) {
+    return null;
+  }
+
+  try {
+    const decoded = atob(value.padEnd(Math.ceil(value.length / 4) * 4, '='));
+
+    return Uint8Array.from(decoded, (character) => character.charCodeAt(0));
+  } catch {
+    return null;
+  }
+};
+
+const readUint32 = (value: Uint8Array, offset: number): number | null => {
+  if (offset + 4 > value.length) {
+    return null;
+  }
+
+  return (value[offset] * 2 ** 24 + value[offset + 1] * 2 ** 16 + value[offset + 2] * 2 ** 8 + value[offset + 3]) >>> 0;
+};
+
+const readSshString = (value: Uint8Array, offset: number): BinaryPart | null => {
+  const length = readUint32(value, offset);
+
+  if (length === null || offset + 4 + length > value.length) {
+    return null;
+  }
+
+  return { value: value.slice(offset + 4, offset + 4 + length), nextOffset: offset + 4 + length };
+};
+
+const isValidOpenSshKey = (value: Uint8Array): boolean => {
+  const magic = new TextEncoder().encode('openssh-key-v1\0');
+
+  if (value.length < magic.length || !magic.every((byte, index) => value[index] === byte)) {
+    return false;
+  }
+
+  let offset = magic.length;
+  const cipher = readSshString(value, offset);
+  const kdf = cipher && readSshString(value, cipher.nextOffset);
+  const kdfOptions = kdf && readSshString(value, kdf.nextOffset);
+
+  if (!cipher || !kdf || !kdfOptions) {
+    return false;
+  }
+
+  const cipherName = textDecoder.decode(cipher.value);
+  const kdfName = textDecoder.decode(kdf.value);
+
+  if (
+    !OPENSSH_CIPHERS.has(cipherName) ||
+    (cipherName === 'none' && (kdfName !== 'none' || kdfOptions.value.length !== 0)) ||
+    (cipherName !== 'none' && (kdfName !== 'bcrypt' || kdfOptions.value.length === 0))
+  ) {
+    return false;
+  }
+
+  offset = kdfOptions.nextOffset;
+  const keyCount = readUint32(value, offset);
+
+  if (!keyCount || keyCount > 64) {
+    return false;
+  }
+
+  offset += 4;
+  for (let index = 0; index < keyCount; index += 1) {
+    const publicKey = readSshString(value, offset);
+
+    if (!publicKey?.value.length) {
+      return false;
+    }
+    offset = publicKey.nextOffset;
+  }
+
+  const privateSection = readSshString(value, offset);
+
+  if (!privateSection?.value.length || privateSection.nextOffset !== value.length) {
+    return false;
+  }
+
+  if (cipherName !== 'none') {
+    return true;
+  }
+
+  const firstCheck = readUint32(privateSection.value, 0);
+  const secondCheck = readUint32(privateSection.value, 4);
+
+  return firstCheck !== null && firstCheck === secondCheck;
+};
+
+const readDerNode = (value: Uint8Array, offset: number): DerNode | null => {
+  if (offset + 2 > value.length) {
+    return null;
+  }
+
+  const tag = value[offset];
+  const firstLengthByte = value[offset + 1];
+  let length = firstLengthByte;
+  let valueOffset = offset + 2;
+
+  if ((firstLengthByte & 0x80) !== 0) {
+    const lengthBytes = firstLengthByte & 0x7f;
+
+    if (lengthBytes === 0 || lengthBytes > 4 || valueOffset + lengthBytes > value.length) {
+      return null;
+    }
+
+    length = 0;
+    for (let index = 0; index < lengthBytes; index += 1) {
+      length = length * 256 + value[valueOffset + index];
+    }
+    valueOffset += lengthBytes;
+  }
+
+  const endOffset = valueOffset + length;
+
+  return endOffset <= value.length ? { tag, valueOffset, endOffset, nextOffset: endOffset } : null;
+};
+
+const readDerChildren = (value: Uint8Array, parent: DerNode): DerNode[] | null => {
+  const children: DerNode[] = [];
+  let offset = parent.valueOffset;
+
+  while (offset < parent.endOffset) {
+    const child = readDerNode(value, offset);
+
+    if (!child || child.nextOffset > parent.endOffset) {
+      return null;
+    }
+    children.push(child);
+    offset = child.nextOffset;
+  }
+
+  return offset === parent.endOffset ? children : null;
+};
+
+const isDerInteger = (value: Uint8Array, node: DerNode, allowedValues?: number[]): boolean =>
+  node.tag === 0x02 &&
+  node.endOffset > node.valueOffset &&
+  (!allowedValues ||
+    (node.endOffset === node.valueOffset + 1 && allowedValues.includes(value[node.valueOffset])));
+
+const derNodeHex = (value: Uint8Array, node: DerNode): string =>
+  Array.from(value.slice(node.valueOffset, node.endOffset), (byte) => byte.toString(16).padStart(2, '0')).join('');
+
+const isValidDerKey = (label: string, value: Uint8Array): boolean => {
+  const root = readDerNode(value, 0);
+
+  if (!root || root.tag !== 0x30 || root.nextOffset !== value.length) {
+    return false;
+  }
+
+  const children = readDerChildren(value, root);
+
+  if (!children) {
+    return false;
+  }
+
+  if (label === 'RSA PRIVATE KEY') {
+    return children.length >= 9 && isDerInteger(value, children[0], [0, 1]) && children.every((node) => isDerInteger(value, node));
+  }
+
+  if (label === 'DSA PRIVATE KEY') {
+    return children.length === 6 && isDerInteger(value, children[0], [0]) && children.every((node) => isDerInteger(value, node));
+  }
+
+  if (label === 'EC PRIVATE KEY') {
+    return (
+      children.length >= 2 &&
+      isDerInteger(value, children[0], [1]) &&
+      children[1].tag === 0x04 &&
+      children[1].endOffset > children[1].valueOffset &&
+      children.slice(2).every((node) => node.tag === 0xa0 || node.tag === 0xa1)
+    );
+  }
+
+  if (label === 'PRIVATE KEY') {
+    const algorithm = children[1] && readDerChildren(value, children[1]);
+    const algorithmOid = algorithm?.[0];
+
+    return (
+      children.length >= 3 &&
+      isDerInteger(value, children[0], [0, 1]) &&
+      children[1].tag === 0x30 &&
+      Boolean(algorithmOid && algorithmOid.tag === 0x06) &&
+      Boolean(algorithmOid && SSH_PKCS8_ALGORITHM_OIDS.has(derNodeHex(value, algorithmOid))) &&
+      children[2].tag === 0x04 &&
+      children[2].endOffset > children[2].valueOffset
+    );
+  }
+
+  if (label === 'ENCRYPTED PRIVATE KEY') {
+    const algorithm = children[0] && readDerChildren(value, children[0]);
+
+    return (
+      children.length === 2 &&
+      children[0].tag === 0x30 &&
+      Boolean(algorithm?.length && algorithm[0].tag === 0x06) &&
+      children[1].tag === 0x04 &&
+      children[1].endOffset > children[1].valueOffset
+    );
+  }
+
+  return false;
+};
+
+export const isValidSshPrivateKey = (value: string): boolean => {
+  const match = value
+    .trim()
+    .match(/^-----BEGIN ([A-Z0-9 ]+)-----\r?\n([A-Za-z0-9+/=\r\n]+?)\r?\n-----END \1-----$/);
+
+  if (!match || !PEM_LABELS.has(match[1])) {
+    return false;
+  }
+
+  const encodedKey = match[2].replace(/\r?\n/g, '');
+  const decodedKey = decodeBase64(encodedKey);
+
+  if (!decodedKey) {
+    return false;
+  }
+
+  return match[1] === 'OPENSSH PRIVATE KEY'
+    ? isValidOpenSshKey(decodedKey)
+    : isValidDerKey(match[1], decodedKey);
+};

--- a/console/ui/src/widgets/cluster-form/model/validation.ts
+++ b/console/ui/src/widgets/cluster-form/model/validation.ts
@@ -18,6 +18,7 @@ import { SSH_KEY_BLOCK_FIELD_NAMES } from '@entities/cluster/ssh-key-block/model
 import { LoadBalancerBlockSchema } from '@entities/cluster/load-balancers-block/model/validation.ts';
 import { DcsBlockSchema } from '@entities/cluster/expert-mode/dcs-block/model/validation.ts';
 import { isValidSshPublicKeyList } from '@shared/lib/sshPublicKeyValidation.ts';
+import { isValidSshPrivateKey } from '@shared/lib/sshPrivateKeyValidation.ts';
 
 const CloudFormSchema = (t: TFunction) =>
   yup.object({
@@ -104,7 +105,14 @@ export const LocalFormSchema = (t: TFunction) =>
                   .mixed()
                   .when(CLUSTER_FORM_FIELD_NAMES.IS_USE_DEFINED_SECRET, ([isUseDefinedSecret], schema) =>
                     !isUseDefinedSecret
-                      ? yup.string().required(t('requiredField', { ns: 'validation' }))
+                      ? yup
+                          .string()
+                          .required(t('requiredField', { ns: 'validation' }))
+                          .test(
+                            'is valid SSH private key',
+                            t('invalidSshPrivateKey', { ns: 'validation' }),
+                            (value) => !value || isValidSshPrivateKey(value),
+                          )
                       : schema.notRequired(),
                   )
               : schema.notRequired(),


### PR DESCRIPTION
Introduce `isValidSshPrivateKey` utility to validate OpenSSH and PEM/DER private key formats (including basic DER/PKCS#8 checks and OpenSSH structure). Integrate the validator into add-secret and local cluster form schemas so SSH private key fields are properly tested.

Added several fixes to the `auth_info` logic.

Closes: https://github.com/autobase-tech/autobase/issues/1654