### PR TITLE
Console: Add backup defaults and apply in forms

### DIFF
--- a/console/ui/src/entities/cluster/expert-mode/backups-block/model/const.ts
+++ b/console/ui/src/entities/cluster/expert-mode/backups-block/model/const.ts
@@ -12,3 +12,11 @@ export const BACKUP_METHODS = Object.freeze({
   PG_BACK_REST: 'pgbackrest_install',
   WAL_G: 'wal_g_install',
 });
+
+export const BACKUP_DEFAULTS = Object.freeze({
+  START_HOUR: 3,
+  RETENTION_BY_METHOD: {
+    [BACKUP_METHODS.PG_BACK_REST]: 30,
+    [BACKUP_METHODS.WAL_G]: 4,
+  },
+});

--- a/console/ui/src/entities/cluster/expert-mode/backups-block/ui/ConfigureBackupModal.tsx
+++ b/console/ui/src/entities/cluster/expert-mode/backups-block/ui/ConfigureBackupModal.tsx
@@ -1,10 +1,12 @@
 import { FC, useState } from 'react';
-import { Button, Card, Modal, Stack, TextField, Tooltip, Typography } from '@mui/material';
+import { Alert, Button, Card, Modal, Stack, TextField, Tooltip, Typography } from '@mui/material';
 import { Controller, useFormContext, useWatch } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 import { BACKUP_METHODS, BACKUPS_BLOCK_FIELD_NAMES } from '@entities/cluster/expert-mode/backups-block/model/const.ts';
 import DoNotDisturbAltOutlinedIcon from '@mui/icons-material/DoNotDisturbAltOutlined';
 import DoneOutlinedIcon from '@mui/icons-material/DoneOutlined';
+import { CLUSTER_FORM_FIELD_NAMES } from '@widgets/cluster-form/model/constants.ts';
+import { PROVIDERS } from '@shared/config/constants.ts';
 
 const ConfigureBackupModal: FC = () => {
   const { t } = useTranslation(['clusters', 'shared']);
@@ -20,6 +22,8 @@ const ConfigureBackupModal: FC = () => {
 
   const watchBackupMethod = useWatch({ name: BACKUPS_BLOCK_FIELD_NAMES.BACKUP_METHOD });
   const watchConfig = useWatch({ name: BACKUPS_BLOCK_FIELD_NAMES.CONFIG });
+  const watchProvider = useWatch({ name: CLUSTER_FORM_FIELD_NAMES.PROVIDER });
+  const isCloudProvider = Boolean(watchProvider?.code && watchProvider.code !== PROVIDERS.LOCAL);
 
   return (
     <>
@@ -40,8 +44,8 @@ const ConfigureBackupModal: FC = () => {
             top: '50%',
             left: '50%',
             transform: 'translate(-50%, -50%)',
-            width: '80%',
-            minWidth: '400px',
+            width: 'calc(100% - 32px)',
+            maxWidth: '900px',
             height: 'max-content',
             bgcolor: 'background.paper',
             borderRadius: '3px',
@@ -51,6 +55,12 @@ const ConfigureBackupModal: FC = () => {
             <Typography fontWeight="bold" fontSize={20}>
               {t('configureBackup')}
             </Typography>
+            {isCloudProvider ? (
+              <>
+                <Alert severity="info">{t('cloudBackupConfigurationHelp')}</Alert>
+                <Typography fontWeight="bold">{t('customConfigurationOptional')}</Typography>
+              </>
+            ) : null}
             {
               <Controller
                 control={control}

--- a/console/ui/src/entities/cluster/expert-mode/backups-block/ui/index.tsx
+++ b/console/ui/src/entities/cluster/expert-mode/backups-block/ui/index.tsx
@@ -14,7 +14,11 @@ import {
 } from '@mui/material';
 import { useTranslation } from 'react-i18next';
 import { Controller, useFormContext, useWatch } from 'react-hook-form';
-import { BACKUP_METHODS, BACKUPS_BLOCK_FIELD_NAMES } from '@entities/cluster/expert-mode/backups-block/model/const.ts';
+import {
+  BACKUP_DEFAULTS,
+  BACKUP_METHODS,
+  BACKUPS_BLOCK_FIELD_NAMES,
+} from '@entities/cluster/expert-mode/backups-block/model/const.ts';
 import { range } from '@mui/x-data-grid/internals';
 import HelpOutlineIcon from '@mui/icons-material/HelpOutline';
 import ConfigureBackupModal from '@entities/cluster/expert-mode/backups-block/ui/ConfigureBackupModal.tsx';
@@ -87,7 +91,13 @@ const BackupsBlock: FC = () => {
                     {...field}
                     row
                     onChange={(e) => {
+                      const method = e.target.value as keyof typeof BACKUP_DEFAULTS.RETENTION_BY_METHOD;
                       resetField(BACKUPS_BLOCK_FIELD_NAMES.CONFIG, { keepDirty: true });
+                      setValue(
+                        BACKUPS_BLOCK_FIELD_NAMES.BACKUP_RETENTION,
+                        BACKUP_DEFAULTS.RETENTION_BY_METHOD[method],
+                        { shouldDirty: true, shouldValidate: true },
+                      );
                       field.onChange(e);
                     }}>
                     {[
@@ -188,7 +198,6 @@ const BackupsBlock: FC = () => {
                           <TextField
                             {...field}
                             required
-                            onChange={handleInputChange(field.onChange)}
                             size="small"
                             error={!!errors?.[fieldName]}
                             helperText={errors?.[fieldName]?.message as string}

--- a/console/ui/src/entities/cluster/expert-mode/backups-block/ui/index.tsx
+++ b/console/ui/src/entities/cluster/expert-mode/backups-block/ui/index.tsx
@@ -36,7 +36,9 @@ const BackupsBlock: FC = () => {
   } = useFormContext();
 
   const watchIsBackupsEnabled = useWatch({ name: BACKUPS_BLOCK_FIELD_NAMES.IS_BACKUPS_ENABLED });
+  const watchBackupMethod = useWatch({ name: BACKUPS_BLOCK_FIELD_NAMES.BACKUP_METHOD });
   const watchProvider = useWatch({ name: CLUSTER_FORM_FIELD_NAMES.PROVIDER });
+  const isWalGSelected = watchBackupMethod === BACKUP_METHODS.WAL_G;
 
   const handleInputChange = (onChange: (event: ChangeEvent) => void) => (e: ChangeEvent<HTMLInputElement>) => {
     // prevent user from entering less than restricted amount in input field
@@ -156,8 +158,8 @@ const BackupsBlock: FC = () => {
               render={({ field }) => (
                 <Stack direction="row" alignItems="center">
                   <Stack width="250px" direction="row" alignItems="center" gap={0.5}>
-                    <Typography>{t('backupRetention')}</Typography>
-                    <Tooltip title={t('backupRetentionTooltip')}>
+                    <Typography>{t(isWalGSelected ? 'fullBackupsToRetain' : 'backupRetention')}</Typography>
+                    <Tooltip title={t(isWalGSelected ? 'fullBackupsToRetainTooltip' : 'backupRetentionTooltip')}>
                       <HelpOutlineIcon fontSize="small" />
                     </Tooltip>
                   </Stack>

--- a/console/ui/src/shared/i18n/locales/en/clusters.json
+++ b/console/ui/src/shared/i18n/locales/en/clusters.json
@@ -85,6 +85,8 @@
   "backupStartTime": "Backup start time",
   "backupRetention": "Backup retention (days)",
   "backupRetentionTooltip": "The number of days to retain backup files. Backups older than this period will be automatically deleted.",
+  "fullBackupsToRetain": "Full backups to retain",
+  "fullBackupsToRetainTooltip": "The number of full backup chains to retain. Older backup chains will be automatically deleted.",
   "configure": "Configure",
   "configureBackup": "Configure backup",
   "global": "Global",

--- a/console/ui/src/shared/i18n/locales/en/clusters.json
+++ b/console/ui/src/shared/i18n/locales/en/clusters.json
@@ -89,6 +89,8 @@
   "fullBackupsToRetainTooltip": "The number of full backup chains to retain. Older backup chains will be automatically deleted.",
   "configure": "Configure",
   "configureBackup": "Configure backup",
+  "cloudBackupConfigurationHelp": "Backup configuration is generated automatically for this cloud provider. Leave this field empty to use the recommended defaults. Add a custom configuration only if you need to override them.",
+  "customConfigurationOptional": "Custom configuration (optional)",
   "global": "Global",
   "postgresParameters": "Postgres parameters",
   "postgresParametersInfo": "These Postgres settings will be applied when the cluster is created.",

--- a/console/ui/src/shared/lib/clusterValuesTransformFunctions.test.ts
+++ b/console/ui/src/shared/lib/clusterValuesTransformFunctions.test.ts
@@ -1,6 +1,23 @@
 // @vitest-environment jsdom
 import { describe, expect, it, vi } from 'vitest';
 
+describe('cluster form backup defaults', () => {
+  it('uses Autobase start hour and retention defaults in expert mode', async () => {
+    localStorage.setItem('isExpertMode', 'true');
+    vi.resetModules();
+
+    const { getClusterFormDefaultValues } = await import('@widgets/cluster-form/model/constants.ts');
+    const { BACKUP_DEFAULTS, BACKUP_METHODS } = await import(
+      '@entities/cluster/expert-mode/backups-block/model/const.ts'
+    );
+    const values = getClusterFormDefaultValues();
+
+    expect(values.backupStartTime).toBe(3);
+    expect(values.backupRetention).toBe(30);
+    expect(BACKUP_DEFAULTS.RETENTION_BY_METHOD[BACKUP_METHODS.WAL_G]).toBe(4);
+  });
+});
+
 describe('getLocalMachineEnvs', () => {
   it('maps per-host ssh port to ansible_ssh_port', async () => {
     localStorage.setItem('isExpertMode', 'false');

--- a/console/ui/src/widgets/cluster-form/model/constants.ts
+++ b/console/ui/src/widgets/cluster-form/model/constants.ts
@@ -1,5 +1,9 @@
 import { AUTHENTICATION_METHODS, IS_EXPERT_MODE } from '@shared/model/constants.ts';
-import { BACKUP_METHODS, BACKUPS_BLOCK_FIELD_NAMES } from '@entities/cluster/expert-mode/backups-block/model/const.ts';
+import {
+  BACKUP_DEFAULTS,
+  BACKUP_METHODS,
+  BACKUPS_BLOCK_FIELD_NAMES,
+} from '@entities/cluster/expert-mode/backups-block/model/const.ts';
 import { ADDITIONAL_SETTINGS_BLOCK_FIELD_NAMES } from '@entities/cluster/expert-mode/additional-settings-block/model/const.ts';
 import { POSTGRES_PARAMETERS_FIELD_NAMES } from '@entities/cluster/expert-mode/postgres-parameters-block/model/const.ts';
 import { KERNEL_PARAMETERS_FIELD_NAMES } from '@entities/cluster/expert-mode/kernel-parameters-block/model/const.ts';
@@ -127,8 +131,9 @@ export const getClusterFormDefaultValues = () => ({
     ? {
         [BACKUPS_BLOCK_FIELD_NAMES.IS_BACKUPS_ENABLED]: true,
         [BACKUPS_BLOCK_FIELD_NAMES.BACKUP_METHOD]: BACKUP_METHODS.PG_BACK_REST,
-        [BACKUPS_BLOCK_FIELD_NAMES.BACKUP_RETENTION]: 30,
-        [BACKUPS_BLOCK_FIELD_NAMES.BACKUP_START_TIME]: 1,
+        [BACKUPS_BLOCK_FIELD_NAMES.BACKUP_RETENTION]:
+          BACKUP_DEFAULTS.RETENTION_BY_METHOD[BACKUP_METHODS.PG_BACK_REST],
+        [BACKUPS_BLOCK_FIELD_NAMES.BACKUP_START_TIME]: BACKUP_DEFAULTS.START_HOUR,
         [BACKUPS_BLOCK_FIELD_NAMES.CONFIG]: '',
         [BACKUPS_BLOCK_FIELD_NAMES.ACCESS_KEY]: '',
         [BACKUPS_BLOCK_FIELD_NAMES.SECRET_KEY]: '',


### PR DESCRIPTION
Improves backup configuration in the Console:

- Introduces centralized backup defaults: start time at `03:00`, 30-day retention for pgBackRest, and 4 full backup chains for WAL-G.
- Automatically updates retention when switching backup methods and resets method-specific custom configuration.
- Shows WAL-G-specific retention labels and tooltips.
- Adds cloud-provider guidance explaining that recommended backup settings are generated automatically and custom configuration is optional.
- Improves the backup configuration modal responsiveness.
- Adds unit test coverage for the new defaults.