### PR TITLE
Console: Improve SQL editor loading with gzip compression

### DIFF
--- a/console/ui/nginx/nginx.conf
+++ b/console/ui/nginx/nginx.conf
@@ -10,6 +10,24 @@ http {
   default_type  application/octet-stream;
   sendfile      on;
 
+  # DBDesk responses must be uncompressed upstream so sub_filter can rewrite
+  # them. Compress the rewritten response before sending it to the browser.
+  gzip on;
+  gzip_vary on;
+  gzip_min_length 1024;
+  gzip_comp_level 5;
+  gzip_types text/plain text/css application/json application/javascript text/javascript application/xml image/svg+xml;
+
+  # Reuse successful DBDesk authorization checks across the burst of static
+  # asset requests made while the editor is starting.
+  proxy_cache_path /var/cache/nginx/dbdesk-auth levels=1:2 keys_zone=dbdesk_auth:1m max_size=10m inactive=10m use_temp_path=off;
+
+  map $uri $dbdesk_expires {
+    default                    epoch;
+    ~^/dbdesk/assets/          1d;
+    ~^/dbdesk/favicon\.ico$    1d;
+  }
+
   server {
     listen 80;
     access_log /var/log/nginx/access.log;
@@ -81,6 +99,12 @@ http {
       proxy_set_header Connection     "";
       proxy_set_header Authorization  "Bearer $cookie_autobase_dbdesk";
 
+      proxy_cache dbdesk_auth;
+      proxy_cache_key $cookie_autobase_dbdesk;
+      proxy_cache_valid 200 10m;
+      proxy_cache_valid 401 1s;
+      proxy_cache_lock on;
+
       proxy_pass http://REPLACE_ME_WITH_API_HOST:REPLACE_ME_WITH_API_PORT/api/v1/version;
     }
 
@@ -98,6 +122,11 @@ http {
       proxy_set_header X-Forwarded-Proto $scheme;
       proxy_set_header Upgrade           $http_upgrade;
       proxy_set_header Connection        "upgrade";
+      proxy_set_header Cookie            "";
+
+      # DBDesk ships hashed assets but does not provide useful browser caching.
+      # Keep API and HTML responses uncached while caching static assets.
+      expires $dbdesk_expires;
 
       # Prevent upstream from compressing so sub_filter can inspect the body
       proxy_set_header Accept-Encoding "";

--- a/console/ui/src/pages/sql-editor/index.tsx
+++ b/console/ui/src/pages/sql-editor/index.tsx
@@ -1,5 +1,5 @@
-import { FC, useEffect, useMemo, useRef } from 'react';
-import { Box, Typography } from '@mui/material';
+import { FC, useEffect, useMemo, useRef, useState } from 'react';
+import { Box, CircularProgress, Typography } from '@mui/material';
 import { useTranslation } from 'react-i18next';
 import { DBDESK_URL } from '@shared/config/constants.ts';
 import { useAppSelector } from '@app/redux/store/hooks.ts';
@@ -19,6 +19,7 @@ const SqlEditor: FC = () => {
   const { t } = useTranslation('shared');
   const actualTheme = useAppSelector(selectActualTheme);
   const iframeRef = useRef<HTMLIFrameElement>(null);
+  const [isLoading, setIsLoading] = useState(true);
 
   const dbdeskOrigin = useMemo(getDbdeskOrigin, []);
 
@@ -54,7 +55,22 @@ const SqlEditor: FC = () => {
         display: 'flex',
         flexDirection: 'column',
         overflow: 'hidden',
+        position: 'relative',
       }}>
+      {isLoading && (
+        <Box
+          sx={{
+            position: 'absolute',
+            inset: 0,
+            zIndex: 1,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            backgroundColor: 'background.paper',
+          }}>
+          <CircularProgress size={48} />
+        </Box>
+      )}
       <iframe
         ref={iframeRef}
         src={DBDESK_URL}
@@ -65,9 +81,11 @@ const SqlEditor: FC = () => {
           height: '100%',
           border: 'none',
           flexGrow: 1,
+          opacity: isLoading ? 0 : 1,
         }}
         allow="clipboard-read; clipboard-write"
         onLoad={() => {
+          setIsLoading(false);
           iframeRef.current?.contentWindow?.postMessage(
             { type: 'dbdesk-set-theme', theme: actualTheme },
             dbdeskOrigin,


### PR DESCRIPTION
Enable gzip compression for DBDesk static assets served through nginx.

This significantly reduces the SQL editor JavaScript transfer size and improves initial page load time, especially on slower connections. Static assets are also cached by the browser to speed up subsequent loads.