### PR TITLE
pgbackrest: add pgbackrest_repo_external to skip the [pgbackrest] group requirement

### DIFF
--- a/automation/roles/common/defaults/main.yml
+++ b/automation/roles/common/defaults/main.yml
@@ -805,6 +805,7 @@ pgbackrest_stanza: "{{ patroni_cluster_name }}" # specify your --stanza
 pgbackrest_repo_type: "posix" # or "s3", "gcs", "azure"
 pgbackrest_repo_host: "" # dedicated repository host (optional)
 pgbackrest_repo_user: "postgres" # if "repo_host" is set (optional)
+pgbackrest_repo_external: false # 'true' if 'repo_host' is an existing repo this collection should not manage (skip the '[pgbackrest]' group requirement)
 pgbackrest_conf_file: "/etc/pgbackrest/pgbackrest.conf"
 # config https://pgbackrest.org/configuration.html
 pgbackrest_conf:

--- a/automation/roles/pre_checks/tasks/pgbackrest.yml
+++ b/automation/roles/pre_checks/tasks/pgbackrest.yml
@@ -21,10 +21,12 @@
     msg:
       - "The 'pgbackrest_repo_host' variable is set but the 'pgbackrest' group in your inventory is empty."
       - "Please add the necessary host to the 'pgbackrest' group in your inventory."
+      - "If 'pgbackrest_repo_host' is an existing repository that should not be managed by this collection, set 'pgbackrest_repo_external: true' instead."
   when:
     - inventory_hostname == groups['master'][0] # display only once
     - pgbackrest_repo_host | length > 0
     - groups['pgbackrest'] is undefined or groups['pgbackrest'] | length == 0
+    - not (pgbackrest_repo_external | default(false) | bool)
 
 - name: "pgBackRest | Ensure 'repo1-host' and 'repo1-host-user' are set correctly"
   ansible.builtin.set_fact:


### PR DESCRIPTION
## Summary
Setting `pgbackrest_repo_host` currently requires the host to be listed in the `[pgbackrest]` inventory group, or the deploy fails on the `pgBackRest | Ensure pgbackrest host is in inventory` pre-check. That group makes this collection manage the host (regenerate its `pgbackrest.conf`, run `stanza-create`, install cron) — which isn't appropriate when `pgbackrest_repo_host` is an existing/external repository (e.g. a read-only production repo) used only as a restore source.

Adds `pgbackrest_repo_external` (default `false`). When `true`, the group-inventory pre-check is skipped.

## Test plan
- [x] Verified with `ansible-playbook ... --check` against a real inventory: the pre-check fires as before with `pgbackrest_repo_external` unset/`false`, and skips when set to `true`.