### PR TITLE
Fix TLS certificate regeneration during cluster scaling

### DIFF
--- a/automation/playbooks/add_node.yml
+++ b/automation/playbooks/add_node.yml
@@ -300,6 +300,7 @@
   any_errors_fatal: true
   vars:
     cluster_scaling: true
+    tls_source_host: "{{ groups['postgres_cluster'] | difference(new_postgres_nodes | default([])) | first }}"
   tasks:
     - name: Generate Postgres TLS certificate
       ansible.builtin.include_role:

--- a/automation/roles/confd/tasks/main.yml
+++ b/automation/roles/confd/tasks/main.yml
@@ -79,7 +79,7 @@
   tags: confd_conf, confd
 
 - block: # for add_balancer.yml
-    - name: "Fetch confd.toml, haproxy.toml, haproxy.tmpl conf files from {{ groups.balancers[0] }}"
+    - name: "Fetch confd.toml, haproxy.toml, haproxy.tmpl conf files from {{ balancer_source_host }}"
       run_once: true
       ansible.builtin.fetch:
         src: "{{ item }}"
@@ -90,7 +90,7 @@
         - /etc/confd/confd.toml
         - /etc/confd/conf.d/haproxy.toml
         - /etc/confd/templates/haproxy.tmpl
-      delegate_to: "{{ groups.balancers[0] }}"
+      delegate_to: "{{ balancer_source_host }}"
 
     - name: Copy confd.toml, haproxy.toml, haproxy.tmpl conf files to replica
       ansible.builtin.copy:
@@ -161,6 +161,13 @@
         label: "{{ line_item_2.line }}"
       notify: "restart confd"
       when: cluster_vip is not defined or cluster_vip | length < 1
+  vars:
+    balancer_source_host: >-
+      {{
+        groups['balancers']
+        | difference(groups['new_balancer'] | default([]))
+        | first
+      }}
   when: add_balancer is defined and add_balancer|bool
   tags: confd_conf, confd
 

--- a/automation/roles/consul/tasks/tls.yml
+++ b/automation/roles/consul/tasks/tls.yml
@@ -22,6 +22,13 @@
         fetch_tls_dir: "{{ consul_tls_dir | default('/etc/consul/tls') }}"
         copy_tls_dir: "{{ consul_tls_dir | default('/etc/consul/tls') }}"
         copy_tls_owner: "{{ consul_user }}"
+  vars:
+    tls_source_host: >-
+      {{
+        (groups['consul_instances'] | difference(new_consul_nodes | default([])) | first)
+        if cluster_scaling | default(false) | bool
+        else (groups['consul_instances'] | first)
+      }}
   when: tls_cert_generate | default(false) | bool
 
 # Copy the existing TLS certificates from the role's files directory if 'tls_cert_generate' is 'false'.

--- a/automation/roles/etcd/tasks/main.yml
+++ b/automation/roles/etcd/tasks/main.yml
@@ -98,6 +98,13 @@
         fetch_tls_dir: "{{ etcd_tls_dir | default('/etc/etcd/tls') }}"
         copy_tls_dir: "{{ etcd_tls_dir | default('/etc/etcd/tls') }}"
         copy_tls_owner: "etcd"
+  vars:
+    tls_source_host: >-
+      {{
+        (groups['etcd_cluster'] | difference(new_etcd_nodes | default([])) | first)
+        if cluster_scaling | default(false) | bool
+        else (groups['etcd_cluster'] | first)
+      }}
   when: tls_cert_generate | default(true) | bool
   tags: etcd, etcd_conf
 

--- a/automation/roles/haproxy/tasks/main.yml
+++ b/automation/roles/haproxy/tasks/main.yml
@@ -104,7 +104,7 @@
   tags: haproxy, haproxy_service, load_balancing
 
 - block: # for add_balancer.yml
-    - name: "Fetch haproxy.cfg file from {{ groups.balancers[0] }}"
+    - name: "Fetch haproxy.cfg file from {{ balancer_source_host }}"
       run_once: true
       ansible.builtin.fetch:
         src: /etc/haproxy/haproxy.cfg
@@ -112,7 +112,7 @@
         validate_checksum: true
         flat: true
       notify: "restart haproxy"
-      delegate_to: "{{ groups.balancers[0] }}"
+      delegate_to: "{{ balancer_source_host }}"
 
     - name: Copy haproxy.cfg file to replica
       ansible.builtin.copy:
@@ -175,6 +175,13 @@
         label: "{{ bind_config_with_vip_item.line }}"
       notify: "restart haproxy"
       when: cluster_vip is defined and cluster_vip | length > 0
+  vars:
+    balancer_source_host: >-
+      {{
+        groups['balancers']
+        | difference(groups['new_balancer'] | default([]))
+        | first
+      }}
   when: add_balancer is defined and add_balancer|bool
   tags: haproxy, haproxy_conf, load_balancing
 

--- a/automation/roles/keepalived/tasks/main.yml
+++ b/automation/roles/keepalived/tasks/main.yml
@@ -61,14 +61,14 @@
   tags: keepalived_conf, keepalived
 
 - block: # for add_balancer.yml
-    - name: "Fetch keepalived.conf conf file from {{ groups.balancers[0] }}"
+    - name: "Fetch keepalived.conf conf file from {{ balancer_source_host }}"
       run_once: true
       ansible.builtin.fetch:
         src: /etc/keepalived/keepalived.conf
         dest: "{{ files_dir | default(playbook_dir ~ '/files') }}/keepalived.conf"
         validate_checksum: true
         flat: true
-      delegate_to: "{{ groups.balancers[0] }}"
+      delegate_to: "{{ balancer_source_host }}"
 
     - name: Copy keepalived.conf conf file to replica
       ansible.builtin.copy:
@@ -95,6 +95,13 @@
       loop_control:
         label: "{{ item.line }}"
       notify: "restart keepalived"
+  vars:
+    balancer_source_host: >-
+      {{
+        groups['balancers']
+        | difference(groups['new_balancer'] | default([]))
+        | first
+      }}
   when: add_balancer is defined and add_balancer|bool
   tags: keepalived_conf, keepalived
 

--- a/automation/roles/tls_certificate/README.md
+++ b/automation/roles/tls_certificate/README.md
@@ -58,6 +58,7 @@ Notes:
 - SAN auto-detection uses one of: etcd_bind_address, consul_bind_address, patroni_bind_address, or bind_address, depending on tls_group_name.
 - Generation and distribution use tls_source_host when provided; otherwise they use groups[tls_group_name][0] (default group “master” in copy.yml if tls_group_name is unset).
 - Existing CA certificates are preserved when only the server certificate is regenerated. Only tls_ca_regenerate may replace a CA.
+- Cluster scaling requires both the existing CA certificate and its private key; the role stops instead of generating a replacement CA when either file is missing.
 - When present on the source node, the CA private key is distributed to all target nodes by default, allowing any remaining node to become the certificate source after a host failure. Existing installations without the key continue copying the other TLS files.
 
 ## Dependencies

--- a/automation/roles/tls_certificate/README.md
+++ b/automation/roles/tls_certificate/README.md
@@ -8,7 +8,7 @@ Generates and manages TLS certificates for the cluster. Creates a self-signed CA
   - SANs are auto-built from hostnames/FQDNs/IPs of hosts in tls_group_name unless tls_subject_alt_name variable is provided.
   - Skips if files exist; override with tls_cert_regenerate/tls_ca_regenerate.
 - Distribution (tasks/copy.yml):
-  - Reads files from the first host in tls_group_name (or master by default) and copies to all nodes with desired owner.
+  - Reads files from tls_source_host (or the first host in tls_group_name by default) and copies to all nodes with desired owner.
 
 ## Main Role Variables
 
@@ -28,6 +28,7 @@ Generates and manages TLS certificates for the cluster. Creates a self-signed CA
 | Variable | Default | Description |
 |---|---|---|
 | tls_group_name | postgres_cluster | Inventory group to derive SANs from and to pick the “first” host. |
+| tls_source_host | first host in tls_group_name | Host that owns the CA private key and generates/distributes certificates. |
 | tls_subject_alt_name | "" | Comma-separated SANs; if empty, auto-generated from ansible_hostname, ansible_fqdn, and bind addresses. |
 | tls_owner | postgres | Default owner used when copying certs/keys to nodes. |
 | generate_tls_dir | unset -> tls_dir | Override generation directory. |
@@ -54,7 +55,8 @@ Generates and manages TLS certificates for the cluster. Creates a self-signed CA
 
 Notes:
 - SAN auto-detection uses one of: etcd_bind_address, consul_bind_address, patroni_bind_address, or bind_address, depending on tls_group_name.
-- Generation runs on groups[tls_group_name][0]; copy slurps from that host (default group “master” in copy.yml if tls_group_name is unset).
+- Generation and distribution use tls_source_host when provided; otherwise they use groups[tls_group_name][0] (default group “master” in copy.yml if tls_group_name is unset).
+- Existing CA certificates are preserved when only the server certificate is regenerated. Only tls_ca_regenerate may replace a CA.
 
 ## Dependencies
 

--- a/automation/roles/tls_certificate/README.md
+++ b/automation/roles/tls_certificate/README.md
@@ -1,6 +1,6 @@
 # Ansible Role: tls_certificate
 
-Generates and manages TLS certificates for the cluster. Creates a self-signed CA and server certificate/key (with SANs), and optionally distributes them to all nodes.
+Generates and manages TLS certificates for the cluster. Creates a self-signed CA and server certificate/key (with SANs), and distributes them to all nodes.
 
 ### How it works
 - Generation (tasks/main.yml):
@@ -8,7 +8,8 @@ Generates and manages TLS certificates for the cluster. Creates a self-signed CA
   - SANs are auto-built from hostnames/FQDNs/IPs of hosts in tls_group_name unless tls_subject_alt_name variable is provided.
   - Skips if files exist; override with tls_cert_regenerate/tls_ca_regenerate.
 - Distribution (tasks/copy.yml):
-  - Reads files from tls_source_host (or the first host in tls_group_name by default) and copies to all nodes with desired owner.
+  - Reads files from tls_source_host (or the first host in tls_group_name by default) and copies them to all nodes.
+  - When available, the CA private key is copied as root:root with mode 0400; other files use the configured TLS owner.
 
 ## Main Role Variables
 
@@ -57,6 +58,7 @@ Notes:
 - SAN auto-detection uses one of: etcd_bind_address, consul_bind_address, patroni_bind_address, or bind_address, depending on tls_group_name.
 - Generation and distribution use tls_source_host when provided; otherwise they use groups[tls_group_name][0] (default group “master” in copy.yml if tls_group_name is unset).
 - Existing CA certificates are preserved when only the server certificate is regenerated. Only tls_ca_regenerate may replace a CA.
+- When present on the source node, the CA private key is distributed to all target nodes by default, allowing any remaining node to become the certificate source after a host failure. Existing installations without the key continue copying the other TLS files.
 
 ## Dependencies
 

--- a/automation/roles/tls_certificate/tasks/copy.yml
+++ b/automation/roles/tls_certificate/tasks/copy.yml
@@ -7,7 +7,7 @@
     - "{{ fetch_tls_privatekey | default(tls_privatekey | default('server.key')) }}"
     - "{{ fetch_tls_cert | default(tls_cert | default('server.crt')) }}"
     - "{{ fetch_tls_ca_cert | default(tls_ca_cert | default('ca.crt')) }}"
-  delegate_to: "{{ groups[tls_group_name | default('master')][0] }}"
+  delegate_to: "{{ tls_source_host | default(groups[tls_group_name | default('master')][0]) }}"
   run_once: true
   tags: tls, tls_cert_copy
 

--- a/automation/roles/tls_certificate/tasks/copy.yml
+++ b/automation/roles/tls_certificate/tasks/copy.yml
@@ -1,5 +1,13 @@
 ---
-- name: "Fetch TLS certificate, key and CA from master node"
+- name: Check if TLS CA private key exists on source node
+  ansible.builtin.stat:
+    path: "{{ fetch_tls_dir | default(tls_dir | default('/etc/tls')) }}/{{ tls_ca_key | default('ca.key') }}"
+  register: tls_ca_key_stat
+  delegate_to: "{{ tls_source_host | default(groups[tls_group_name | default('master')][0]) }}"
+  run_once: true
+  tags: tls, tls_cert_copy
+
+- name: Fetch TLS certificate, key and CA from TLS source node
   ansible.builtin.slurp:
     src: "{{ fetch_tls_dir | default(tls_dir | default('/etc/tls')) }}/{{ item }}"
   register: tls_files_raw
@@ -7,8 +15,10 @@
     - "{{ fetch_tls_privatekey | default(tls_privatekey | default('server.key')) }}"
     - "{{ fetch_tls_cert | default(tls_cert | default('server.crt')) }}"
     - "{{ fetch_tls_ca_cert | default(tls_ca_cert | default('ca.crt')) }}"
+    - "{{ (tls_ca_key | default('ca.key')) if tls_ca_key_stat.stat.exists else '' }}"
   delegate_to: "{{ tls_source_host | default(groups[tls_group_name | default('master')][0]) }}"
   run_once: true
+  when: item | length > 0
   tags: tls, tls_cert_copy
 
 - name: "Set variable: tls_files"
@@ -17,6 +27,7 @@
       server_key: "{{ tls_files_raw.results[0].content }}"
       server_crt: "{{ tls_files_raw.results[1].content }}"
       ca_crt: "{{ tls_files_raw.results[2].content }}"
+      ca_key: "{{ tls_files_raw.results[3].content | default('') }}"
   run_once: true
   tags: tls, tls_cert_copy
 
@@ -33,14 +44,16 @@
   ansible.builtin.copy:
     content: "{{ (tls_files[item.key] | b64decode) }}"
     dest: "{{ copy_tls_dir | default(tls_dir | default('/etc/tls')) }}/{{ item.filename }}"
-    owner: "{{ copy_tls_owner | default(tls_owner | default('postgres')) }}"
-    group: "{{ copy_tls_owner | default(tls_owner | default('postgres')) }}"
+    owner: "{{ item.owner | default(copy_tls_owner | default(tls_owner | default('postgres'))) }}"
+    group: "{{ item.group | default(copy_tls_owner | default(tls_owner | default('postgres'))) }}"
     mode: "{{ item.mode }}"
   notify: "{{ copy_tls_notify | default([]) }}"
   loop:
     - { key: "server_crt", filename: "{{ copy_tls_cert | default(tls_cert | default('server.crt')) }}", mode: "0644" }
     - { key: "ca_crt", filename: "{{ copy_tls_ca_cert | default(tls_ca_cert | default('ca.crt')) }}", mode: "0644" }
     - { key: "server_key", filename: "{{ copy_tls_privatekey | default(tls_privatekey | default('server.key')) }}", mode: "0400" }
+    - { key: "ca_key", filename: "{{ tls_ca_key | default('ca.key') }}", owner: "root", group: "root", mode: "0400" }
   loop_control:
     label: "{{ copy_tls_dir | default(tls_dir | default('/etc/tls')) }}/{{ item.filename }}"
+  when: item.key != 'ca_key' or tls_files.ca_key | length > 0
   tags: tls, tls_cert_copy

--- a/automation/roles/tls_certificate/tasks/main.yml
+++ b/automation/roles/tls_certificate/tasks/main.yml
@@ -25,7 +25,8 @@
         mode: "0755"
 
     - block:
-        # Check if certificates already exist
+        # Check if certificates already exist. This must also run when only the
+        # server certificate is regenerated, so the existing CA is preserved.
         - name: Check if TLS CA cert already exists
           ansible.builtin.stat:
             path: "{{ tls_directory }}/{{ generate_tls_ca_cert | default(tls_ca_cert | default('ca.crt')) }}"
@@ -54,11 +55,10 @@
                  else 'consul_tls_cert_regenerate' if tls_group_name | default('') == 'consul_instances'
                  else 'tls_cert_regenerate' }}
           when:
+            - not tls_cert_regenerate | default(false) | bool
             - server_key.stat.exists | default(false)
             - server_cert.stat.exists | default(false)
-      when:
-        - not tls_cert_regenerate | default(false) | bool
-        - inventory_hostname == (groups[tls_group_name | default('master')][0])
+      when: inventory_hostname == tls_certificate_source_host
 
     # Clean up existing certificates if tls_cert_regenerate is true
     - name: Clean up existing certificates
@@ -68,7 +68,9 @@
       loop:
         - "{{ generate_tls_privatekey | default(tls_privatekey | default('server.key')) }}"
         - "{{ generate_tls_cert | default(tls_cert | default('server.crt')) }}"
-      when: tls_cert_regenerate | default(false) | bool
+      when:
+        - inventory_hostname == tls_certificate_source_host
+        - tls_cert_regenerate | default(false) | bool
 
     # Clean up existing CA certificates if tls_ca_regenerate is true
     - name: Clean up existing CA certificates
@@ -78,9 +80,12 @@
       loop:
         - "{{ generate_tls_ca_cert | default(tls_ca_cert | default('ca.crt')) }}"
         - "{{ generate_tls_ca_key | default(tls_ca_key | default('ca.key')) }}"
-      when: tls_ca_regenerate | default(false) | bool
+      when:
+        - inventory_hostname == tls_certificate_source_host
+        - tls_ca_regenerate | default(false) | bool
   vars:
     tls_directory: "{{ generate_tls_dir | default(tls_dir | default('/etc/tls')) }}"
+    tls_certificate_source_host: "{{ tls_source_host | default(groups[tls_group_name | default('postgres_cluster')][0]) }}"
   when: inventory_hostname in (groups[tls_group_name | default('postgres_cluster')])
   tags: tls, tls_cert_generate
 
@@ -204,5 +209,6 @@
     need_ca: "{{ not (ca_cert is defined and ca_cert.stat.exists | default(false)) or (tls_ca_regenerate | default(false) | bool) }}"
     need_srv_key: "{{ not (server_key is defined and server_key.stat.exists | default(false)) or (tls_cert_regenerate | default(false) | bool) }}"
     need_srv_cert: "{{ not (server_cert is defined and server_cert.stat.exists | default(false)) or (tls_cert_regenerate | default(false) | bool) }}"
-  when: inventory_hostname == (groups[tls_group_name | default('postgres_cluster')][0])
+    tls_certificate_source_host: "{{ tls_source_host | default(groups[tls_group_name | default('postgres_cluster')][0]) }}"
+  when: inventory_hostname == tls_certificate_source_host
   tags: tls, tls_cert_generate

--- a/automation/roles/tls_certificate/tasks/main.yml
+++ b/automation/roles/tls_certificate/tasks/main.yml
@@ -32,6 +32,22 @@
             path: "{{ tls_directory }}/{{ generate_tls_ca_cert | default(tls_ca_cert | default('ca.crt')) }}"
           register: ca_cert
 
+        - name: Check if TLS CA key already exists
+          ansible.builtin.stat:
+            path: "{{ tls_directory }}/{{ generate_tls_ca_key | default(tls_ca_key | default('ca.key')) }}"
+          register: ca_key
+
+        - name: Validate existing TLS CA files
+          ansible.builtin.assert:
+            that:
+              - not (cluster_scaling | default(false) | bool) or ca_cert.stat.exists | default(false)
+              - not (cluster_scaling | default(false) | bool) or ca_key.stat.exists | default(false)
+              - tls_ca_regenerate | default(false) | bool or
+                (ca_cert.stat.exists | default(false)) == (ca_key.stat.exists | default(false))
+            fail_msg: >-
+              The existing TLS CA certificate and private key must both be present on
+              {{ tls_certificate_source_host }}. Refusing to generate a replacement CA.
+
         - name: Check if TLS server cert already exists
           ansible.builtin.stat:
             path: "{{ tls_directory }}/{{ generate_tls_cert | default(tls_cert | default('server.crt')) }}"
@@ -206,7 +222,12 @@
       when: need_srv_cert
   vars:
     tls_directory: "{{ generate_tls_dir | default(tls_dir | default('/etc/tls')) }}"
-    need_ca: "{{ not (ca_cert is defined and ca_cert.stat.exists | default(false)) or (tls_ca_regenerate | default(false) | bool) }}"
+    need_ca: >-
+      {{
+        not (ca_cert is defined and ca_cert.stat.exists | default(false)) or
+        not (ca_key is defined and ca_key.stat.exists | default(false)) or
+        (tls_ca_regenerate | default(false) | bool)
+      }}
     need_srv_key: "{{ not (server_key is defined and server_key.stat.exists | default(false)) or (tls_cert_regenerate | default(false) | bool) }}"
     need_srv_cert: "{{ not (server_cert is defined and server_cert.stat.exists | default(false)) or (tls_cert_regenerate | default(false) | bool) }}"
     tls_certificate_source_host: "{{ tls_source_host | default(groups[tls_group_name | default('postgres_cluster')][0]) }}"


### PR DESCRIPTION
Preserve existing TLS CA when adding cluster nodes.

- Use an existing node as the TLS certificate source.
- Preserve the existing CA when regenerating server certificates.
- Apply the fix to etcd, Consul, and PostgreSQL.
- Limit certificate cleanup to the source node. This prevents new nodes from generating and distributing a new CA during add_node.