### PR TITLE
Fix role tag handling in deployment playbooks

### DIFF
--- a/automation/playbooks/config_pgcluster.yml
+++ b/automation/playbooks/config_pgcluster.yml
@@ -149,13 +149,13 @@
   pre_tasks:
     - block: # Ensure Postgres TLS certificates exist on all nodes
         - name: Generate Postgres TLS certificate
-          ansible.builtin.include_role:
+          ansible.builtin.import_role:
             name: vitabaks.autobase.tls_certificate
           vars:
             tls_group_name: "postgres_cluster"
 
         - name: Copy Postgres TLS certificate, key and CA to all nodes
-          ansible.builtin.include_role:
+          ansible.builtin.import_role:
             name: vitabaks.autobase.tls_certificate
             tasks_from: copy
       when: tls_cert_generate | default(true) | bool

--- a/automation/playbooks/deploy_pgcluster.yml
+++ b/automation/playbooks/deploy_pgcluster.yml
@@ -37,7 +37,7 @@
       tags: always
 
     - name: Define bind_address
-      ansible.builtin.include_role:
+      ansible.builtin.import_role:
         name: vitabaks.autobase.bind_address
       when: bind_address is not defined
       tags: always
@@ -292,7 +292,7 @@
       tags: always
 
     - name: Generate Postgres TLS certificate
-      ansible.builtin.include_role:
+      ansible.builtin.import_role:
         name: vitabaks.autobase.tls_certificate
       vars:
         tls_group_name: "postgres_cluster"
@@ -300,7 +300,7 @@
       when: tls_cert_generate | default(true) | bool
 
     - name: Copy Postgres TLS certificate, key and CA to all nodes
-      ansible.builtin.include_role:
+      ansible.builtin.import_role:
         name: vitabaks.autobase.tls_certificate
         tasks_from: copy
       when: tls_cert_generate | default(true) | bool
@@ -347,13 +347,13 @@
 
   tasks:
     - name: Create pgbackrest stanza
-      ansible.builtin.include_role:
+      ansible.builtin.import_role:
         name: vitabaks.autobase.pgbackrest
         tasks_from: stanza_create
       when: pgbackrest_install | default(false) | bool
 
     - name: Install and configure pgbouncer
-      ansible.builtin.include_role:
+      ansible.builtin.import_role:
         name: vitabaks.autobase.pgbouncer
         tasks_from: config
       when: pgbouncer_install | default(true) | bool
@@ -419,5 +419,5 @@
 
     # finish (info)
     - name: Cluster deployment completed
-      ansible.builtin.include_role:
+      ansible.builtin.import_role:
         name: vitabaks.autobase.deploy_finish


### PR DESCRIPTION
Replace `include_role` with `import_role` in `deploy_pgcluster.yml` and `config_pgcluster.yml`. Dynamic role inclusion caused tagged tasks, such as pgBackRest stanza creation, to be skipped when running the playbook with `--tags`.

Static role imports allow Ansible to discover and execute tags defined inside roles. Syntax checks and YAML validation pass.