### PR TITLE
Wait for AWS NLB creation and add retries

### DIFF
--- a/automation/roles/cloud_resources/tasks/aws.yml
+++ b/automation/roles/cloud_resources/tasks/aws.yml
@@ -589,7 +589,7 @@
                 TargetGroupName: "{{ patroni_cluster_name }}-tg-{{ item }}"
         cross_zone_load_balancing: true
         scheme: "{{ 'internet-facing' if database_public_access | bool else 'internal' }}"
-        wait: false
+        wait: true
         state: present
       loop:
         - "primary"
@@ -598,6 +598,9 @@
       loop_control:
         label: "{{ patroni_cluster_name }}-{{ item }}"
       register: aws_elb_network_lb
+      until: aws_elb_network_lb is success
+      retries: 3
+      delay: 10
       vars:
         target_port: "{{ pgbouncer_listen_port | default('6432') if pgbouncer_install | bool else postgresql_port | default('5432') }}"
       when: cloud_load_balancer | bool and aws_load_balancer_type | lower == 'nlb' and

--- a/automation/roles/cloud_resources/tasks/aws.yml
+++ b/automation/roles/cloud_resources/tasks/aws.yml
@@ -521,6 +521,9 @@
       loop_control:
         label: "{{ patroni_cluster_name }}-{{ item }}"
       register: aws_elb_classic_lb
+      until: aws_elb_classic_lb is success
+      retries: 3
+      delay: 10
       when: server_result.results | default([]) | length > 0 and
         cloud_load_balancer | bool and aws_load_balancer_type | lower == 'clb' and
         (item == 'primary' or
@@ -718,6 +721,7 @@
         secret_key: "{{ lookup('ansible.builtin.env', 'AWS_SECRET_ACCESS_KEY') }}"
         name: "{{ patroni_cluster_name }}-{{ item }}"
         region: "{{ server_location }}"
+        wait: true
         state: absent
       loop:
         - "primary"
@@ -725,6 +729,10 @@
         - "sync"
       loop_control:
         label: "{{ patroni_cluster_name }}-{{ item }}"
+      register: aws_elb_classic_lb_delete
+      until: aws_elb_classic_lb_delete is success
+      retries: 3
+      delay: 10
       when: aws_load_balancer_type | lower == 'clb' and
         (item == 'primary' or
         (item == 'replica' and server_count | int > 1) or
@@ -736,6 +744,7 @@
         secret_key: "{{ lookup('ansible.builtin.env', 'AWS_SECRET_ACCESS_KEY') }}"
         name: "{{ patroni_cluster_name }}-{{ item }}"
         region: "{{ server_location }}"
+        wait: true
         state: absent
       loop:
         - "primary"
@@ -743,6 +752,10 @@
         - "sync"
       loop_control:
         label: "{{ patroni_cluster_name }}-{{ item }}"
+      register: aws_elb_network_lb_delete
+      until: aws_elb_network_lb_delete is success
+      retries: 3
+      delay: 10
       when: aws_load_balancer_type | lower == 'nlb' and
         (item == 'primary' or
         (item == 'replica' and server_count | int > 1) or
@@ -761,6 +774,10 @@
         - "sync"
       loop_control:
         label: "{{ patroni_cluster_name }}-tg-{{ item }}"
+      register: aws_elb_target_group_delete
+      until: aws_elb_target_group_delete is success
+      retries: 3
+      delay: 10
       when: aws_load_balancer_type | lower == 'nlb' and
         (item == 'primary' or
         (item == 'replica' and server_count | int > 1) or


### PR DESCRIPTION
Set `wait: true` for AWS Network Load Balancer creation so Ansible waits for resource readiness. Add retry logic (until: `aws_elb_network_lb` is success, retries: 3, delay: 10) to handle transient failures during NLB creation.

To exclude a similar error:

```
TASK [vitabaks.autobase.cloud\_resources : AWS: Create Network Load Balancer (NLB)] \*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*
[ERROR]: Task failed: Module failed: Failed to describe load balancer attributes: An error occurred (LoadBalancerNotFound) when calling the DescribeLoadBalancerAttributes operation: Load balancer 'arn:aws:elasticloadbalancing:us-east-1:554482772640:loadbalancer/net/vitabaks-pgcluster-primary/b6af8df8e8e1cceb' not found
Origin: /root/.ansible/collections/ansible\_collections/vitabaks/autobase/roles/cloud\_resources/tasks/aws.yml:576:7
\
574         (item in ['sync', 'async'] and server\_count | int > 1 and synchronous\_mode | bool))
575
576     - name: "AWS: Create Network Load Balancer (NLB)"
          ^ column 7
\
failed: [localhost] (item=vitabaks-pgcluster-primary) => {"ansible\_loop\_var": "item", "changed": false, "item": "primary", "msg": "Task failed: Module failed: Failed to describe load balancer attributes: An error occurred (LoadBalancerNotFound) when calling the DescribeLoadBalancerAttributes operation: Load balancer 'arn:aws:elasticloadbalancing:us-east-1:554482772640:loadbalancer/net/vitabaks-pgcluster-primary/b6af8df8e8e1cceb' not found"}
\
```