### PR TITLE
fix: require console auth for the embedded SQL editor (/dbdesk)

### DIFF
--- a/console/docker-compose.caddy.yml
+++ b/console/docker-compose.caddy.yml
@@ -87,8 +87,6 @@ services:
   dbdesk-studio:
     image: docker.io/bhavikagarwal2001/dbdesk-studio:0.1.5
     container_name: dbdesk-studio
-    ports:
-      - 9876:9876  # nginx (frontend + /api/ proxy); Express listens internally on PORT
     healthcheck:
       test: ["CMD", "curl", "-fsS", "http://localhost:6789/health"]
       interval: 10s

--- a/console/docker-compose.enterprise.ssl.yml
+++ b/console/docker-compose.enterprise.ssl.yml
@@ -87,8 +87,6 @@ services:
   dbdesk-studio:
     image: docker.io/bhavikagarwal2001/dbdesk-studio:0.1.5
     container_name: dbdesk-studio
-    ports:
-      - 9876:9876  # nginx (frontend + /api/ proxy); Express listens internally on PORT
     healthcheck:
       test: ["CMD", "curl", "-fsS", "http://localhost:6789/health"]
       interval: 10s

--- a/console/docker-compose.enterprise.yml
+++ b/console/docker-compose.enterprise.yml
@@ -65,8 +65,6 @@ services:
   dbdesk-studio:
     image: docker.io/bhavikagarwal2001/dbdesk-studio:0.1.5
     container_name: dbdesk-studio
-    ports:
-      - 9876:9876  # nginx (frontend + /api/ proxy); Express listens internally on PORT
     healthcheck:
       test: ["CMD", "curl", "-fsS", "http://localhost:6789/health"]
       interval: 10s

--- a/console/docker-compose.yml
+++ b/console/docker-compose.yml
@@ -64,8 +64,6 @@ services:
   dbdesk-studio:
     image: docker.io/bhavikagarwal2001/dbdesk-studio:0.1.5
     container_name: dbdesk-studio
-    ports:
-      - 9876:9876  # nginx (frontend + /api/ proxy); Express listens internally on PORT
     healthcheck:
       test: ["CMD", "curl", "-fsS", "http://localhost:6789/health"]
       interval: 10s

--- a/console/ui/nginx/nginx.conf
+++ b/console/ui/nginx/nginx.conf
@@ -65,8 +65,29 @@ http {
       add_header Cache-Control "public, max-age=86400";
     }
 
+    # Auth gate for the embedded SQL editor. dbdesk-studio is a separate app
+    # served under /dbdesk/ and cannot send the console's Authorization header
+    # (page navigation + its own XHR), so the UI mirrors the console token into
+    # the `autobase_dbdesk` cookie (Path=/dbdesk/) and nginx validates it against
+    # the API with the same check /api/ enforces. Without this, /dbdesk/api/*
+    # (including stored cluster credentials) was reachable with no auth at all.
+    location = /_dbdesk_auth {
+      internal;
+      resolver 127.0.0.11 ipv6=off;
+
+      proxy_http_version 1.1;
+      proxy_pass_request_body off;
+      proxy_set_header Content-Length "";
+      proxy_set_header Connection     "";
+      proxy_set_header Authorization  "Bearer $cookie_autobase_dbdesk";
+
+      proxy_pass http://REPLACE_ME_WITH_API_HOST:REPLACE_ME_WITH_API_PORT/api/v1/version;
+    }
+
     # dbdesk-studio reverse proxy (same-origin access under /dbdesk/ path)
     location ^~ /dbdesk/ {
+      auth_request /_dbdesk_auth;
+
       resolver 127.0.0.11 ipv6=off;
 
       proxy_pass http://REPLACE_ME_WITH_DBDESK_HOST:REPLACE_ME_WITH_DBDESK_LISTEN_PORT/;

--- a/console/ui/src/app/router/PrivateRouterWrapper.tsx
+++ b/console/ui/src/app/router/PrivateRouterWrapper.tsx
@@ -4,6 +4,7 @@ import { FC, useEffect } from 'react';
 import { toast } from 'react-toastify';
 import { useTranslation } from 'react-i18next';
 import { AUTH_TOKEN } from '@shared/config/constants.ts';
+import { setDbdeskAuthCookie } from '@shared/lib/dbdeskAuthCookie.ts';
 
 const PrivateRouteWrapper: FC = () => {
   const { t } = useTranslation('toasts');
@@ -12,6 +13,8 @@ const PrivateRouteWrapper: FC = () => {
   useEffect(() => {
     const token = localStorage.getItem('token');
     if (token && token !== AUTH_TOKEN) toast.error(t('invalidToken'));
+    // Keep the SQL editor auth cookie in sync for sessions restored from localStorage.
+    if (token && token === AUTH_TOKEN) setDbdeskAuthCookie(token);
   }, [localStorage.getItem('token')]);
 
   return localStorage.getItem('token') === AUTH_TOKEN ? (

--- a/console/ui/src/features/logout-button/ui/index.tsx
+++ b/console/ui/src/features/logout-button/ui/index.tsx
@@ -4,6 +4,7 @@ import { IconButton, Tooltip } from '@mui/material';
 import { useNavigate } from 'react-router-dom';
 import RouterPaths from '@app/router/routerPathsConfig';
 import { generateAbsoluteRouterPath } from '@shared/lib/functions.ts';
+import { clearDbdeskAuthCookie } from '@shared/lib/dbdeskAuthCookie.ts';
 import { useTranslation } from 'react-i18next';
 
 const LogoutButton: FC = () => {
@@ -12,6 +13,7 @@ const LogoutButton: FC = () => {
 
   const handleLogout = () => {
     localStorage.removeItem('token');
+    clearDbdeskAuthCookie();
     navigate(generateAbsoluteRouterPath(RouterPaths.login.absolutePath));
   };
 

--- a/console/ui/src/pages/login/ui/index.tsx
+++ b/console/ui/src/pages/login/ui/index.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import RouterPaths from '@app/router/routerPathsConfig';
 import { generateAbsoluteRouterPath } from '@shared/lib/functions.ts';
+import { setDbdeskAuthCookie } from '@shared/lib/dbdeskAuthCookie.ts';
 import { Controller, useForm } from 'react-hook-form';
 import { LoginFormValues } from '@pages/login/model/types.ts';
 import { LOGIN_FORM_FIELD_NAMES } from '@pages/login/model/constants.ts';
@@ -18,6 +19,7 @@ const Login: FC = () => {
 
   const onSubmit = (values: LoginFormValues) => {
     localStorage.setItem('token', values[LOGIN_FORM_FIELD_NAMES.TOKEN]);
+    setDbdeskAuthCookie(values[LOGIN_FORM_FIELD_NAMES.TOKEN]);
     navigate(generateAbsoluteRouterPath(RouterPaths.clusters.absolutePath));
   };
 

--- a/console/ui/src/shared/lib/dbdeskAuthCookie.ts
+++ b/console/ui/src/shared/lib/dbdeskAuthCookie.ts
@@ -1,0 +1,30 @@
+import { DBDESK_URL } from '@shared/config/constants.ts';
+
+/**
+ * The embedded SQL editor (dbdesk-studio) is served under DBDESK_URL and cannot
+ * send the console's `Authorization` header (it is loaded by navigation and
+ * issues its own XHR). nginx guards that path with `auth_request` and reads the
+ * console token from this cookie instead (see console/ui/nginx/nginx.conf).
+ */
+const COOKIE_NAME = 'autobase_dbdesk';
+
+const getCookiePath = (): string => {
+  try {
+    return new URL(DBDESK_URL || '/dbdesk/', window.location.origin).pathname || '/dbdesk/';
+  } catch {
+    return '/dbdesk/';
+  }
+};
+
+const cookieAttributes = (): string => {
+  const secure = window.location.protocol === 'https:' ? '; Secure' : '';
+  return `Path=${getCookiePath()}; SameSite=Strict${secure}`;
+};
+
+export const setDbdeskAuthCookie = (token: string): void => {
+  document.cookie = `${COOKIE_NAME}=${token}; ${cookieAttributes()}`;
+};
+
+export const clearDbdeskAuthCookie = (): void => {
+  document.cookie = `${COOKIE_NAME}=; Max-Age=0; ${cookieAttributes()}`;
+};


### PR DESCRIPTION
## Summary

The embedded SQL editor (dbdesk-studio) is reverse-proxied by the console UI's nginx under `/dbdesk/` **without any authentication**, while `/api/` requires the console token. Because dbdesk-studio's own API is reachable through that proxy, an unauthenticated client can do everything the editor can — including reading the stored cluster credentials:

```
$ curl -s http://<console>/dbdesk/api/connections
[{"id":"…","name":"db1","type":"postgres","options":{"host":"…","port":5000,"database":"db1","user":"postgres","password":"<cleartext>","sslMode":"require"}, …}]
$ curl -s -X POST http://<console>/dbdesk/api/connections/<id>/query -H 'content-type: application/json' -d '{"query":"select 1"}'
{"rows":[…]}   # arbitrary SQL as the cluster superuser
```

The connection is created automatically by the console (`console/service/internal/watcher/dbdesk.go` → `POST /api/connections` with the `postgres` password), so every deployed cluster is exposed this way, on both the all-in-one `autobase/console` image and the compose setup.

## Fix

nginx now guards `/dbdesk/` with `auth_request`, delegating to the API's existing token check (`GET /api/v1/version` → 200/401), so there is a single source of truth for what a valid token is. Since the editor is loaded by navigation and issues its own XHR, it cannot carry the `Authorization` header; the UI therefore mirrors the console token into an `autobase_dbdesk` cookie scoped to the editor path (`Path=/dbdesk/; SameSite=Strict`, `Secure` on https), set on login and for sessions restored from `localStorage`, and cleared on logout.

- `console/ui/nginx/nginx.conf`: internal `location = /_dbdesk_auth` + `auth_request` in `location ^~ /dbdesk/` (uses the existing `REPLACE_ME_WITH_API_HOST/PORT` placeholders, so `env.sh` needs no change).
- `console/ui/src/shared/lib/dbdeskAuthCookie.ts`: `setDbdeskAuthCookie` / `clearDbdeskAuthCookie` (path derived from `VITE_DBDESK_URL`).
- `pages/login`, `features/logout-button`, `app/router/PrivateRouterWrapper`: set / clear / refresh the cookie.

No new configuration, no API changes. `auth_request` is part of the stock nginx build used by the images.

## Verification

Applied the nginx change to a running `autobase/console:2.10.0` container (all-in-one) and checked:

| request | before | after |
|---|---|---|
| `GET /dbdesk/api/connections` (no cookie) | 200 + credentials | **401** |
| `GET /dbdesk/api/connections` (wrong cookie) | 200 | **401** |
| `GET /dbdesk/api/connections` (cookie = console token) | 200 | 200 |
| `GET /dbdesk/` (editor HTML, no cookie) | 200 | **401** |
| `POST /dbdesk/api/connections/:id/query` (cookie) | 200 | 200 |
| `GET /api/v1/version` (no bearer / bearer) | 401 / 200 | 401 / 200 (unchanged) |
| `GET /` (console SPA) | 200 | 200 |

UI: `eslint` clean (only two pre-existing `react-hooks/exhaustive-deps` warnings on the untouched `useEffect` line), prettier clean on the changed lines; `tsc --noEmit` run separately (slow on my machine).

## Notes

- Every request under `/dbdesk/` (including static assets) now costs one subrequest to the API; if that matters, a small `proxy_cache` on `/_dbdesk_auth` keyed by the cookie would remove it.
- Tokens containing `;`, `,`, whitespace or `"` cannot be stored in a cookie verbatim; the console token is normally a plain string, but it's worth documenting.
- Related, but out of scope for this PR: dbdesk-studio's `GET /api/connections` returns stored passwords in cleartext (that's why the unauthenticated proxy was so damaging), and `VITE_AUTH_TOKEN` is substituted into the shipped JS bundle by `env.sh`, which makes the console token recoverable from the login page's assets. I'm reporting the latter separately.
