### PR TITLE
Console: Show missing required fields in the cluster creation form

### DIFF
--- a/console/ui/src/entities/authentification-method-form-block/ui/AuthenticationFormPart.tsx
+++ b/console/ui/src/entities/authentification-method-form-block/ui/AuthenticationFormPart.tsx
@@ -25,7 +25,7 @@ const AuthenticationFormPart: FC = () => {
         render={({ field: { value, onChange } }) => (
           <TextField
             fullWidth
-            required={watchAuthenticationMethod === AUTHENTICATION_METHODS.PASSWORD}
+            required
             value={value as string}
             onChange={onChange}
             label={t('username')}

--- a/console/ui/src/entities/authentification-method-form-block/ui/index.tsx
+++ b/console/ui/src/entities/authentification-method-form-block/ui/index.tsx
@@ -42,11 +42,11 @@ const AuthenticationMethodFormBlock: React.FC = () => {
 
   useEffect(() => {
     resetField(CLUSTER_FORM_FIELD_NAMES.SECRET_ID);
-  }, [watchIsUseDefinedSecret, watchAuthenticationMethod]);
+  }, [watchIsUseDefinedSecret, watchAuthenticationMethod, resetField]);
 
   useEffect(() => {
     setValue(CLUSTER_FORM_FIELD_NAMES.IS_USE_DEFINED_SECRET, !!secrets.data?.data?.length);
-  }, [secrets.data?.data?.length]);
+  }, [secrets.data?.data?.length, setValue]);
 
   return (
     <Box sx={{ width: '100%' }}>
@@ -110,7 +110,6 @@ const AuthenticationMethodFormBlock: React.FC = () => {
                   size="small"
                   error={!!errors[CLUSTER_FORM_FIELD_NAMES.IS_USE_DEFINED_SECRET]}
                   helperText={errors[CLUSTER_FORM_FIELD_NAMES.IS_USE_DEFINED_SECRET]?.message as string}>
-                  {/* eslint-disable-next-line @typescript-eslint/ban-ts-comment */}
                   {[t('yes', { ns: 'shared' }), t('no', { ns: 'shared' })].map((option) => (
                     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
                     // @ts-expect-error
@@ -130,6 +129,7 @@ const AuthenticationMethodFormBlock: React.FC = () => {
                     render={({ field: { value, onChange } }) => (
                       <TextField
                         fullWidth
+                        required
                         value={value as string}
                         onChange={onChange}
                         label={t('username', { ns: 'shared' })}
@@ -154,7 +154,7 @@ const AuthenticationMethodFormBlock: React.FC = () => {
                       size="small"
                       error={!!errors[CLUSTER_FORM_FIELD_NAMES.SECRET_ID]}
                       helperText={errors[CLUSTER_FORM_FIELD_NAMES.SECRET_ID]?.message as string}>
-                      {secrets.data?.data?.map((secret: any) => (
+                      {secrets.data?.data?.map((secret) => (
                         <MenuItem key={secret?.id} value={secret?.id}>
                           {secret?.name}
                         </MenuItem>

--- a/console/ui/src/features/cluster-secret-modal/model/types.ts
+++ b/console/ui/src/features/cluster-secret-modal/model/types.ts
@@ -27,6 +27,7 @@ import { YamlEditorFormValues } from '@widgets/yaml-editor-form/model/types.ts';
 export interface ClusterSecretModalProps {
   isClusterFormSubmitting?: boolean;
   isClusterFormDisabled?: boolean;
+  validateClusterForm?: () => Promise<boolean>;
   customExtraVars?: Record<string, never>;
 }
 

--- a/console/ui/src/features/cluster-secret-modal/ui/index.tsx
+++ b/console/ui/src/features/cluster-secret-modal/ui/index.tsx
@@ -40,7 +40,11 @@ import { mapFormValuesToRequestFields } from '@shared/lib/clusterValuesTransform
 import { PROVIDERS } from '@shared/config/constants.ts';
 import { isEmpty } from 'lodash';
 
-const ClusterSecretModal: FC<ClusterSecretModalProps> = ({ isClusterFormDisabled = false, customExtraVars = {} }) => {
+const ClusterSecretModal: FC<ClusterSecretModalProps> = ({
+  isClusterFormDisabled = false,
+  validateClusterForm,
+  customExtraVars = {},
+}) => {
   const { t } = useTranslation(['clusters', 'shared', 'toasts']);
   const navigate = useNavigate();
   const currentProject = useAppSelector(selectCurrentProject);
@@ -68,6 +72,12 @@ const ClusterSecretModal: FC<ClusterSecretModalProps> = ({ isClusterFormDisabled
   const watchIsSaveToConsole = methods.watch(CLUSTER_SECRET_MODAL_FORM_FIELD_NAMES.IS_SAVE_TO_CONSOLE);
 
   const handleModalOpenState = (isOpen: boolean) => () => setIsModalOpen(isOpen);
+
+  const handleCreateClusterClick = async () => {
+    if (!validateClusterForm || (await validateClusterForm())) {
+      setIsModalOpen(true);
+    }
+  };
 
   const cancelHandler = () => navigate(generateAbsoluteRouterPath(RouterPaths.clusters.absolutePath));
 
@@ -144,7 +154,7 @@ const ClusterSecretModal: FC<ClusterSecretModalProps> = ({ isClusterFormDisabled
         disabled={
           isClusterFormDisabled || isSubmitting || addSecretTriggerState.isLoading || addClusterTriggerState.isLoading
         }
-        onClick={handleModalOpenState(true)}
+        onClick={handleCreateClusterClick}
         variant="contained"
         startIcon={
           isSubmitting || addSecretTriggerState.isLoading || addClusterTriggerState.isLoading ? (

--- a/console/ui/src/shared/i18n/locales/en/clusters.json
+++ b/console/ui/src/shared/i18n/locales/en/clusters.json
@@ -2,6 +2,7 @@
   "clusters": "Clusters",
   "cluster": "Cluster",
   "createCluster": "Create cluster",
+  "fieldsToComplete": "Complete or correct the following fields to create the cluster",
   "createPostgresCluster": "Create Postgres Cluster",
   "clusterName": "Cluster name",
   "showFailureLog": "Show failure log",
@@ -80,6 +81,7 @@
   "fileSystemType": "File system type",
   "volumeType": "Volume type",
   "backupMethod": "Backup method",
+  "backupConfiguration": "Backup configuration",
   "backupStartTime": "Backup start time",
   "backupRetention": "Backup retention (days)",
   "backupRetentionTooltip": "The number of days to retain backup files. Backups older than this period will be automatically deleted.",
@@ -135,5 +137,10 @@
   "custom": "Custom",
   "customInstanceTypeInfo": "If the required instance type is not listed, you can specify it here (ensure it follows the format supported by the API).",
   "accessKey": "Access key",
-  "secretKey": "Secret key"
+  "secretKey": "Secret key",
+  "databaseServerNumber": "Database server {{number}}",
+  "loadBalancerNumber": "Load balancer {{number}}",
+  "dcsServerNumber": "DCS server {{number}}",
+  "databaseNumber": "Database {{number}}",
+  "connectionPoolNumber": "Connection pool {{number}}"
 }

--- a/console/ui/src/widgets/cluster-form/model/usernameValidation.test.ts
+++ b/console/ui/src/widgets/cluster-form/model/usernameValidation.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { LocalFormSchema } from '@widgets/cluster-form/model/validation.ts';
+import { SECRET_MODAL_CONTENT_FORM_FIELD_NAMES } from '@entities/secret-form-block/model/constants.ts';
+import { CLUSTER_FORM_FIELD_NAMES } from '@widgets/cluster-form/model/constants.ts';
+import { PROVIDERS } from '@shared/config/constants.ts';
+import { AUTHENTICATION_METHODS } from '@shared/model/constants.ts';
+
+const t = ((key: string) => key) as never;
+const usernameField = SECRET_MODAL_CONTENT_FORM_FIELD_NAMES.USERNAME;
+
+const validateUsername = (authenticationMethod: string, isUseDefinedSecret: boolean) =>
+  LocalFormSchema(t).validateAt(usernameField, {
+    [CLUSTER_FORM_FIELD_NAMES.PROVIDER]: { code: PROVIDERS.LOCAL },
+    [CLUSTER_FORM_FIELD_NAMES.AUTHENTICATION_METHOD]: authenticationMethod,
+    [CLUSTER_FORM_FIELD_NAMES.IS_USE_DEFINED_SECRET]: isUseDefinedSecret,
+    [usernameField]: '',
+  });
+
+describe('local cluster username validation', () => {
+  it('requires a username for inline SSH authentication', async () => {
+    await expect(validateUsername(AUTHENTICATION_METHODS.SSH, false)).rejects.toThrow('requiredField');
+  });
+
+  it('requires a username when an existing SSH secret is used', async () => {
+    await expect(validateUsername(AUTHENTICATION_METHODS.SSH, true)).rejects.toThrow('requiredField');
+  });
+
+  it('requires a username for inline password authentication', async () => {
+    await expect(validateUsername(AUTHENTICATION_METHODS.PASSWORD, false)).rejects.toThrow('requiredField');
+  });
+
+  it('uses the username stored in an existing password secret', async () => {
+    await expect(validateUsername(AUTHENTICATION_METHODS.PASSWORD, true)).resolves.toBe('');
+  });
+});

--- a/console/ui/src/widgets/cluster-form/model/validation.ts
+++ b/console/ui/src/widgets/cluster-form/model/validation.ts
@@ -120,16 +120,16 @@ export const LocalFormSchema = (t: TFunction) =>
       [SECRET_MODAL_CONTENT_FORM_FIELD_NAMES.USERNAME]: yup
         .mixed()
         .when(
-          [CLUSTER_FORM_FIELD_NAMES.PROVIDER, CLUSTER_FORM_FIELD_NAMES.AUTHENTICATION_METHOD],
-          ([provider, authenticationMethod], schema) =>
-            provider?.code === PROVIDERS.LOCAL && authenticationMethod === AUTHENTICATION_METHODS.PASSWORD
-              ? yup
-                  .mixed()
-                  .when(CLUSTER_FORM_FIELD_NAMES.IS_USE_DEFINED_SECRET, ([isUseDefinedSecret], schema) =>
-                    !isUseDefinedSecret
-                      ? yup.string().required(t('requiredField', { ns: 'validation' }))
-                      : schema.notRequired(),
-                  )
+          [
+            CLUSTER_FORM_FIELD_NAMES.PROVIDER,
+            CLUSTER_FORM_FIELD_NAMES.AUTHENTICATION_METHOD,
+            CLUSTER_FORM_FIELD_NAMES.IS_USE_DEFINED_SECRET,
+          ],
+          ([provider, authenticationMethod, isUseDefinedSecret], schema) =>
+            provider?.code === PROVIDERS.LOCAL &&
+            (authenticationMethod === AUTHENTICATION_METHODS.SSH ||
+              (authenticationMethod === AUTHENTICATION_METHODS.PASSWORD && !isUseDefinedSecret))
+              ? yup.string().required(t('requiredField', { ns: 'validation' }))
               : schema.notRequired(),
         ),
       [SECRET_MODAL_CONTENT_FORM_FIELD_NAMES.PASSWORD]: yup

--- a/console/ui/src/widgets/cluster-form/model/validationErrors.test.ts
+++ b/console/ui/src/widgets/cluster-form/model/validationErrors.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it, vi } from 'vitest';
+import { FieldErrors } from 'react-hook-form';
+import { getClusterFormValidationErrors } from '@widgets/cluster-form/model/validationErrors.ts';
+
+const t = vi.fn((key: string, options?: { number?: number }) =>
+  options?.number ? `${key} ${options.number}` : key,
+);
+
+describe('getClusterFormValidationErrors', () => {
+  it('returns readable labels for top-level fields', () => {
+    const errors = {
+      clusterName: { type: 'required', message: 'Required field' },
+      postgresVersion: { type: 'required', message: 'Required field' },
+    } as FieldErrors;
+
+    expect(getClusterFormValidationErrors(errors, t)).toEqual([
+      { path: 'clusterName', label: 'clusterName', message: 'Required field' },
+      { path: 'postgresVersion', label: 'postgresVersion', message: 'Required field' },
+    ]);
+  });
+
+  it('includes the item number for errors in repeatable blocks', () => {
+    const errors = {
+      databaseServers: [
+        undefined,
+        {
+          databaseServerHostname: { type: 'required', message: 'Required field' },
+          databaseServerIpAddress: { type: 'format', message: 'Enter a valid IP address' },
+        },
+      ],
+      dcsDatabases: [{ dcsDatabasePort: { type: 'required', message: 'Required field' } }],
+    } as FieldErrors;
+
+    expect(getClusterFormValidationErrors(errors, t)).toEqual([
+      {
+        path: 'databaseServers.1.databaseServerHostname',
+        label: 'databaseServerNumber 2 — hostname',
+        message: 'Required field',
+      },
+      {
+        path: 'databaseServers.1.databaseServerIpAddress',
+        label: 'databaseServerNumber 2 — ipAddress',
+        message: 'Enter a valid IP address',
+      },
+      {
+        path: 'dcsDatabases.0.dcsDatabasePort',
+        label: 'dcsServerNumber 1 — port',
+        message: 'Required field',
+      },
+    ]);
+  });
+});

--- a/console/ui/src/widgets/cluster-form/model/validationErrors.ts
+++ b/console/ui/src/widgets/cluster-form/model/validationErrors.ts
@@ -1,0 +1,121 @@
+import { TFunction } from 'i18next';
+import { FieldErrors } from 'react-hook-form';
+import { CLUSTER_FORM_FIELD_NAMES } from '@widgets/cluster-form/model/constants.ts';
+import { DATABASE_SERVERS_FIELD_NAMES } from '@entities/cluster/database-servers-block/model/const.ts';
+import { LOAD_BALANCERS_FIELD_NAMES } from '@entities/cluster/load-balancers-block/model/const.ts';
+import { DCS_BLOCK_FIELD_NAMES } from '@entities/cluster/expert-mode/dcs-block/model/const.ts';
+import { BACKUPS_BLOCK_FIELD_NAMES } from '@entities/cluster/expert-mode/backups-block/model/const.ts';
+import { CONNECTION_POOLS_BLOCK_FIELD_NAMES } from '@entities/cluster/expert-mode/connection-pools-block/model/const.ts';
+import { DATABASES_BLOCK_FIELD_NAMES } from '@entities/cluster/expert-mode/databases-block/model/const.ts';
+import { ADDITIONAL_SETTINGS_BLOCK_FIELD_NAMES } from '@entities/cluster/expert-mode/additional-settings-block/model/const.ts';
+import { POSTGRES_PARAMETERS_FIELD_NAMES } from '@entities/cluster/expert-mode/postgres-parameters-block/model/const.ts';
+import { KERNEL_PARAMETERS_FIELD_NAMES } from '@entities/cluster/expert-mode/kernel-parameters-block/model/const.ts';
+import { DATA_DIRECTORY_FIELD_NAMES } from '@entities/cluster/expert-mode/data-directory-block/model/const.ts';
+import { SECRET_MODAL_CONTENT_FORM_FIELD_NAMES } from '@entities/secret-form-block/model/constants.ts';
+
+export interface ClusterFormValidationError {
+  path: string;
+  label: string;
+  message: string;
+}
+
+interface ErrorLeaf {
+  path: string[];
+  message: string;
+}
+
+const collectErrorLeaves = (node: unknown, path: string[] = []): ErrorLeaf[] => {
+  if (!node || typeof node !== 'object') return [];
+
+  if ('message' in node && typeof node.message === 'string') {
+    return [{ path, message: node.message }];
+  }
+
+  return Object.entries(node).flatMap(([key, value]) => collectErrorLeaves(value, [...path, key]));
+};
+
+const getFieldLabels = (t: TFunction): Record<string, string> => ({
+  [CLUSTER_FORM_FIELD_NAMES.PROVIDER]: t('selectDeploymentDestination'),
+  [CLUSTER_FORM_FIELD_NAMES.REGION]: t('selectCloudRegion'),
+  [CLUSTER_FORM_FIELD_NAMES.REGION_CONFIG]: t('selectCloudRegion'),
+  [CLUSTER_FORM_FIELD_NAMES.INSTANCE_TYPE]: t('instanceType'),
+  [CLUSTER_FORM_FIELD_NAMES.INSTANCE_CONFIG]: t('instanceType'),
+  [CLUSTER_FORM_FIELD_NAMES.INSTANCES_AMOUNT]: t('numberOfInstances'),
+  [CLUSTER_FORM_FIELD_NAMES.STORAGE_AMOUNT]: t('dataDiskStorage'),
+  [CLUSTER_FORM_FIELD_NAMES.SSH_PUBLIC_KEY]: t('sshPublicKey'),
+  [CLUSTER_FORM_FIELD_NAMES.AUTHENTICATION_METHOD]: t('authenticationMethod'),
+  [SECRET_MODAL_CONTENT_FORM_FIELD_NAMES.SSH_PRIVATE_KEY]: t('sshKey'),
+  [SECRET_MODAL_CONTENT_FORM_FIELD_NAMES.USERNAME]: t('username', { ns: 'shared' }),
+  [SECRET_MODAL_CONTENT_FORM_FIELD_NAMES.PASSWORD]: t('password', { ns: 'shared' }),
+  [CLUSTER_FORM_FIELD_NAMES.SECRET_KEY_NAME]: t('secretName', { ns: 'settings' }),
+  [CLUSTER_FORM_FIELD_NAMES.SECRET_ID]: t('secret', { ns: 'settings' }),
+  [CLUSTER_FORM_FIELD_NAMES.CLUSTER_VIP_ADDRESS]: t('clusterVipAddress'),
+  [CLUSTER_FORM_FIELD_NAMES.CLUSTER_NAME]: t('clusterName'),
+  [CLUSTER_FORM_FIELD_NAMES.POSTGRES_VERSION]: t('postgresVersion'),
+  [DATABASE_SERVERS_FIELD_NAMES.DATABASE_HOSTNAME]: t('hostname'),
+  [DATABASE_SERVERS_FIELD_NAMES.DATABASE_IP_ADDRESS]: t('ipAddress'),
+  [DATABASE_SERVERS_FIELD_NAMES.DATABASE_SSH_PORT]: t('sshPort'),
+  [LOAD_BALANCERS_FIELD_NAMES.LOAD_BALANCER_DATABASES_HOSTNAME]: t('hostname'),
+  [LOAD_BALANCERS_FIELD_NAMES.LOAD_BALANCER_DATABASES_IP_ADDRESS]: t('ipAddress'),
+  [LOAD_BALANCERS_FIELD_NAMES.LOAD_BALANCER_DATABASES_SSH_PORT]: t('sshPort'),
+  [DCS_BLOCK_FIELD_NAMES.TYPE]: t('dcsType'),
+  [DCS_BLOCK_FIELD_NAMES.DCS_DATABASE_HOSTNAME]: t('hostname'),
+  [DCS_BLOCK_FIELD_NAMES.DCS_DATABASE_IP_ADDRESS]: t('ipAddress'),
+  [DCS_BLOCK_FIELD_NAMES.DCS_DATABASE_SSH_PORT]: t('sshPort'),
+  [DCS_BLOCK_FIELD_NAMES.DCS_DATABASE_PORT]: t('port'),
+  [BACKUPS_BLOCK_FIELD_NAMES.CONFIG]: t('backupConfiguration'),
+  [BACKUPS_BLOCK_FIELD_NAMES.BACKUP_RETENTION]: t('backupRetention'),
+  [BACKUPS_BLOCK_FIELD_NAMES.ACCESS_KEY]: t('accessKey'),
+  [BACKUPS_BLOCK_FIELD_NAMES.SECRET_KEY]: t('secretKey'),
+  [CONNECTION_POOLS_BLOCK_FIELD_NAMES.POOL_NAME]: t('poolName'),
+  [CONNECTION_POOLS_BLOCK_FIELD_NAMES.POOL_SIZE]: t('poolSize'),
+  [CONNECTION_POOLS_BLOCK_FIELD_NAMES.POOL_MODE]: t('poolMode'),
+  [DATABASES_BLOCK_FIELD_NAMES.DATABASE_NAME]: t('databaseName'),
+  [DATABASES_BLOCK_FIELD_NAMES.USER_NAME]: t('username', { ns: 'shared' }),
+  [DATABASES_BLOCK_FIELD_NAMES.USER_PASSWORD]: t('userPassword', { ns: 'shared' }),
+  [DATABASES_BLOCK_FIELD_NAMES.ENCODING]: t('encoding'),
+  [DATABASES_BLOCK_FIELD_NAMES.LOCALE]: t('locale', { ns: 'shared' }),
+  [ADDITIONAL_SETTINGS_BLOCK_FIELD_NAMES.SYNC_STANDBY_NODES]: t('syncStandbyNodes'),
+  [POSTGRES_PARAMETERS_FIELD_NAMES.POSTGRES_PARAMETERS]: t('postgresParameters'),
+  [KERNEL_PARAMETERS_FIELD_NAMES.KERNEL_PARAMETERS]: t('kernelParameters'),
+  [DATA_DIRECTORY_FIELD_NAMES.DATA_DIRECTORY]: t('dataDirectory'),
+});
+
+const getArrayContext = (path: string[], t: TFunction): string | undefined => {
+  const arrayContexts: Record<string, string> = {
+    [DATABASE_SERVERS_FIELD_NAMES.DATABASE_SERVERS]: 'databaseServerNumber',
+    [LOAD_BALANCERS_FIELD_NAMES.LOAD_BALANCER_DATABASES]: 'loadBalancerNumber',
+    [DCS_BLOCK_FIELD_NAMES.DCS_DATABASES]: 'dcsServerNumber',
+    [DATABASES_BLOCK_FIELD_NAMES.DATABASES]: 'databaseNumber',
+    [CONNECTION_POOLS_BLOCK_FIELD_NAMES.POOLS]: 'connectionPoolNumber',
+  };
+
+  for (let index = path.length - 2; index >= 0; index -= 1) {
+    const translationKey = arrayContexts[path[index]];
+    const itemIndex = Number(path[index + 1]);
+    if (translationKey && Number.isInteger(itemIndex)) {
+      return t(translationKey, { number: itemIndex + 1 });
+    }
+  }
+
+  return undefined;
+};
+
+export const getClusterFormValidationErrors = (
+  errors: FieldErrors,
+  t: TFunction,
+): ClusterFormValidationError[] => {
+  const fieldLabels = getFieldLabels(t);
+
+  return collectErrorLeaves(errors).map(({ path, message }) => {
+    const fieldName = path.at(-1) ?? '';
+    const fieldLabel = fieldLabels[fieldName] ?? fieldName;
+    const context = getArrayContext(path, t);
+
+    return {
+      path: path.join('.'),
+      label: context ? `${context} — ${fieldLabel}` : fieldLabel,
+      message,
+    };
+  });
+};

--- a/console/ui/src/widgets/cluster-form/ui/ClusterFormValidationAlert.tsx
+++ b/console/ui/src/widgets/cluster-form/ui/ClusterFormValidationAlert.tsx
@@ -1,0 +1,30 @@
+import { FC } from 'react';
+import { Alert, AlertTitle } from '@mui/material';
+import { useFormContext } from 'react-hook-form';
+import { useTranslation } from 'react-i18next';
+import { getClusterFormValidationErrors } from '@widgets/cluster-form/model/validationErrors.ts';
+
+const ClusterFormValidationAlert: FC = () => {
+  const { t } = useTranslation(['clusters', 'shared', 'settings']);
+  const {
+    formState: { errors },
+  } = useFormContext();
+  const validationErrors = getClusterFormValidationErrors(errors, t);
+
+  if (!validationErrors.length) return null;
+
+  return (
+    <Alert severity="warning">
+      <AlertTitle>{t('fieldsToComplete')}</AlertTitle>
+      <ul style={{ margin: 0, paddingLeft: '20px' }}>
+        {validationErrors.map(({ path, label, message }) => (
+          <li key={path}>
+            <strong>{label}:</strong> {message}
+          </li>
+        ))}
+      </ul>
+    </Alert>
+  );
+};
+
+export default ClusterFormValidationAlert;

--- a/console/ui/src/widgets/cluster-form/ui/index.tsx
+++ b/console/ui/src/widgets/cluster-form/ui/index.tsx
@@ -126,6 +126,7 @@ const ClusterForm: React.FC<ClusterFormProps> = ({
   return (
     <Stack direction="column" gap={2} padding="8px">
       <form
+        noValidate
         onSubmit={
           watchProvider?.code !== PROVIDERS.LOCAL && secrets?.data?.data?.length !== 1
             ? undefined

--- a/console/ui/src/widgets/cluster-form/ui/index.tsx
+++ b/console/ui/src/widgets/cluster-form/ui/index.tsx
@@ -121,7 +121,7 @@ const ClusterForm: React.FC<ClusterFormProps> = ({
 
   const cancelHandler = () => navigate(generateAbsoluteRouterPath(RouterPaths.clusters.absolutePath));
 
-  const { isValid, isSubmitting } = methods.formState; // spreading is required by React Hook Form to ensure the correct form state
+  const { isSubmitting } = methods.formState; // spreading is required by React Hook Form to ensure the correct form state
 
   return (
     <Stack direction="column" gap={2} padding="8px">
@@ -156,10 +156,11 @@ const ClusterForm: React.FC<ClusterFormProps> = ({
           ) : null}
           <ClusterFormValidationAlert />
           {watchProvider?.code !== PROVIDERS.LOCAL && secrets?.data?.data?.length !== 1 ? (
-            <ClusterSecretModal isClusterFormDisabled={!isValid} />
+            <ClusterSecretModal
+              validateClusterForm={() => methods.trigger(undefined, { shouldFocus: true })}
+            />
           ) : (
             <DefaultFormButtons
-              isDisabled={!isValid}
               isSubmitting={isSubmitting || addClusterTriggerState.isLoading || addSecretTriggerState.isLoading}
               cancelHandler={cancelHandler}
               submitButtonLabel={t('createCluster')}

--- a/console/ui/src/widgets/cluster-form/ui/index.tsx
+++ b/console/ui/src/widgets/cluster-form/ui/index.tsx
@@ -28,6 +28,7 @@ import { SECRET_MODAL_CONTENT_FORM_FIELD_NAMES } from '@entities/secret-form-blo
 import { ClusterFormProps } from '@widgets/cluster-form/model/types.ts';
 import { DATABASE_SERVERS_FIELD_NAMES } from '@/entities/cluster/database-servers-block/model/const';
 import { mapFormValuesToRequestFields } from '@shared/lib/clusterValuesTransformFunctions.ts';
+import ClusterFormValidationAlert from '@widgets/cluster-form/ui/ClusterFormValidationAlert.tsx';
 
 const DatabaseBlock = lazy(() => import('@entities/cluster/expert-mode/databases-block/ui'));
 const ConnectionPoolsBlock = lazy(() => import('@entities/cluster/expert-mode/connection-pools-block/ui'));
@@ -153,6 +154,7 @@ const ClusterForm: React.FC<ClusterFormProps> = ({
               <AdditionalSettingsBlock />
             </>
           ) : null}
+          <ClusterFormValidationAlert />
           {watchProvider?.code !== PROVIDERS.LOCAL && secrets?.data?.data?.length !== 1 ? (
             <ClusterSecretModal isClusterFormDisabled={!isValid} />
           ) : (


### PR DESCRIPTION
Adds a validation summary to the cluster creation form, showing which fields must be completed or corrected before the cluster can be created. Supports both standard and Expert Mode fields, including indexed DB, DCS, and load balancer servers.

<img width="3584" height="2108" alt="image" src="https://github.com/user-attachments/assets/d20b9c41-e25b-4e96-8da1-21ecf59746a2" />

Closes: https://github.com/autobase-tech/autobase/issues/1437