### PR TITLE
Fix Azure backup credentials when updating configuration

### DIFF
--- a/automation/roles/cloud_resources/tasks/backup_storage.yml
+++ b/automation/roles/cloud_resources/tasks/backup_storage.yml
@@ -120,19 +120,6 @@
             allow_blob_public_access: "{{ azure_blob_storage_account_allow_blob_public_access }}"
             state: present
 
-        - name: "Azure: Get Storage Account info"
-          azure.azcollection.azure_rm_storageaccount_info:
-            resource_group: "{{ azure_resource_group | default('postgres-cluster-resource-group' ~ '-' ~ azure_backup_location) }}"
-            name: "{{ azure_blob_storage_account_name }}"
-            show_connection_string: true
-          no_log: true
-          register: azure_storage_account_info
-
-        - name: "Set variable: azure_storage_account_key"
-          ansible.builtin.set_fact:
-            azure_storage_account_key: "{{ azure_storage_account_info.storageaccounts[0].primary_endpoints.key }}"
-          no_log: true
-
         - name: "Azure: Create Blob Storage container '{{ azure_blob_storage_name | default('') }}'"
           azure.azcollection.azure_rm_storageblob:
             resource_group: "{{ azure_resource_group | default('postgres-cluster-resource-group' ~ '-' ~ azure_backup_location) }}"

--- a/automation/roles/pgbackrest/tasks/auto_conf.yml
+++ b/automation/roles/pgbackrest/tasks/auto_conf.yml
@@ -67,6 +67,27 @@
   when: cloud_backup_provider | default(cloud_provider | default('')) | lower == 'gcp'
 
 # Azure Blob Storage (if 'cloud_backup_provider=azure')
+- name: Get Azure Storage Account key for backup configuration
+  block:
+    - name: "Azure: Get Storage Account info"
+      azure.azcollection.azure_rm_storageaccount_info:
+        resource_group: "{{ azure_resource_group | default('postgres-cluster-resource-group-' ~ (azure_backup_location | default(server_location | default('')))) }}"
+        name: "{{ pgbackrest_azure_account | default(azure_blob_storage_account_name | default(patroni_cluster_name | lower | replace('-', '') | truncate(24, true, ''))) }}"
+        show_connection_string: true
+      register: azure_storage_account_info
+
+    - name: "Set variable: azure_storage_account_key"
+      ansible.builtin.set_fact:
+        azure_storage_account_key: "{{ azure_storage_account_info.storageaccounts[0].primary_endpoints.key }}"
+      delegate_facts: true
+  delegate_to: localhost
+  become: false
+  run_once: true # noqa run-once
+  no_log: true
+  when:
+    - cloud_backup_provider | default(cloud_provider | default('')) | lower == 'azure'
+    - pgbackrest_azure_key is not defined
+
 - name: "Set variable 'pgbackrest_conf' for backup in Azure Blob Storage"
   ansible.builtin.set_fact:
     pgbackrest_conf:

--- a/automation/roles/wal_g/tasks/auto_conf.yml
+++ b/automation/roles/wal_g/tasks/auto_conf.yml
@@ -43,6 +43,27 @@
   when: cloud_backup_provider | default(cloud_provider | default('')) | lower == 'gcp'
 
 # Azure Blob Storage (if 'cloud_backup_provider=azure')
+- name: Get Azure Storage Account key for backup configuration
+  block:
+    - name: "Azure: Get Storage Account info"
+      azure.azcollection.azure_rm_storageaccount_info:
+        resource_group: "{{ azure_resource_group | default('postgres-cluster-resource-group-' ~ (azure_backup_location | default(server_location | default('')))) }}"
+        name: "{{ wal_g_azure_storage_account | default(azure_blob_storage_account_name | default(patroni_cluster_name | lower | replace('-', '') | truncate(24, true, ''))) }}"
+        show_connection_string: true
+      register: azure_storage_account_info
+
+    - name: "Set variable: azure_storage_account_key"
+      ansible.builtin.set_fact:
+        azure_storage_account_key: "{{ azure_storage_account_info.storageaccounts[0].primary_endpoints.key }}"
+      delegate_facts: true
+  delegate_to: localhost
+  become: false
+  run_once: true # noqa run-once
+  no_log: true
+  when:
+    - cloud_backup_provider | default(cloud_provider | default('')) | lower == 'azure'
+    - wal_g_azure_storage_access_key is not defined
+
 - name: "Set variable 'wal_g_json' for backup in Azure Blob Storage"
   ansible.builtin.set_fact:
     wal_g_json:


### PR DESCRIPTION
Move Azure Storage Account key retrieval into pgBackRest and WAL-G auto-configuration so configuration updates fetch the key before rewriting backup settings. Skip retrieval when an explicit storage key is provided.