### PR TITLE
pgbackrest: add pgbackrest_repo_external for restoring from an unmanaged external repo

### DIFF
--- a/automation/roles/common/defaults/main.yml
+++ b/automation/roles/common/defaults/main.yml
@@ -805,6 +805,7 @@ pgbackrest_stanza: "{{ patroni_cluster_name }}" # specify your --stanza
 pgbackrest_repo_type: "posix" # or "s3", "gcs", "azure"
 pgbackrest_repo_host: "" # dedicated repository host (optional)
 pgbackrest_repo_user: "postgres" # if "repo_host" is set (optional)
+pgbackrest_repo_external: false # 'true' if 'repo_host' is an existing repo this collection should not manage (skip the '[pgbackrest]' group requirement and server-side config/stanza-create/cron)
 pgbackrest_conf_file: "/etc/pgbackrest/pgbackrest.conf"
 # config https://pgbackrest.org/configuration.html
 pgbackrest_conf:

--- a/automation/roles/pre_checks/tasks/main.yml
+++ b/automation/roles/pre_checks/tasks/main.yml
@@ -37,8 +37,8 @@
 - name: Perform pre-checks for pgbackrest
   ansible.builtin.import_tasks: pgbackrest.yml
   when:
-    - pgbackrest_install is defined
-    - pgbackrest_install | bool
+    - (pgbackrest_install is defined and pgbackrest_install | bool) or
+      (pgbackrest_repo_external | default(false) | bool)
     - inventory_hostname in groups['postgres_cluster']
 
 - name: Perform pre-checks for WAL-G

--- a/automation/roles/pre_checks/tasks/pgbackrest.yml
+++ b/automation/roles/pre_checks/tasks/pgbackrest.yml
@@ -21,10 +21,12 @@
     msg:
       - "The 'pgbackrest_repo_host' variable is set but the 'pgbackrest' group in your inventory is empty."
       - "Please add the necessary host to the 'pgbackrest' group in your inventory."
+      - "If 'pgbackrest_repo_host' is an existing repository that should not be managed by this collection, set 'pgbackrest_repo_external: true' instead."
   when:
     - inventory_hostname == groups['master'][0] # display only once
     - pgbackrest_repo_host | length > 0
     - groups['pgbackrest'] is undefined or groups['pgbackrest'] | length == 0
+    - not (pgbackrest_repo_external | default(false) | bool)
 
 - name: "pgBackRest | Ensure 'repo1-host' and 'repo1-host-user' are set correctly"
   ansible.builtin.set_fact:


### PR DESCRIPTION
## Summary
Adds pgbackrest_repo_external (default false) so pgbackrest_repo_host can point at an existing/external repository (e.g. a read-only repo) used purely as a restore source, without this collection managing it.

Setting pgbackrest_repo_host requires the host to be in the [pgbackrest] inventory group, which makes this collection manage that host (regenerate its pgbackrest.conf, run stanza-create, install cron). Setting pgbackrest_repo_external: true skips that requirement and skips managing the repo, while client nodes still get repo1-host/repo1-host-user injected into their local pgbackrest_conf.
