### PR TITLE
Add custom cloud resource tagging support

### DIFF
--- a/automation/playbooks/add_node.yml
+++ b/automation/playbooks/add_node.yml
@@ -109,7 +109,6 @@
     - name: Update apt cache
       ansible.builtin.apt:
         update_cache: true
-        cache_valid_time: 3600
       register: apt_status
       until: apt_status is success
       delay: 5

--- a/automation/playbooks/deploy_pgcluster.yml
+++ b/automation/playbooks/deploy_pgcluster.yml
@@ -88,7 +88,6 @@
     - name: Update apt cache
       ansible.builtin.apt:
         update_cache: true
-        cache_valid_time: 3600
       register: apt_status
       until: apt_status is success
       delay: 5

--- a/automation/roles/add_repository/tasks/extensions.yml
+++ b/automation/roles/add_repository/tasks/extensions.yml
@@ -24,6 +24,7 @@
         components: [main]
         state: present
         enabled: true
+      register: timescaledb_apt_repository_status
       when: ansible_os_family == "Debian"
 
     # RedHat based
@@ -52,6 +53,7 @@
         signed_by: "https://repos.citusdata.com/community/gpgkey"
         state: present
         enabled: true
+      register: citus_apt_repository_status
       when: ansible_os_family == "Debian" and ansible_architecture in ["x86_64", "amd64"]
 
     # RedHat based
@@ -78,5 +80,9 @@
   delay: 5
   retries: 3
   environment: "{{ proxy_env | default({}) }}"
-  when: ansible_os_family == "Debian"
+  when:
+    - ansible_os_family == "Debian"
+    - >-
+      (timescaledb_apt_repository_status | default({})) is changed or
+      (citus_apt_repository_status | default({})) is changed
   tags: add_repo, timescaledb, timescale, citus

--- a/automation/roles/add_repository/tasks/main.yml
+++ b/automation/roles/add_repository/tasks/main.yml
@@ -35,6 +35,7 @@
         enabled: "{{ item.enabled | default(true) }}"
         state: present
       loop: "{{ apt_repository }}"
+      register: apt_repository_status
       when: apt_repository | length > 0
 
     - name: Update apt cache
@@ -44,6 +45,7 @@
       until: apt_status is success
       delay: 5
       retries: 3
+      when: apt_repository_status is changed
   environment: "{{ proxy_env | default({}) }}"
   when: installation_method == "packages" and ansible_os_family == "Debian"
   tags: add_repo

--- a/automation/roles/cloud_resources/README.md
+++ b/automation/roles/cloud_resources/README.md
@@ -27,7 +27,7 @@ Provision the PostgreSQL cluster infrastructure in public clouds (AWS, GCP, Azur
 |---------|------|---------|-------------|
 | cloud_provider | string | "" | Specifies the Cloud provider for server creation. Available options: 'aws', 'gcp', 'azure', 'digitalocean', 'hetzner' |
 | cloud_backup_provider | string | cloud_provider | Specifies the Cloud provider for backup storage independently of the server provider. |
-| cloud_provider_tags | dict | {} | Custom resource tags (string keys and values). |
+| cloud_provider_tags | dict | managed-by: autobase | Custom resource tags (string keys and values). |
 | cloud_backup_provider_tags | dict | cloud_provider_tags | Custom backup storage tags. An explicit dictionary replaces the inherited custom tags. |
 | state | string | present | present to create, absent to delete |
 | server_count | int | 3 | Number of servers in the cluster |
@@ -97,9 +97,11 @@ The `server_location` value continues to describe the server provider and is not
 
 ```yaml
 cloud_provider_tags:
+  managed-by: autobase
   environment: production
   team: platform
 cloud_backup_provider_tags: # Optional; inherits cloud_provider_tags when omitted
+  managed-by: autobase
   environment: production
   team: platform
   purpose: backup

--- a/automation/roles/cloud_resources/README.md
+++ b/automation/roles/cloud_resources/README.md
@@ -111,6 +111,7 @@ DigitalOcean adds missing `key:value` tags to Droplets and removes previous valu
 Removing a key from the variables does not remove it on AWS, Azure or DigitalOcean.
 
 Autobase's `Name` (EC2 instances) and `Cluster`/`cluster` values take precedence over conflicting custom values.
+GCP requires label keys and values to use lowercase letters, numbers, underscores or hyphens. Keys must start with a lowercase letter.
 The DigitalOcean cluster tag and GCP network tags remain unchanged because firewalls and load balancers use them to select servers.
 Use strings for all keys and values (quote numeric values), and follow the selected provider's naming and count limits.
 When backup storage uses a different provider, inherited tags must also satisfy that provider's restrictions.

--- a/automation/roles/cloud_resources/README.md
+++ b/automation/roles/cloud_resources/README.md
@@ -72,8 +72,8 @@ Provision the PostgreSQL cluster infrastructure in public clouds (AWS, GCP, Azur
 | azure_blob_storage_blob_type | string | block | Type of blob object. Values include: block, page |
 | azure_blob_storage_account_name | string | {{ patroni_cluster_name }} | Storage account name. Must be between 3 and 24 characters in length and use numbers and lower-case letters only |
 | azure_blob_storage_account_type | string | Standard_RAGRS | Type of storage account. Values include: Standard_LRS, Standard_GRS, Standard_RAGRS, Standard_ZRS, Standard_RAGZRS, Standard_GZRS, Premium_LRS, Premium_ZRS |
-| azure_blob_storage_account_kind | string | BlobStorage | The kind of storage. Values include: Storage, StorageV2, BlobStorage, BlockBlobStorage, FileStorage |
-| azure_blob_storage_account_access_tier | string | Hot | The access tier for this storage account. Required when kind=BlobStorage |
+| azure_blob_storage_account_kind | string | StorageV2 | The kind of storage. Values include: StorageV2, BlockBlobStorage, FileStorage |
+| azure_blob_storage_account_access_tier | string | Hot | The access tier for blob data in this storage account |
 | azure_blob_storage_account_public_network_access | string | Enabled | Allow public network access to Storage Account to create Blob Storage container |
 | azure_blob_storage_account_allow_blob_public_access | bool | false | Allow anonymous blob access |
 | azure_blob_storage_absent | bool | false | Allow delete Azure Blob Storage on state=absent |

--- a/automation/roles/cloud_resources/README.md
+++ b/automation/roles/cloud_resources/README.md
@@ -27,6 +27,8 @@ Provision the PostgreSQL cluster infrastructure in public clouds (AWS, GCP, Azur
 |---------|------|---------|-------------|
 | cloud_provider | string | "" | Specifies the Cloud provider for server creation. Available options: 'aws', 'gcp', 'azure', 'digitalocean', 'hetzner' |
 | cloud_backup_provider | string | cloud_provider | Specifies the Cloud provider for backup storage independently of the server provider. |
+| cloud_provider_tags | dict | {} | Custom resource tags (string keys and values). |
+| cloud_backup_provider_tags | dict | cloud_provider_tags | Custom backup storage tags. An explicit dictionary replaces the inherited custom tags. |
 | state | string | present | present to create, absent to delete |
 | server_count | int | 3 | Number of servers in the cluster |
 | server_name | string | {{ patroni_cluster_name }}-pgnode | Will be automatically named with suffixes 01, 02, 03, etc. |
@@ -90,6 +92,36 @@ Provision the PostgreSQL cluster infrastructure in public clouds (AWS, GCP, Azur
 Set `cloud_backup_provider` when backup storage should be provisioned in a different cloud than the database servers.
 In that case, also provide the credentials and region-related variables required by the selected backup provider (for example, `azure_backup_location` for Azure).
 The `server_location` value continues to describe the server provider and is not translated between clouds.
+
+#### Custom resource tags
+
+```yaml
+cloud_provider_tags:
+  environment: production
+  team: platform
+cloud_backup_provider_tags: # Optional; inherits cloud_provider_tags when omitted
+  environment: production
+  team: platform
+  purpose: backup
+```
+
+Run `cloud_resources.yml` again with `state: present` and the same cluster variables to apply tags to existing resources.
+AWS and Azure add tags and update values without removing unrelated tags. GCP and Hetzner label dictionaries replace the existing labels on managed resources.
+DigitalOcean adds missing `key:value` tags to Droplets and removes previous values for keys present in `cloud_provider_tags`. Custom keys cannot contain `:`.
+Removing a key from the variables does not remove it on AWS, Azure or DigitalOcean.
+
+Autobase's `Name` (EC2 instances) and `Cluster`/`cluster` values take precedence over conflicting custom values.
+The DigitalOcean cluster tag and GCP network tags remain unchanged because firewalls and load balancers use them to select servers.
+Use strings for all keys and values (quote numeric values), and follow the selected provider's naming and count limits.
+When backup storage uses a different provider, inherited tags must also satisfy that provider's restrictions.
+
+| Provider | Resources tagged by this role | Exceptions |
+|----------|-------------------------------|------------|
+| AWS | SSH keys created by the role, security groups, EC2 instances, Spot requests, attached EBS system/data volumes, instance network interfaces, CLB/NLB, NLB target groups, S3 buckets | Existing VPCs/subnets are reused and not modified. Service-managed load balancer child resources are not managed separately. |
+| GCP | VM instances, system/data disks, GCS buckets | The Ansible modules used for global static load balancer IP addresses, forwarding rules, backend services, health checks, proxies, unmanaged instance groups and VPC firewall rules do not expose labels. Existing networks/subnets are not modified. |
+| Azure | Resource groups, VNets created by the role, public IPs, security groups, NICs, VMs, OS/data managed disks, load balancers, backup storage accounts | Subnets, load balancer child configurations and Blob containers do not support resource tags. Tags on a resource group are not inherited automatically. |
+| DigitalOcean | Droplets | The collection's tag module does not support data volumes. VPCs, SSH keys, firewalls, load balancers and Spaces buckets do not support resource tagging. Root disks and public IPs belong to the Droplet. |
+| Hetzner | SSH keys created by the role, networks created by the role, firewalls, servers, Primary IPv4 addresses, volumes and load balancers | Subnetworks and load balancer services/targets are child configurations without labels. Root disks belong to the server. Object Storage bucket tagging is unsupported. |
 
 ### Provider-specific (optional) variables referenced in tasks
 

--- a/automation/roles/cloud_resources/README.md
+++ b/automation/roles/cloud_resources/README.md
@@ -109,12 +109,13 @@ cloud_backup_provider_tags: # Optional; inherits cloud_provider_tags when omitte
 
 Run `cloud_resources.yml` again with `state: present` and the same cluster variables to apply tags to existing resources.
 AWS and Azure add tags and update values without removing unrelated tags. GCP and Hetzner label dictionaries replace the existing labels on managed resources.
-DigitalOcean adds missing `key:value` tags to Droplets and removes previous values for keys present in `cloud_provider_tags`. Custom keys cannot contain `:`.
+DigitalOcean adds missing `key:value` tags to Droplets. Changing a value adds a new `key:value` tag without removing the previous value. Custom keys cannot contain `:`.
 Removing a key from the variables does not remove it on AWS, Azure or DigitalOcean.
 
 Autobase's `Name` (EC2 instances) and `Cluster`/`cluster` values take precedence over conflicting custom values.
 GCP requires label keys and values to use lowercase letters, numbers, underscores or hyphens. Keys must start with a lowercase letter.
 The DigitalOcean cluster tag and GCP network tags remain unchanged because firewalls and load balancers use them to select servers.
+Shared Azure resource groups and virtual networks, and shared Hetzner networks, receive the tags of the most recently processed cluster.
 Use strings for all keys and values (quote numeric values), and follow the selected provider's naming and count limits.
 When backup storage uses a different provider, inherited tags must also satisfy that provider's restrictions.
 

--- a/automation/roles/cloud_resources/defaults/main.yml
+++ b/automation/roles/cloud_resources/defaults/main.yml
@@ -68,8 +68,8 @@ azure_blob_storage_name: "{{ patroni_cluster_name }}-backup" # Name of a blob co
 azure_blob_storage_blob_type: "block" # Type of blob object. Values include: block, page.
 azure_blob_storage_account_name: "{{ patroni_cluster_name | lower | replace('-', '') | truncate(24, true, '') }}" # Storage account name must be between 3 and 24 characters in length and use numbers and lower-case letters only.
 azure_blob_storage_account_type: "Standard_RAGRS" # Type of storage account. Values include: Standard_LRS, Standard_GRS, Standard_RAGRS, Standard_ZRS, Standard_RAGZRS, Standard_GZRS, Premium_LRS, Premium_ZRS.
-azure_blob_storage_account_kind: "BlobStorage" # The kind of storage. Values include: Storage, StorageV2, BlobStorage, BlockBlobStorage, FileStorage.
-azure_blob_storage_account_access_tier: "Hot" # The access tier for this storage account. Required when kind=BlobStorage.
+azure_blob_storage_account_kind: "StorageV2" # The kind of storage. Values include: StorageV2, BlockBlobStorage, FileStorage.
+azure_blob_storage_account_access_tier: "Hot" # The access tier for blob data in this storage account.
 azure_blob_storage_account_public_network_access: "Enabled" # Allow public network access to Storage Account to create Blob Storage container.
 azure_blob_storage_account_allow_blob_public_access: false # Disallow public anonymous access.
 azure_blob_storage_absent: false # Allow to delete Azure Blob Storage when deleting a cluster servers using the 'state=absent' variable.

--- a/automation/roles/cloud_resources/defaults/main.yml
+++ b/automation/roles/cloud_resources/defaults/main.yml
@@ -2,6 +2,11 @@
 ---
 cloud_provider: "{{ provision | default('') }}" # Specifies the Cloud provider for server creation. Available options: 'aws', 'gcp', 'azure', 'digitalocean', 'hetzner'.
 cloud_backup_provider: "{{ cloud_provider }}" # Cloud provider for backup storage. Defaults to the server cloud provider.
+cloud_provider_tags: { } # Custom resource tags (dictionary of string keys and values; DigitalOcean uses key:value tags).
+#  environment: production
+#  project: myproject
+#  key: value
+cloud_backup_provider_tags: "{{ cloud_provider_tags }}" # Custom backup storage tags.
 state: present # Set to 'present' to create a server, 'absent' to delete.
 
 server_count: "{{ servers_count | default(3) }}" # Number of servers in the cluster.

--- a/automation/roles/cloud_resources/defaults/main.yml
+++ b/automation/roles/cloud_resources/defaults/main.yml
@@ -2,7 +2,7 @@
 ---
 cloud_provider: "{{ provision | default('') }}" # Specifies the Cloud provider for server creation. Available options: 'aws', 'gcp', 'azure', 'digitalocean', 'hetzner'.
 cloud_backup_provider: "{{ cloud_provider }}" # Cloud provider for backup storage. Defaults to the server cloud provider.
-cloud_provider_tags: { } # Custom resource tags (dictionary of string keys and values; DigitalOcean uses key:value tags).
+cloud_provider_tags: { } # Custom resource tags (dictionary of string keys and values.
 #  environment: production
 #  project: myproject
 #  key: value

--- a/automation/roles/cloud_resources/defaults/main.yml
+++ b/automation/roles/cloud_resources/defaults/main.yml
@@ -2,7 +2,8 @@
 ---
 cloud_provider: "{{ provision | default('') }}" # Specifies the Cloud provider for server creation. Available options: 'aws', 'gcp', 'azure', 'digitalocean', 'hetzner'.
 cloud_backup_provider: "{{ cloud_provider }}" # Cloud provider for backup storage. Defaults to the server cloud provider.
-cloud_provider_tags: { } # Custom resource tags (dictionary of string keys and values.
+cloud_provider_tags: # Custom resource tags (dictionary of string keys and values).
+  managed-by: autobase
 #  environment: production
 #  project: myproject
 #  key: value

--- a/automation/roles/cloud_resources/tasks/aws.yml
+++ b/automation/roles/cloud_resources/tasks/aws.yml
@@ -1,4 +1,16 @@
 ---
+- name: "AWS: Validate cluster name length for NLB target groups"
+  ansible.builtin.assert:
+    that:
+      - patroni_cluster_name | length <= 21
+    fail_msg: >-
+      AWS NLB requires patroni_cluster_name to be 21 characters or fewer because
+      the generated target group name adds the '-tg-primary' suffix and cannot exceed 32 characters.
+  when:
+    - state == 'present'
+    - cloud_load_balancer | bool
+    - aws_load_balancer_type | lower == 'nlb'
+
 # SSH key
 - block:
     # Delete the temporary ssh key from the cloud (if exists)

--- a/automation/roles/cloud_resources/tasks/aws.yml
+++ b/automation/roles/cloud_resources/tasks/aws.yml
@@ -23,6 +23,8 @@
         key_material: "{{ ssh_key_content }}"
         region: "{{ server_location }}"
         state: present
+        tags: "{{ cloud_provider_tags | combine({'Cluster': patroni_cluster_name}) }}"
+        purge_tags: false
       register: ssh_key_result
       when:
         - ssh_key_name | length > 0
@@ -85,6 +87,8 @@
         vpc_id: "{{ vpc_id }}"
         region: "{{ server_location }}"
         rules: "{{ rules }}"
+        tags: "{{ cloud_provider_tags | combine({'Cluster': patroni_cluster_name}) }}"
+        purge_tags: false
       vars:
         vpc_cidr_blocks: >-
           {{
@@ -232,9 +236,8 @@
                 assign_public_ip: "{{ server_public_ip | bool }}"
                 delete_on_termination: true
             volumes: "{{ [system_volume] + ([] if use_local_disk | bool else [data_volume]) }}"
-            tags:
-              Name: "{{ server_name | lower }}{{ '%02d' % (idx + 1) }}"
-              Cluster: "{{ patroni_cluster_name }}"
+            tags: "{{ cloud_provider_tags | combine({'Name': server_name | lower ~ '%02d' % (idx + 1), 'Cluster': patroni_cluster_name}) }}"
+            purge_tags: false
           loop: "{{ range(0, server_count | int) | list }}"
           loop_control:
             index_var: idx
@@ -298,9 +301,7 @@
                   delete_on_termination: true
                   device_index: 0
               block_device_mappings: "{{ [system_volume] + ([] if use_local_disk | bool else [data_volume]) }}"
-            tags:
-              Name: "{{ server_name | lower }}{{ '%02d' % (idx + 1) }}"
-              Cluster: "{{ patroni_cluster_name }}"
+            tags: "{{ cloud_provider_tags | combine({'Name': server_name | lower ~ '%02d' % (idx + 1), 'Cluster': patroni_cluster_name}) }}"
           loop: "{{ ec2_spot_instance_info.results }}"
           loop_control:
             index_var: idx
@@ -350,11 +351,10 @@
             secret_key: "{{ lookup('ansible.builtin.env', 'AWS_SECRET_ACCESS_KEY') }}"
             region: "{{ server_location }}"
             name: "{{ server_name | lower }}{{ '%02d' % (idx + 1) }}"
-            tags:
-              Name: "{{ server_name | lower }}{{ '%02d' % (idx + 1) }}"
-              Cluster: "{{ patroni_cluster_name }}"
             filters:
               spot-instance-request-id: "{{ item.spot_request.spot_instance_request_id }}"
+            tags: "{{ cloud_provider_tags | combine({'Name': server_name | lower ~ '%02d' % (idx + 1), 'Cluster': patroni_cluster_name}) }}"
+            purge_tags: false
           loop: "{{ ec2_spot_request_result.results }}"
           loop_control:
             index_var: idx
@@ -382,6 +382,34 @@
               | selectattr('instances', '!=', [])
               | list
             }}
+
+    - name: "AWS: Update instance tags"
+      amazon.aws.ec2_tag:
+        region: "{{ server_location }}"
+        resource: "{{ item.instances[0].instance_id }}"
+        state: present
+        tags: "{{ cloud_provider_tags | combine({'Name': item.instances[0].tags.Name, 'Cluster': patroni_cluster_name}) }}"
+        purge_tags: false
+      loop: "{{ server_result.results }}"
+      loop_control:
+        label: "{{ item.instances[0].instance_id }}"
+
+    - name: "AWS: Tag attached EBS volumes, network interfaces"
+      amazon.aws.ec2_tag:
+        region: "{{ server_location }}"
+        resource: "{{ item }}"
+        state: present
+        tags: "{{ cloud_provider_tags | combine({'Cluster': patroni_cluster_name}) }}"
+        purge_tags: false
+      loop: >-
+        {{
+          (server_result.results | map(attribute='instances') | flatten
+            | map(attribute='block_device_mappings') | flatten | map(attribute='ebs.volume_id') | list)
+          + (server_result.results | map(attribute='instances') | flatten
+            | map(attribute='network_interfaces') | flatten | map(attribute='network_interface_id') | list)
+          + (server_result.results | map(attribute='instances') | flatten
+            | selectattr('spot_instance_request_id', 'defined') | map(attribute='spot_instance_request_id') | list)
+        }}
 
     # Required to allow data volume parameters to be changed after deployment.
     - name: "AWS: Ensure EBS data volume parameters"
@@ -444,6 +472,8 @@
         idle_timeout: 600
         scheme: "{{ 'internet-facing' if database_public_access | bool else 'internal' }}"
         state: present
+        tags: "{{ cloud_provider_tags | combine({'Cluster': patroni_cluster_name}) }}"
+        purge_tags: false
       loop:
         - "primary"
         - "replica"
@@ -493,6 +523,8 @@
         modify_targets: true
         wait: false
         state: present
+        tags: "{{ cloud_provider_tags | combine({'Cluster': patroni_cluster_name}) }}"
+        purge_tags: false
       loop:
         - "primary"
         - "replica"
@@ -524,6 +556,8 @@
         scheme: "{{ 'internet-facing' if database_public_access | bool else 'internal' }}"
         wait: true
         state: present
+        tags: "{{ cloud_provider_tags | combine({'Cluster': patroni_cluster_name}) }}"
+        purge_tags: false
       loop:
         - "primary"
         - "replica"

--- a/automation/roles/cloud_resources/tasks/azure.yml
+++ b/automation/roles/cloud_resources/tasks/azure.yml
@@ -12,6 +12,8 @@
       azure.azcollection.azure_rm_resourcegroup:
         name: "{{ azure_resource_group | default('postgres-cluster-resource-group' ~ '-' ~ server_location) }}"
         location: "{{ server_location }}"
+        tags: "{{ cloud_provider_tags | combine({'Cluster': patroni_cluster_name}) }}"
+        append_tags: true
 
     # if server_network is not specified, create a network and subnet
     - block:
@@ -20,6 +22,8 @@
             resource_group: "{{ azure_resource_group | default('postgres-cluster-resource-group' ~ '-' ~ server_location) }}"
             name: "{{ azure_virtual_network | default('postgres-cluster-network') }}"
             address_prefixes_cidr: ["{{ azure_virtual_network_prefix | default('10.0.0.0/16') }}"]
+            tags: "{{ cloud_provider_tags | combine({'Cluster': patroni_cluster_name}) }}"
+            append_tags: true
 
         - name: "Azure: Create subnet"
           azure.azcollection.azure_rm_subnet:
@@ -41,6 +45,8 @@
         name: "{{ server_name | lower }}{{ '%02d' % (idx + 1) }}-public-ip"
         allocation_method: "Static"
         sku: "Standard"
+        tags: "{{ cloud_provider_tags | combine({'Cluster': patroni_cluster_name}) }}"
+        append_tags: true
       loop: "{{ range(0, server_count | int) | list }}"
       loop_control:
         index_var: idx
@@ -54,6 +60,8 @@
         resource_group: "{{ azure_resource_group | default('postgres-cluster-resource-group' ~ '-' ~ server_location) }}"
         name: "{{ patroni_cluster_name }}-security-group"
         rules: "{{ rules }}"
+        tags: "{{ cloud_provider_tags | combine({'Cluster': patroni_cluster_name}) }}"
+        append_tags: true
       vars:
         rules: >-
           {{
@@ -146,6 +154,8 @@
             public_ip_address_name: "{{ server_public_ip | bool | ternary(server_name | lower ~ '%02d' % (idx + 1) ~ '-public-ip', None) }}"
         dns_servers:
           - 8.8.8.8
+        tags: "{{ cloud_provider_tags | combine({'Cluster': patroni_cluster_name}) }}"
+        append_tags: true
       loop: "{{ range(0, server_count | int) | list }}"
       loop_control:
         index_var: idx
@@ -189,8 +199,8 @@
         data_disks: "{{ [] if use_local_disk | bool else [data_disk] }}"
         network_interface_names:
           - "{{ server_name | lower }}{{ '%02d' % (idx + 1) }}-network-interface"
-        tags:
-          Cluster: "{{ patroni_cluster_name }}"
+        tags: "{{ cloud_provider_tags | combine({'Cluster': patroni_cluster_name}) }}"
+        append_tags: true
       loop: "{{ range(0, server_count | int) | list }}"
       loop_control:
         index_var: idx
@@ -210,6 +220,8 @@
         location: "{{ server_location }}"
         disk_size_gb: "{{ volume_size | int }}"
         state: present
+        tags: "{{ cloud_provider_tags | combine({'Cluster': patroni_cluster_name}) }}"
+        append_tags: true
       loop: "{{ server_result.results | selectattr('ansible_facts.azure_vm', 'defined') | list }}"
       loop_control:
         label: "{{ item.ansible_facts.azure_vm.storage_profile.data_disks[0].name | default('data-disk') }}"
@@ -219,6 +231,17 @@
         - item.ansible_facts.azure_vm.storage_profile.data_disks | length > 0
         - item.ansible_facts.azure_vm.storage_profile.data_disks[0].managed_disk is defined
 
+    - name: "Azure: Update OS disk tags"
+      azure.azcollection.azure_rm_manageddisk:
+        resource_group: "{{ azure_resource_group | default('postgres-cluster-resource-group' ~ '-' ~ server_location) }}"
+        name: "{{ item.ansible_facts.azure_vm.storage_profile.os_disk.name }}"
+        state: present
+        tags: "{{ cloud_provider_tags | combine({'Cluster': patroni_cluster_name}) }}"
+        append_tags: true
+      loop: "{{ server_result.results | selectattr('ansible_facts.azure_vm', 'defined') | list }}"
+      loop_control:
+        label: "{{ item.ansible_facts.azure_vm.storage_profile.os_disk.name }}"
+
     # Load Balancer
     - name: "Azure: Create public IP address for Load Balancer"
       azure.azcollection.azure_rm_publicipaddress:
@@ -226,6 +249,8 @@
         name: "{{ patroni_cluster_name }}-{{ item }}-public-ip"
         allocation_method: "Static"
         sku: "Standard"
+        tags: "{{ cloud_provider_tags | combine({'Cluster': patroni_cluster_name}) }}"
+        append_tags: true
       loop:
         - "primary"
         - "replica"
@@ -268,6 +293,8 @@
             enable_floating_ip: false
             disable_outbound_snat: true
         sku: "Standard"
+        tags: "{{ cloud_provider_tags | combine({'Cluster': patroni_cluster_name}) }}"
+        append_tags: true
       loop:
         - "primary"
         - "replica"

--- a/automation/roles/cloud_resources/tasks/backup_storage.yml
+++ b/automation/roles/cloud_resources/tasks/backup_storage.yml
@@ -48,6 +48,7 @@
         storage_class: "{{ gcp_bucket_storage_class }}"
         predefined_default_object_acl: "{{ gcp_bucket_default_object_acl }}"
         state: present
+        labels: "{{ cloud_backup_provider_tags | combine({'cluster': patroni_cluster_name}) }}"
       when:
         - state == 'present'
         - gcp_bucket_create | bool
@@ -79,6 +80,8 @@
           block_public_acls: "{{ aws_s3_bucket_block_public_acls }}"
           ignore_public_acls: "{{ aws_s3_bucket_ignore_public_acls }}"
         state: present
+        tags: "{{ cloud_backup_provider_tags | combine({'Cluster': patroni_cluster_name}) }}"
+        purge_tags: false
       when:
         - state == 'present'
         - aws_s3_bucket_create | bool
@@ -108,6 +111,8 @@
           azure.azcollection.azure_rm_resourcegroup:
             name: "{{ azure_resource_group | default('postgres-cluster-resource-group' ~ '-' ~ azure_backup_location) }}"
             location: "{{ azure_backup_location }}"
+            tags: "{{ cloud_backup_provider_tags | combine({'Cluster': patroni_cluster_name}) }}"
+            append_tags: true
 
         - name: "Azure: Create Storage Account '{{ azure_blob_storage_account_name | default('') }}'"
           azure.azcollection.azure_rm_storageaccount:
@@ -119,6 +124,8 @@
             public_network_access: "{{ azure_blob_storage_account_public_network_access }}"
             allow_blob_public_access: "{{ azure_blob_storage_account_allow_blob_public_access }}"
             state: present
+            tags: "{{ cloud_backup_provider_tags | combine({'Cluster': patroni_cluster_name}) }}"
+            append_tags: true
 
         - name: "Azure: Create Blob Storage container '{{ azure_blob_storage_name | default('') }}'"
           azure.azcollection.azure_rm_storageblob:

--- a/automation/roles/cloud_resources/tasks/digitalocean.yml
+++ b/automation/roles/cloud_resources/tasks/digitalocean.yml
@@ -149,11 +149,21 @@
           }}
       when: server_network | length > 0
 
-    - name: "DigitalOcean: Create a tag '{{ patroni_cluster_name | default('') }}'"
+    - name: "DigitalOcean: Build custom resource tags"
+      ansible.builtin.set_fact:
+        digital_ocean_resource_tags: "{{ [patroni_cluster_name] }}"
+
+    - name: "DigitalOcean: Convert custom tags to key:value strings"
+      ansible.builtin.set_fact:
+        digital_ocean_resource_tags: "{{ digital_ocean_resource_tags + [item.key ~ ':' ~ item.value] }}"
+      loop: "{{ cloud_provider_tags | dict2items }}"
+
+    - name: "DigitalOcean: Ensure custom resource tags exist"
       community.digitalocean.digital_ocean_tag:
         oauth_token: "{{ lookup('ansible.builtin.env', 'DO_API_TOKEN') }}"
-        name: "{{ patroni_cluster_name }}"
+        name: "{{ item }}"
         state: present
+      loop: "{{ digital_ocean_resource_tags }}"
 
     # Firewall
     # Note: digital_ocean_droplet module doesn't support disabling public IP,
@@ -445,13 +455,22 @@
         ssh_keys: "{{ ssh_key_fingerprint }}"
         vpc_uuid: "{{ vpc_id | default(omit) }}"
         wait_timeout: 500
-        tags:
-          - "{{ patroni_cluster_name }}"
+        tags: "{{ digital_ocean_resource_tags }}"
       loop: "{{ range(0, server_count | int) | list }}"
       loop_control:
         index_var: idx
         label: "{{ server_name | lower }}{{ '%02d' % (idx + 1) }}"
       register: droplet_result
+
+    - name: "DigitalOcean: Apply tags to Droplets"
+      community.digitalocean.digital_ocean_tag:
+        oauth_token: "{{ lookup('ansible.builtin.env', 'DO_API_TOKEN') }}"
+        name: "{{ item.1 }}"
+        resource_id: "{{ item.0.data.droplet.id }}"
+        state: present
+      loop: "{{ droplet_result.results | product(digital_ocean_resource_tags) | list }}"
+      loop_control:
+        label: "{{ item.0.data.droplet.name }}: {{ item.1 }}"
 
     - name: "DigitalOcean: Create or modify Block Storage"
       community.digitalocean.digital_ocean_block_storage:
@@ -467,6 +486,23 @@
         label: "{{ server_name | lower }}{{ '%02d' % (idx + 1) }}-storage"
       register: block_storage_result
       when: not use_local_disk | bool
+
+    - name: "DigitalOcean: Remove previous values of configured custom tags"
+      community.digitalocean.digital_ocean_tag:
+        oauth_token: "{{ lookup('ansible.builtin.env', 'DO_API_TOKEN') }}"
+        name: "{{ item.1 }}"
+        resource_id: "{{ item.0.id }}"
+        state: absent
+      vars:
+        tagged_droplets: "{{ droplet_result.results | map(attribute='data.droplet') | list }}"
+      loop: "{{ tagged_droplets | subelements('tags', skip_missing=True) }}"
+      loop_control:
+        label: "{{ item.0.name }}: {{ item.1 }}"
+      when:
+        - item.1 != patroni_cluster_name
+        - "':' in item.1"
+        - item.1.split(':', 1)[0] in cloud_provider_tags
+        - "item.1 != item.1.split(':', 1)[0] ~ ':' ~ cloud_provider_tags[item.1.split(':', 1)[0]]"
 
     - name: "DigitalOcean: Attach Block Storage to Droplet"
       community.digitalocean.digital_ocean_block_storage:

--- a/automation/roles/cloud_resources/tasks/digitalocean.yml
+++ b/automation/roles/cloud_resources/tasks/digitalocean.yml
@@ -487,23 +487,6 @@
       register: block_storage_result
       when: not use_local_disk | bool
 
-    - name: "DigitalOcean: Remove previous values of configured custom tags"
-      community.digitalocean.digital_ocean_tag:
-        oauth_token: "{{ lookup('ansible.builtin.env', 'DO_API_TOKEN') }}"
-        name: "{{ item.1 }}"
-        resource_id: "{{ item.0.id }}"
-        state: absent
-      vars:
-        tagged_droplets: "{{ droplet_result.results | map(attribute='data.droplet') | list }}"
-      loop: "{{ tagged_droplets | subelements('tags', skip_missing=True) }}"
-      loop_control:
-        label: "{{ item.0.name }}: {{ item.1 }}"
-      when:
-        - item.1 != patroni_cluster_name
-        - "':' in item.1"
-        - item.1.split(':', 1)[0] in cloud_provider_tags
-        - "item.1 != item.1.split(':', 1)[0] ~ ':' ~ cloud_provider_tags[item.1.split(':', 1)[0]]"
-
     - name: "DigitalOcean: Attach Block Storage to Droplet"
       community.digitalocean.digital_ocean_block_storage:
         oauth_token: "{{ lookup('ansible.builtin.env', 'DO_API_TOKEN') }}"

--- a/automation/roles/cloud_resources/tasks/gcp.yml
+++ b/automation/roles/cloud_resources/tasks/gcp.yml
@@ -265,10 +265,9 @@
         tags:
           items:
             - "{{ patroni_cluster_name }}"
-        labels:
-          cluster: "{{ patroni_cluster_name }}"
         status: "{{ gcp_instance_status | default('RUNNING') }}"
         state: present
+        labels: "{{ cloud_provider_tags | combine({'cluster': patroni_cluster_name}) }}"
       loop: "{{ range(0, server_count | int) | list }}"
       loop_control:
         index_var: idx
@@ -295,6 +294,22 @@
             disk_size_gb: "{{ volume_size | int }}"
             disk_type: "{{ volume_type | default('pd-ssd', true) }}"
 
+    - name: "GCP: Update system disk labels"
+      google.cloud.gcp_compute_disk:
+        auth_kind: serviceaccount
+        service_account_contents: "{{ gcp_service_account_contents }}"
+        project: "{{ gcp_project }}"
+        zone: "{{ server_location + '-b' if not server_location is match('.*-[a-z]$') else server_location }}"
+        name: "{{ server_name | lower }}{{ '%02d' % (idx + 1) }}-system"
+        size_gb: "{{ system_volume_size }}"
+        type: "{{ system_volume_type | default('pd-ssd', true) }}"
+        state: present
+        labels: "{{ cloud_provider_tags | combine({'cluster': patroni_cluster_name}) }}"
+      loop: "{{ range(0, server_count | int) | list }}"
+      loop_control:
+        index_var: idx
+        label: "{{ server_name | lower }}{{ '%02d' % (idx + 1) }}-system"
+
     # Required to allow data disk size to be changed after deployment.
     - name: "GCP: Ensure data disk size"
       google.cloud.gcp_compute_disk:
@@ -306,6 +321,7 @@
         size_gb: "{{ volume_size | int }}"
         type: "{{ volume_type | default('pd-ssd', true) }}"
         state: present
+        labels: "{{ cloud_provider_tags | combine({'cluster': patroni_cluster_name}) }}"
       loop: "{{ range(0, server_count | int) | list }}"
       loop_control:
         index_var: idx

--- a/automation/roles/cloud_resources/tasks/hetzner.yml
+++ b/automation/roles/cloud_resources/tasks/hetzner.yml
@@ -12,6 +12,29 @@
         - tmp_ssh_key_name is defined
         - ssh_key_name == tmp_ssh_key_name
 
+    - name: "Hetzner Cloud: Gather SSH keys to match '{{ ssh_key_name | default('') }}' by public key"
+      hetzner.hcloud.ssh_key_info:
+        api_token: "{{ lookup('ansible.builtin.env', 'HCLOUD_API_TOKEN') }}"
+      register: hetzner_available_ssh_keys
+      when:
+        - ssh_key_name | length > 0
+        - ssh_key_content | length > 0
+
+    - name: "Hetzner Cloud: Update labels on the existing SSH key"
+      hetzner.hcloud.ssh_key:
+        api_token: "{{ lookup('ansible.builtin.env', 'HCLOUD_API_TOKEN') }}"
+        id: "{{ hetzner_matching_ssh_keys[0].id }}"
+        state: present
+        labels: >-
+          {{
+            hetzner_matching_ssh_keys[0].labels | default({})
+            | combine(cloud_provider_tags)
+            | combine({'cluster': patroni_cluster_name})
+          }}
+      when:
+        - hetzner_matching_ssh_keys | length > 0
+        - hetzner_matching_ssh_keys[0].name == ssh_key_name
+
     # if ssh_key_name and ssh_key_content is specified, add this ssh key to the cloud
     - name: "Hetzner Cloud: Add SSH key '{{ ssh_key_name | default('') }}' to cloud"
       hetzner.hcloud.ssh_key:
@@ -23,19 +46,20 @@
       when:
         - ssh_key_name | length > 0
         - ssh_key_content | length > 0
+        - hetzner_matching_ssh_keys | default([]) | length < 1
 
     # if ssh_key_name is specified
-    - name: "Hetzner Cloud: Gather information about SSH key '{{ ssh_key_name | default('') }}'"
+    - name: "Hetzner Cloud: Gather information about SSH key '{{ hetzner_effective_ssh_key_name }}'"
       hetzner.hcloud.ssh_key_info:
         api_token: "{{ lookup('ansible.builtin.env', 'HCLOUD_API_TOKEN') }}"
-        name: "{{ ssh_key_name }}"
+        name: "{{ hetzner_effective_ssh_key_name }}"
       register: ssh_keys
       when: ssh_key_name | length > 0
 
     # Stop, if the ssh key is not found
     - name: "Hetzner Cloud: Fail if SSH key is not found"
       ansible.builtin.fail:
-        msg: "SSH key {{ ssh_key_name }} not found. Ensure that key has been added to Hetzner Cloud."
+        msg: "SSH key {{ hetzner_effective_ssh_key_name }} not found. Ensure that key has been added to Hetzner Cloud."
       when:
         - ssh_key_name | length > 0
         - ssh_keys.hcloud_ssh_key_info is defined
@@ -70,6 +94,24 @@
       when:
         - (ssh_key_name | length < 1 or ssh_key_name == (tmp_ssh_key_name | default('')))
         - (ssh_public_keys is not defined or ssh_public_keys | length < 1)
+  vars:
+    hetzner_public_key_identity: "{{ ssh_key_content.split()[0:2] | map('regex_escape') | join('[ \\t]+') }}"
+    hetzner_matching_ssh_keys: >-
+      {{
+        (hetzner_available_ssh_keys | default({})).get('hcloud_ssh_key_info', [])
+        | selectattr(
+            'public_key',
+            'match',
+            '^' ~ hetzner_public_key_identity ~ '(?:[ \t]|$)'
+          )
+        | list
+      }}
+    hetzner_effective_ssh_key_name: >-
+      {{
+        hetzner_matching_ssh_keys[0].name
+        if hetzner_matching_ssh_keys | length > 0
+        else ssh_key_name
+      }}
   when: state == 'present'
 
 # Create (if state is present)

--- a/automation/roles/cloud_resources/tasks/hetzner.yml
+++ b/automation/roles/cloud_resources/tasks/hetzner.yml
@@ -19,6 +19,7 @@
         name: "{{ ssh_key_name }}"
         public_key: "{{ ssh_key_content }}"
         state: present
+        labels: "{{ cloud_provider_tags | combine({'cluster': patroni_cluster_name}) }}"
       when:
         - ssh_key_name | length > 0
         - ssh_key_content | length > 0
@@ -131,6 +132,7 @@
             name: "{{ hcloud_network_name | default('postgres-cluster-network-' + target_network_zone) }}"
             ip_range: "{{ hcloud_network_ip_range | default('10.0.0.0/16') }}"
             state: present
+            labels: "{{ cloud_provider_tags | combine({'cluster': patroni_cluster_name}) }}"
 
         - name: "Hetzner Cloud: Create a subnetwork in postgres cluster network"
           hetzner.hcloud.subnetwork:
@@ -154,6 +156,7 @@
         state: "present"
         name: "{{ patroni_cluster_name }}-public-firewall"
         rules: "{{ rules }}"
+        labels: "{{ cloud_provider_tags | combine({'cluster': patroni_cluster_name}) }}"
       vars:
         rules: >-
           {{
@@ -234,6 +237,7 @@
         state: "present"
         name: "{{ patroni_cluster_name }}-firewall"
         rules: "{{ rules }}"
+        labels: "{{ cloud_provider_tags | combine({'cluster': patroni_cluster_name}) }}"
       vars:
         rules: >-
           {{
@@ -400,8 +404,7 @@
         private_networks:
           - "{{ server_network }}"
         firewalls: "{{ firewalls_list }}"
-        labels:
-          cluster: "{{ patroni_cluster_name }}"
+        labels: "{{ cloud_provider_tags | combine({'cluster': patroni_cluster_name}) }}"
       loop: "{{ range(0, server_count | int) | list }}"
       loop_control:
         index_var: idx
@@ -414,6 +417,26 @@
               (ssh_public_access | bool or netdata_public_access | bool or database_public_access | bool) else []) +
             ([patroni_cluster_name + '-firewall'] if cloud_firewall | bool else [])
           }}
+
+    - name: "Hetzner Cloud: Gather Primary IPs for tagging"
+      hetzner.hcloud.primary_ip_info:
+        api_token: "{{ lookup('ansible.builtin.env', 'HCLOUD_API_TOKEN') }}"
+      register: primary_ip_info
+      when: server_public_ip | bool
+
+    - name: "Hetzner Cloud: Update server Primary IP labels"
+      hetzner.hcloud.primary_ip:
+        api_token: "{{ lookup('ansible.builtin.env', 'HCLOUD_API_TOKEN') }}"
+        id: "{{ item.id }}"
+        auto_delete: "{{ item.auto_delete }}"
+        state: present
+        labels: "{{ cloud_provider_tags | combine({'cluster': patroni_cluster_name}) }}"
+      loop: "{{ primary_ip_info.hcloud_primary_ip_info | default([]) }}"
+      loop_control:
+        label: "{{ item.ip }}"
+      when:
+        - server_public_ip | bool
+        - item.ip in (server_result.results | map(attribute='hcloud_server.ipv4_address') | list)
 
     - name: "Hetzner Cloud: Add server to network '{{ server_network | default('') }}'"
       hetzner.hcloud.server_network:
@@ -434,6 +457,7 @@
         state: present
         size: "{{ volume_size | int }}"
         server: "{{ server_name | lower }}{{ '%02d' % (idx + 1) }}"
+        labels: "{{ cloud_provider_tags | combine({'cluster': patroni_cluster_name}) }}"
       loop: "{{ range(0, server_count | int) | list }}"
       loop_control:
         index_var: idx
@@ -450,8 +474,7 @@
         algorithm: round_robin
         delete_protection: true
         state: present
-        labels:
-          cluster: "{{ patroni_cluster_name }}"
+        labels: "{{ cloud_provider_tags | combine({'cluster': patroni_cluster_name}) }}"
       loop:
         - "primary"
         - "replica"

--- a/automation/roles/cloud_resources/tasks/main.yml
+++ b/automation/roles/cloud_resources/tasks/main.yml
@@ -1,4 +1,30 @@
 ---
+- name: Validate custom cloud tags
+  ansible.builtin.assert:
+    that:
+      - cloud_provider_tags is mapping
+      - cloud_backup_provider_tags is mapping
+    fail_msg: cloud_provider_tags and cloud_backup_provider_tags must be dictionaries of string keys and values.
+
+- name: Validate custom cloud tag keys and values
+  ansible.builtin.assert:
+    that:
+      - item.key is string
+      - item.key | length > 0
+      - item.value is string
+    fail_msg: Cloud tag keys must be non-empty strings and values must be strings.
+  loop: "{{ (cloud_provider_tags | dict2items) + (cloud_backup_provider_tags | dict2items) }}"
+  loop_control:
+    label: "{{ item.key }}"
+
+- name: "DigitalOcean: Validate custom tag keys"
+  ansible.builtin.assert:
+    that:
+      - "':' not in item"
+    fail_msg: DigitalOcean custom tag keys cannot contain ':' because tags use the key:value format.
+  loop: "{{ cloud_provider_tags.keys() | list }}"
+  when: cloud_provider | lower in ['digitalocean', 'do']
+
 - name: Ensure that required variables are specified
   ansible.builtin.fail:
     msg:

--- a/automation/roles/consul/tasks/install_linux_repo.yml
+++ b/automation/roles/consul/tasks/install_linux_repo.yml
@@ -94,6 +94,7 @@
         components: "main"
         enabled: true
         state: present
+      register: consul_apt_repository_status
       when: "ansible_os_family|lower == 'debian'"
 
     - name: Update apt cache
@@ -103,7 +104,9 @@
       until: apt_status is success
       delay: 5
       retries: 3
-      when: ansible_os_family == "Debian"
+      when:
+        - ansible_os_family == "Debian"
+        - consul_apt_repository_status is changed
 
   when: "ansible_os_family|lower in [ 'debian', 'redhat' ]"
   become: true

--- a/automation/roles/packages/tasks/main.yml
+++ b/automation/roles/packages/tasks/main.yml
@@ -73,6 +73,7 @@
 - name: Update apt cache
   ansible.builtin.apt:
     update_cache: true
+    cache_valid_time: 3600
   register: apt_status
   until: apt_status is success
   delay: 5

--- a/automation/roles/pg_probackup/tasks/main.yml
+++ b/automation/roles/pg_probackup/tasks/main.yml
@@ -29,6 +29,7 @@
         components: "main-{{ ansible_distribution_release }}"
         state: present
         enabled: true
+      register: pg_probackup_apt_repository_status
       when: ansible_os_family == "Debian"
 
     - name: Update apt cache
@@ -38,6 +39,7 @@
       until: apt_status is success
       delay: 5
       retries: 3
+      when: pg_probackup_apt_repository_status is changed
 
     - name: Install pg_probackup
       ansible.builtin.package:

--- a/console/ui/src/shared/i18n/locales/en/validation.json
+++ b/console/ui/src/shared/i18n/locales/en/validation.json
@@ -2,7 +2,7 @@
   "requiredField": "Required field",
   "onlyNumbers": "Values should be only numbers",
   "sshPortRange": "SSH port must be between 1 and 65535",
-  "clusterShouldHaveProperNaming": "Cluster name should have only letters, numbers, hyphens and have length equal or less than 24",
+  "clusterShouldHaveProperNaming": "Cluster name should have only letters, numbers, hyphens and have length equal or less than 21",
   "shouldBeACorrectV4Ip": "The value should be a valid IPv4 address",
   "invalidSshPublicKey": "Enter a valid SSH public key",
   "invalidSshPrivateKey": "Enter a valid SSH private key",

--- a/console/ui/src/widgets/cluster-form/model/validation.ts
+++ b/console/ui/src/widgets/cluster-form/model/validation.ts
@@ -203,7 +203,7 @@ export const ClusterFormSchema = (t: TFunction) => {
       [CLUSTER_FORM_FIELD_NAMES.CLUSTER_NAME]: yup
         .string()
         .test('clusters should have proper naming', t('clusterShouldHaveProperNaming', { ns: 'validation' }), (value) =>
-          value.match(/^[a-z0-9][a-z0-9-]{0,23}$/g),
+          value.match(/^[a-z0-9][a-z0-9-]{0,20}$/g),
         )
         .required(t('requiredField', { ns: 'validation' })),
       [CLUSTER_FORM_FIELD_NAMES.DESCRIPTION]: yup.string(),


### PR DESCRIPTION
Introduce `cloud_provider_tags` and `cloud_backup_provider_tags` variables with validation. cloud_backup_provider_tags inherits from cloud_provider_tags by default.

Apply custom tags and labels to resources supported by the provider Ansible modules:

- **AWS**: SSH keys, security groups, EC2 and Spot instances, Spot requests, EBS volumes, network interfaces, load balancers, target groups, and S3 buckets.
- **Azure**: resource groups, virtual networks, public IPs, security groups, network interfaces, virtual machines, OS and data disks, load balancers, and backup storage accounts.
- **GCP**: VM instances, system and data disks, and GCS buckets. Label keys and values must follow GCP lowercase naming requirements.
- **Hetzner Cloud**: SSH keys, networks, firewalls, servers, Primary IPs, volumes, and load balancers.
- **DigitalOcean**: new and existing Droplets.

Provider-managed tags such as `Name`, `Cluster` take precedence over conflicting custom values. 

Closes: https://github.com/autobase-tech/autobase/issues/1259